### PR TITLE
fix: move kernel quiet flag from hardcoded to osimage default

### DIFF
--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -909,6 +909,11 @@ sub update_tables_with_templates
                             pkglist      => $pkglistfile,
                             otherpkglist => $otherpkgsfile,
                             otherpkgdir => "$installroot/post/otherpkgs/$osver/$arch");
+                        my ($existing) = $linuximagetab->getAttribs({ imagename => $imagename }, 'pkgdir');
+                        unless ($existing) {
+                            $tb_cols{addkcmdline} = "quiet";
+                        }
+
                         $linuximagetab->setAttribs(\%key_col, \%tb_cols);
 
                     } else {
@@ -1096,6 +1101,10 @@ sub update_tables_with_mgt_image
                             pkglist      => $pkglistfile,
                             otherpkglist => $otherpkgsfile,
                             otherpkgdir => "$installroot/post/otherpkgs/$osver/$arch");
+                        my ($existing) = $linuximagetab->getAttribs({ imagename => $imagename }, 'pkgdir');
+                        unless ($existing) {
+                            $tb_cols{addkcmdline} = "quiet";
+                        }
                         $linuximagetab->setAttribs(\%key_col, \%tb_cols);
 
                     } else {
@@ -1325,6 +1334,10 @@ sub update_tables_with_diskless_image
                             exlist      => $exlistfile,
                             postinstall => $postfile,
                             rootimgdir => "$installroot/netboot/$osver/$arch/$profile");
+                        my ($existing) = $linuximagetab->getAttribs({ imagename => $imagename }, 'pkgdir');
+                        unless ($existing) {
+                            $tb_cols{addkcmdline} = "quiet";
+                        }
                         $linuximagetab->setAttribs(\%key_col, \%tb_cols);
 
                     } else {

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -1331,12 +1331,12 @@ sub mkinstall
                 $kcmdline = "ksdevice=bootif kssendmac text selinux=0 rd.dm=0 rd.md=0 repo=$httpmethod://$instserver:$httpport$httpprefix/packages/ kvmp.inst.auto=$httpmethod://$instserver:$httpport/install/autoinst/$node root=live:$httpmethod://$instserver:$httpport$httpprefix/LiveOS/squashfs.img";
             } else {
                 if (xCAT::Utils->version_cmp($kversion, "7.0") < 0) {
-                    $kcmdline = "quiet repo=$httpmethod://$instserver:$httpport$httpprefix ks=$httpmethod://"
+                    $kcmdline = "repo=$httpmethod://$instserver:$httpport$httpprefix ks=$httpmethod://"
                       . $instserver . ":" . $httpport
                       . "/install/autoinst/"
                       . $node;
                 } else {
-                    $kcmdline = "quiet inst.repo=$httpmethod://$instserver:$httpport$httpprefix inst.ks="
+                    $kcmdline = "inst.repo=$httpmethod://$instserver:$httpport$httpprefix inst.ks="
                       . "$httpmethod://"
                       . $instserver . ":" . $httpport
                       . "/install/autoinst/"

--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -342,10 +342,10 @@ sub process_request {
             open($cfg, ">", "$tftpdir/xcat/xnba/nets/$net");
             print $cfg "#!gpxe\n";
             if ($invisibletouch) {
-                print $cfg 'imgfetch -n kernel http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.kernel.' . "$arch quiet xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline BOOTIF=01-" . '${netX/machyp}' . "\n";
+                print $cfg 'imgfetch -n kernel http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.kernel.' . "$arch xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline BOOTIF=01-" . '${netX/machyp}' . "\n";
                 print $cfg 'imgfetch -n nbfs http://${next-server}:'.$httpport . "$initrd_file\n";
             } else {
-                print $cfg 'imgfetch -n kernel http://${next-server}:'.$httpport.'/tftpboot/xcat/nbk.' . "$arch quiet xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline\n";
+                print $cfg 'imgfetch -n kernel http://${next-server}:'.$httpport.'/tftpboot/xcat/nbk.' . "$arch xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline\n";
                 print $cfg 'imgfetch -n nbfs http://${next-server}:'.$httpport . "$initrd_file\n";
             }
             print $cfg "imgload kernel\n";
@@ -358,12 +358,12 @@ sub process_request {
                 print $cfg '   image=/tftpboot/xcat/genesis.kernel.' . "$arch\n";
                 print $cfg "   label=\"xCAT Genesis (" . $normnets->{$_} . ")\"\n";
                 print $cfg "   initrd=$initrd_file\n";
-                print $cfg "   append=\"quiet xcatd=" . $normnets->{$_} . ":$xcatdport destiny=discover $consolecmdline BOOTIF=%B\"\n";
+                print $cfg "   append=\"xcatd=" . $normnets->{$_} . ":$xcatdport destiny=discover $consolecmdline BOOTIF=%B\"\n";
                 close($cfg);
                 open($cfg, ">", "$tftpdir/xcat/xnba/nets/$net.uefi");
                 print $cfg "#!gpxe\n";
                 print $cfg 'imgfetch -n kernel http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.kernel.' . "$arch\nimgload kernel\n";
-                print $cfg "imgargs kernel quiet xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline BOOTIF=01-" . '${netX/mac:hexhyp}' . " destiny=discover initrd=initrd\n";
+                print $cfg "imgargs kernel xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline BOOTIF=01-" . '${netX/mac:hexhyp}' . " destiny=discover initrd=initrd\n";
                 print $cfg 'imgfetch -n initrd http://${next-server}:'.$httpport . "$initrd_file\nimgexec kernel\n";
                 close($cfg);
             }
@@ -374,7 +374,7 @@ sub process_request {
             print $cfgfile "   label \"xCAT Genesis (" . $normnets->{$_} . ")\"\n";
             print $cfgfile "   kernel http://" . $normnets->{$_} . ":$httpport/$tftpdir/xcat/genesis.kernel.$arch\n";
             print $cfgfile "   initrd http://" . $normnets->{$_} . ":$httpport/$initrd_file\n";
-            print $cfgfile '   append "quiet xcatd=' . $normnets->{$_} . ":$xcatdport $consolecmdline\"\n";
+            print $cfgfile '   append "xcatd=' . $normnets->{$_} . ":$xcatdport $consolecmdline\"\n";
             close($cfgfile);
         }
     }
@@ -404,7 +404,7 @@ sub process_request {
             print $cfgfile "DEFAULT xCAT\n";
             print $cfgfile "  LABEL xCAT\n";
             print $cfgfile "  KERNEL xcat/nbk.$arch\n";
-            print $cfgfile "  APPEND initrd=$tftp_initrd quiet xcatd=" . $hexnets->{$_} . ":$xcatdport $consolecmdline\n";
+            print $cfgfile "  APPEND initrd=$tftp_initrd xcatd=" . $hexnets->{$_} . ":$xcatdport $consolecmdline\n";
             close($cfgfile);
         } elsif ($arch =~ /ppc/) {
             open($cfgfile, ">", "$tftpdir/etc/" . lc($_));
@@ -413,7 +413,7 @@ sub process_request {
             print $cfgfile "   label \"xCAT Genesis (" . $normnets->{$_} . ")\"\n";
             print $cfgfile "   kernel http://" . $hexnets->{$_} . ":$httpport/$tftpdir/xcat/genesis.kernel.$arch\n";
             print $cfgfile "   initrd http://" . $hexnets->{$_} . ":$httpport/$initrd_file\n";
-            print $cfgfile '   append "quiet xcatd=' . $hexnets->{$_} . ":$xcatdport $consolecmdline\"\n";
+            print $cfgfile '   append "xcatd=' . $hexnets->{$_} . ":$xcatdport $consolecmdline\"\n";
             close($cfgfile);
         }
     }

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -514,7 +514,7 @@ sub mknetboot
             $kcmdline =
               "imgurl=$httpmethod://$imgsrv:$httpport/$rootimgdir/$compressedrootimg ";
         }
-        $kcmdline .= "XCAT=$xcatmaster:$xcatdport quiet ";
+        $kcmdline .= "XCAT=$xcatmaster:$xcatdport ";
         $kcmdline .= " XCATHTTPPORT=$httpport ";
 
         #if site.nodestatus="n", append "nonodestatus" to kcmdline
@@ -1098,7 +1098,7 @@ sub mkinstall
                 $httpprefix =~ s/^$installroot/\/install/;
             }
             my $kcmdline =
