### PR TITLE
fix: guardrails for Ubuntu genimage

### DIFF
--- a/docs/source/guides/admin-guides/references/man5/linuximage.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/linuximage.5.rst
@@ -68,7 +68,7 @@ linuximage Attributes:
 
 \ **pkgdir**\ 
  
- The name of the directory where the distro packages are stored. It could be set to multiple paths. The multiple paths must be separated by ",". The first path in the value of osimage.pkgdir must be the OS base pkg dir path, such as pkgdir=/install/rhels6.2/x86_64,/install/updates . In the os base pkg path, there are default repository data. And in the other pkg path(s), the users should make sure there are repository data. If not, use "createrepo" command to create them. For ubuntu, multiple mirrors can be specified in the pkgdir attribute, the mirrors must be prefixed by the protocol(http/ssh) and delimited with "," between each other.
+ The name of the directory where the distro packages are stored. It could be set to multiple paths. The multiple paths must be separated by ",". The first path in the value of osimage.pkgdir must be the OS base pkg dir path, such as pkgdir=/install/rhels6.2/x86_64,/install/updates . In the os base pkg path, there are default repository data. And in the other pkg path(s), the users should make sure there are repository data. If not, use "createrepo" command to create them. For ubuntu, multiple mirrors can be specified in the pkgdir attribute, the mirrors must be prefixed by the protocol(http/ssh) and delimited with "," between each other. Ubuntu live-server media copied by copycds is not a complete apt package mirror; Ubuntu netboot or statelite image generation may require a complete local Ubuntu apt mirror or an explicitly configured HTTP/HTTPS Ubuntu apt repository.
  
 
 
@@ -208,4 +208,3 @@ SEE ALSO
 
 
 \ **nodels(1)**\ , \ **chtab(8)**\ , \ **tabdump(8)**\ , \ **tabedit(8)**\ 
-

--- a/docs/source/guides/admin-guides/references/man7/osimage.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/osimage.7.rst
@@ -307,7 +307,7 @@ osimage Attributes:
 
 \ **pkgdir**\  (linuximage.pkgdir)
  
- The name of the directory where the distro packages are stored. It could be set to multiple paths. The multiple paths must be separated by ",". The first path in the value of osimage.pkgdir must be the OS base pkg dir path, such as pkgdir=/install/rhels6.2/x86_64,/install/updates . In the os base pkg path, there are default repository data. And in the other pkg path(s), the users should make sure there are repository data. If not, use "createrepo" command to create them. For ubuntu, multiple mirrors can be specified in the pkgdir attribute, the mirrors must be prefixed by the protocol(http/ssh) and delimited with "," between each other.
+ The name of the directory where the distro packages are stored. It could be set to multiple paths. The multiple paths must be separated by ",". The first path in the value of osimage.pkgdir must be the OS base pkg dir path, such as pkgdir=/install/rhels6.2/x86_64,/install/updates . In the os base pkg path, there are default repository data. And in the other pkg path(s), the users should make sure there are repository data. If not, use "createrepo" command to create them. For ubuntu, multiple mirrors can be specified in the pkgdir attribute, the mirrors must be prefixed by the protocol(http/ssh) and delimited with "," between each other. Ubuntu live-server media copied by copycds is not a complete apt package mirror; Ubuntu netboot or statelite image generation may require a complete local Ubuntu apt mirror or an explicitly configured HTTP/HTTPS Ubuntu apt repository.
  
 
 
@@ -461,4 +461,3 @@ SEE ALSO
 
 
 \ **mkdef(1)**\ , \ **chdef(1)**\ , \ **lsdef(1)**\ , \ **rmdef(1)**\ 
-

--- a/docs/source/guides/admin-guides/references/man8/copycds.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/copycds.8.rst
@@ -33,6 +33,8 @@ DESCRIPTION
 
 The \ **copycds**\  command copies all contents of Distribution DVDs/ISOs or Service Pack DVDs/ISOs to a destination directory. The destination directory can be specified by the \ **-p**\  option. If no path is specified, the default destination directory will be formed from the \ **installdir**\  site table attribute, distro name and architecture, for example: /install/rhels6.3/x86_64. The \ **copycds**\  command can copy from one or more ISO files, or the CD/DVD device path.
 
