### PR TITLE
docs: update copyright to include xCAT Consortium

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,8 +50,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'xCAT'
-copyright = u'2015-2022, IBM Corporation'
-author = u'IBM Corporation'
+copyright = u'2015-2022 IBM Corporation, 2023-2026 xCAT Consortium'
+author = u'IBM Corporation, xCAT Consortium'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Add xCAT Consortium (2022-2026) alongside the original IBM Corporation copyright (2015-2022) in the Sphinx documentation configuration.