-              "quiet autoyast=$httpmethod://"
+              "autoyast=$httpmethod://"
               . $netserver . ":" . $httpport
               . "/install/autoinst/"
               . $node


### PR DESCRIPTION
This PR modified the `quiet` kernel parameter behaviour as discussed in #6916. The kernel parameter was hardcoded in `anaconda.pm` and `sles.pm`, making it impossible to get verbose boot output without editing the plugin source. The existing `addkcmdline` mechanism only appends to the kernel command line, so there was no clean way to remove `quiet`.

This moves `quiet` out of the plugin `kcmdline` construction and into the `linuximage.addkcmdline` default, set during `copycds` osimage creation.

## How it works

```bash
# New osimage gets quiet by default
$ copycds /iso/rhels9.iso
$ lsdef -t osimage rhels9-x86_64-install-compute -i addkcmdline
  addkcmdline=quiet

# Want verbose boot for debugging?
$ chdef -t osimage rhels9-x86_64-install-compute addkcmdline=""
$ nodeset cn-01 osimage=rhels9-x86_64-install-compute
# boots with verbose kernel output

# Want quiet back?
$ chdef -t osimage rhels9-x86_64-install-compute addkcmdline="quiet"
```

## Caveats
- Existing osimages are not modified on `copycds` re-run -- only new rows get the default

## Behaviour matrix

| Test | Before patch | After patch |
|------|-------------|-------------|
| PXE config with default `addkcmdline=""` | `quiet inst.repo=...` | `inst.repo=...` (no quiet) |
| PXE config with `addkcmdline=quiet` | n/a | `inst.repo=... quiet` (quiet from addkcmdline) |
| PXE config with `addkcmdline=""` | n/a | `inst.repo=...` (no quiet) |
| Toggle works via `chdef` | No | Yes -- per-osimage control |

Fixes #6916