+For Ubuntu live-server media, \ **copycds**\  copies the installer media and can create install osimages, but the copied media is not a complete Ubuntu apt package mirror. Ubuntu netboot or statelite image generation with \ **genimage**\  may require additional package sources configured through \ **linuximage.pkgdir**\  or \ **linuximage.otherpkgdir**\ , such as a local mirror or an explicitly configured HTTP/HTTPS Ubuntu apt repository.
+
 You can specify \ **-i**\  or \ **-**\ **-inspection**\  option to check whether the DVDs/ISOs can be recognized by xCAT. If recognized, the distribution name, architecture and the disc no (the disc sequence number of DVDs/ISOs in multi-disk distribution) of the DVD/ISO is displayed. If xCAT doesn't recognize the DVD/ISO, you must manually specify the distro name and architecture using the \ **-n**\  and \ **-a**\  options. This is sometimes the case for distros that have very recently been released, and the xCAT code hasn't been updated for it yet.
 
 You can get xCAT to recognize new DVDs/ISOs by adding them to /opt/xcat/lib/perl/xCAT/data/discinfo.pm (the key of the hash is the first line of .discinfo) and reloading xcatd (\ **service xcatd reload**\ ).
@@ -175,4 +177,3 @@ SEE ALSO
 
 
 nodeset(8)|nodeset.8, site(5)|site.5, nodetype(5)|nodetype.5
-

--- a/xCAT-server/lib/xcat/plugins/debian.pm
+++ b/xCAT-server/lib/xcat/plugins/debian.pm
@@ -178,6 +178,31 @@ sub using_subiquity
     return 0;
 }
 
+sub is_ubuntu_live_media
+{
+    my $media_path = shift;
+
+    return 0 unless ($media_path && -d "$media_path/casper");
+    return 1 if (-r "$media_path/casper/install-sources.yaml");
+
+    my @squashfs_images = glob("$media_path/casper/*.squashfs");
+    return scalar(@squashfs_images) ? 1 : 0;
+}
+
+sub warn_ubuntu_live_media_pkg_source
+{
+    my $callback = shift;
+    my $media_path = shift;
+
+    return unless is_ubuntu_live_media($media_path);
+
+    $callback->({
+        warning => [
+            "Ubuntu live media was copied successfully, but this media is not a complete Ubuntu apt package mirror. Install osimages can use it, but netboot/statelite image generation with genimage may require additional package sources through linuximage.pkgdir or linuximage.otherpkgdir, such as a local mirror or an explicitly configured HTTP/HTTPS Ubuntu apt repository."
+        ]
+    });
+}
+
 sub copyAndAddCustomizations {
     my $source = shift;
     my $dest   = shift;
@@ -462,6 +487,10 @@ sub copycd
         my @ret = xCAT::SvrUtils->update_osdistro_table($distname, $arch, $temppath, $osdistroname);
         if ($ret[0] != 0) {
             $callback->({ data => "Error when updating the osdistro tables: " . $ret[1] });
+        }
+
+        if (($prod eq "Ubuntu") || ($prod eq "Ubuntu-Server")) {
+            warn_ubuntu_live_media_pkg_source($callback, $temppath);
         }
 
         $callback->({ data => "Media copy operation successful" });

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -312,9 +312,10 @@ unless ($onlyinitrd) {
     my $aptcmd1 = "debootstrap";
     my $aptcmd2;
 
-    # Check whether a local Ubuntu mirror is specified
-    # if linuximage.pkgdir has http mirror is set, we consider the first http mirror
-    # as a full Ubuntu mirror which will be used to create bootstrap
+    # Check whether an explicit Ubuntu mirror is specified.
+    # If linuximage.pkgdir has an http mirror set, use it for bootstrap.
+    # Otherwise use the copied local media and fail clearly if it is not
+    # a complete debootstrap-capable package source.
     if (@pkgdir_internet) {
         my $mirrorurl = $pkgdir_internet[0];
         if ($pkgdir_internet[0] =~ /(http.*?) +([^ ]+)/) {
@@ -326,11 +327,11 @@ unless ($onlyinitrd) {
             exit 1;
         }
     } else {
-        if ($uarch eq 'ppc64el') {
-            $aptcmd2 = "--verbose --arch $uarch $dist $rootimg_dir http://ports.ubuntu.com/ubuntu-ports/";
-        } else {
-            $aptcmd2 = "--verbose  --arch $uarch $dist $rootimg_dir http://archive.ubuntu.com/ubuntu/";
+        if (!$srcdir) {
+            print "Error: No local Ubuntu package directory is configured in osimage.pkgdir.\n";
+            exit 1;
         }
+        $aptcmd2 = "--verbose --arch $uarch $dist $rootimg_dir file://$srcdir";
     }
 
     print "Run cmd [$aptcmd1 $aptcmd2] to create rootimage bootstraps\n";
@@ -338,10 +339,15 @@ unless ($onlyinitrd) {
     if ($rc) {
         my $os=xCAT::Utils->osver("os");
         if ($os ne 'ubuntu') {
-            print "Error: Can not run genimage for Ubunty OS on a non-Ubunty system ($os)";
+            print "Error: Can not run genimage for Ubuntu OS on a non-Ubuntu system ($os)\n";
             exit 1;
         }
-        print "Error: Can not create bootstraps for rootimage. Make sure you specified full http mirror path.\n";
+        if (@pkgdir_internet) {
+            print "Error: Can not create bootstraps for rootimage. Make sure you specified full mirror path.\n";
+        } else {
+            print "Error: Can not create bootstraps for rootimage using copied Ubuntu media at $srcdir.\n";
+            print "The copied media does not contain every package required by debootstrap. Configure osimage.pkgdir with a complete local Ubuntu apt mirror, or explicitly add an HTTP/HTTPS Ubuntu apt repository to osimage.pkgdir.\n";
+        }
         exit 1;
     }
 

--- a/xCAT-test/unit/ubuntu_live_media_guardrails.t
+++ b/xCAT-test/unit/ubuntu_live_media_guardrails.t
@@ -1,0 +1,45 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use File::Spec;
+use Test::More;
+
+my $repo_root = File::Spec->catdir( $FindBin::Bin, '..', '..' );
+
+sub read_file {
+    my ($file) = @_;
+    my $path = File::Spec->catfile( $repo_root, $file );
+
+    open( my $fh, '<', $path ) or die "Unable to read $path: $!";
+    my $contents = do { local $/; <$fh> };
+    close($fh);
+
+    return $contents;
+}
+
+my $debian_pm = read_file('xCAT-server/lib/xcat/plugins/debian.pm');
+like( $debian_pm, qr/sub is_ubuntu_live_media/, 'copycds can detect Ubuntu live media' );
+like( $debian_pm, qr/casper\/install-sources\.yaml/, 'copycds recognizes Subiquity install source metadata' );
+like( $debian_pm, qr/casper\/\*\.squashfs/, 'copycds recognizes live squashfs media' );
+like( $debian_pm, qr/not a complete Ubuntu apt package mirror/, 'copycds warns that Ubuntu live media is not a complete apt mirror' );
+like( $debian_pm, qr/linuximage\.pkgdir.*linuximage\.otherpkgdir.*HTTP\/HTTPS Ubuntu apt repository/s, 'copycds warning points to explicit package source attributes' );
+
+my $genimage = read_file('xCAT-server/share/xcat/netboot/ubuntu/genimage');
+unlike( $genimage, qr{http://archive\.ubuntu\.com/ubuntu/}, 'Ubuntu genimage does not implicitly use the public amd64 archive' );
+unlike( $genimage, qr{http://ports\.ubuntu\.com/ubuntu-ports/}, 'Ubuntu genimage does not implicitly use the public ports archive' );
+like( $genimage, qr{\$aptcmd2 = "--verbose --arch \$uarch \$dist \$rootimg_dir file://\$srcdir"}, 'Ubuntu genimage uses copied local media when no explicit mirror is configured' );
+like( $genimage, qr/copied Ubuntu media.*complete local Ubuntu apt mirror.*HTTP\/HTTPS Ubuntu apt repository/s, 'Ubuntu genimage gives an actionable package source error' );
+like( $genimage, qr{\@pkgdir_internet.*?\$aptcmd2 = "--verbose --arch \$uarch \$dist \$rootimg_dir \$mirrorurl"}s, 'Ubuntu genimage still honors an explicit mirror configured in pkgdir' );
+
+my $copycds_doc = read_file('docs/source/guides/admin-guides/references/man8/copycds.8.rst');
+like( $copycds_doc, qr/Ubuntu live-server media.*not a complete Ubuntu apt package mirror/s, 'copycds documentation explains Ubuntu live media package limits' );
+
+my $linuximage_doc = read_file('docs/source/guides/admin-guides/references/man5/linuximage.5.rst');
+like( $linuximage_doc, qr/Ubuntu live-server media copied by copycds is not a complete apt package mirror.*HTTP\/HTTPS Ubuntu apt repository/, 'linuximage documentation explains Ubuntu live media package limits' );
+
+my $osimage_doc = read_file('docs/source/guides/admin-guides/references/man7/osimage.7.rst');
+like( $osimage_doc, qr/Ubuntu live-server media copied by copycds is not a complete apt package mirror.*HTTP\/HTTPS Ubuntu apt repository/, 'osimage documentation explains Ubuntu live media package limits' );
+
+done_testing();


### PR DESCRIPTION
This PR makes Ubuntu live-server media handling honest and deterministic.

`copycds` still works as before, but now warns that Ubuntu live-server ISOs are not complete apt package mirrors. Ubuntu `genimage` no longer silently falls back to public Ubuntu archives when copied media cannot satisfy `debootstrap`. Instead, it uses configured sources and fails with a clear message telling the admin to provide a complete local apt mirror or explicitly configure an HTTP/HTTPS Ubuntu apt repository.
