### PR TITLE
fix: ipmi rmcptag and cbcpad

### DIFF
--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -973,6 +973,12 @@ sub got_rakp2 {
     }
     $byte = shift @data;
     unless ($byte == 0x00) {
+        if (($byte == 0x9 or $byte == 0xd) and $self->{attempthash} == 256) {
+            $self->{attempthash} = 1;
+            $self->{sessionestablishmentcontext} = 0;
+            $self->open_rmcpplus_request();
+            return;
+        }
         if (($byte == 0x9 or $byte == 0xd) and $self->{privlevel} == 4) {
 
             # this is probably an environment that wants to give us only operator

--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -780,8 +780,12 @@ sub got_rmcp_response {
         #we would ignore an RMCP+ open session response if we are not in an IPMI2 negotiation, so we have to have *some* state that isn't established for this to be kosher
         return 9;    #now's not the time for this response, ignore it
     }
-    unless ($byte == $self->{rmcptag}) { #make sure this rmcp response is specifically the last one we sent.... we don't want to happily proceed with the risk a retry request blew up our temp session id without letting us know
-        return 9;
+    unless ($byte == $self->{rmcptag}) {
+        return 9 unless $byte == 0;
+        my @sid_check = @data[3..6];
+        unless (pack("C4", @sid_check) eq pack("C4", @{ $self->{sidm} })) {
+            return 9;
+        }
     }
     $byte = shift @data;
     unless ($byte == 0x00) {
@@ -895,8 +899,12 @@ sub got_rakp4 {
     unless ($self->{sessionestablishmentcontext} == STATE_EXPECTINGRAKP4) { #ignore rakp4 unless we are explicitly expecting RAKP4
         return 9;    #now's not the time for this response, ignore it
     }
-    unless ($byte == $self->{rmcptag}) { #make sure this rmcp response is specifically the last one we sent.... we don't want to happily proceed with the risk a retry request blew up our temp session id without letting us know
-        return 9;
+    unless ($byte == $self->{rmcptag}) {
+        return 9 unless $byte == 0;
+        my @sid_check = @data[3..6];
+        unless (pack("C4", @sid_check) eq pack("C4", @{ $self->{sidm} })) {
+            return 9;
+        }
     }
     $byte = shift @data;
     unless ($byte == 0x00) {
@@ -955,8 +963,12 @@ sub got_rakp2 {
         #the reason being that if an old rakp1 retry actually made it and we were just too aggressive, then a previous rakp2 is invalidated and invalid session id or the integrity check value is bad
         return 9;    #now's not the time for this response, ignore it
     }
-    unless ($byte == $self->{rmcptag}) { #make sure this rmcp response is specifically the last one we sent.... we don't want to happily proceed with the risk a retry request blew up our temp session id without letting us know
-        return 9;
+    unless ($byte == $self->{rmcptag}) {
+        return 9 unless $byte == 0;
+        my @sid_check = @data[3..6];
+        unless (pack("C4", @sid_check) eq pack("C4", @{ $self->{sidm} })) {
+            return 9;
+        }
     }
     $byte = shift @data;
     unless ($byte == 0x00) {

--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -825,7 +825,7 @@ sub send_rakp3 {
     $self->{rmcptag} += 1;
     my @payload = ($self->{rmcptag}, 0, 0, 0, @{ $self->{pendingsessionid} });
     my @user = unpack("C*", $self->{userid});
-    push @payload, unpack("C*", $self->{hshfn}->(pack("C*", @{ $self->{remoterandomnumber} }, @{ $self->{sidm} }, $self->{privlevel}, scalar @user, @user), $self->{password}));
+    push @payload, unpack("C*", $self->{hshfn}->(pack("C*", @{ $self->{remoterandomnumber} }, @{ $self->{sidm} }, $self->{rakp_privbyte}, scalar @user, @user), $self->{password}));
     $self->sendpayload(payload => \@payload, type => $payload_types{'rakp3'});
 }
 
@@ -839,7 +839,8 @@ sub send_rakp1 {
         push @{ $self->{randomnumber} }, $randomnumber;
     }
     push @payload, @{ $self->{randomnumber} };
-    push @payload, ($self->{privlevel}, 0, 0);    # request priv
+    $self->{rakp_privbyte} = $self->{privlevel} | 0x10;
+    push @payload, ($self->{rakp_privbyte}, 0, 0);    # request priv, with name-only lookup
     my @user = unpack("C*", $self->{userid});
     push @payload, scalar @user;
     push @payload, @user;
@@ -1007,7 +1008,7 @@ sub got_rakp2 {
     #Data now represents authcode.. sha1 only..
     my @user = unpack("C*", $self->{userid});
     my $ulength = scalar @user;
-    my $hmacdata = pack("C*", (@{ $self->{sidm} }, @{ $self->{pendingsessionid} }, @{ $self->{randomnumber} }, @{ $self->{remoterandomnumber} }, @{ $self->{remoteguid} }, $self->{privlevel}, $ulength, @user));
+    my $hmacdata = pack("C*", (@{ $self->{sidm} }, @{ $self->{pendingsessionid} }, @{ $self->{randomnumber} }, @{ $self->{remoterandomnumber} }, @{ $self->{remoteguid} }, $self->{rakp_privbyte}, $ulength, @user));
     my @expectedhash = (unpack("C*", $self->{hshfn}->($hmacdata, $self->{password})));
     foreach (0 .. (scalar(@expectedhash) - 1)) {
         if ($expectedhash[$_] != $data[$_]) {
@@ -1016,7 +1017,7 @@ sub got_rakp2 {
             return 9;
         }
     }
-    $self->{sik} = $self->{hshfn}->(pack("C*", @{ $self->{randomnumber} }, @{ $self->{remoterandomnumber} }, $self->{privlevel}, $ulength, @user), $self->{password});
+    $self->{sik} = $self->{hshfn}->(pack("C*", @{ $self->{randomnumber} }, @{ $self->{remoterandomnumber} }, $self->{rakp_privbyte}, $ulength, @user), $self->{password});
     $self->{k1} = $self->{hshfn}->(pack("C*", 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), $self->{sik});
     $self->{k2} = $self->{hshfn}->(pack("C*", 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2), $self->{sik});
     my @aeskey = unpack("C*", $self->{k2});

--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -763,6 +763,9 @@ sub cbc_pad {
         unless ($count) {
             return pack("C*", @block);
         }
+        if ($count > scalar @block) {
+            return "";
+        }
         splice @block, 0 - $count;
         return pack("C*", @block);
     }


### PR DESCRIPTION
@Obihoernchen this one was only possible with the help of AI assisted tools, so the explanation is also up to them:

## Problem

xCAT's IPMI implementation can't talk to OpenBMC-based BMCs. All commands (rpower, rsetboot, rinv, rvitals) either timeout or crash with the `splice` error from #7511. Meanwhile, ipmitool works fine on the same hardware with the same credentials.

Reported on Lenovo XCC3 (#7511). We reproduced it on an IBM POWER9 AC922 (also OpenBMC-based). @Obihoernchen has seen the same class of failure on Intel/Mitac BMCs.

## What we found

We instrumented IPMI.pm with syslog traces and did packet captures against a POWER9 BMC to compare xCAT's RMCP+ handshake with ipmitool's. Three things were wrong:

### 1. OpenBMC returns message tag 0 in RAKP2

The IPMI spec says RAKP Message 2 should echo the tag from RAKP Message 1. OpenBMC returns 0 instead. xCAT rejected every RAKP2 as stale and retried until timeout:

```
IPMI_RAKP2: rmcptag check: got=0 expected=137
IPMI_RAKP2: rmcptag check: got=0 expected=139
IPMI_RAKP2: rmcptag check: got=0 expected=141
... (128 times, then timeout)
```

The same check exists in `got_rmcp_response` and `got_rakp4`.

### 2. xCAT doesn't set the name-only lookup bit in RAKP1

After fixing the tag, sessions got through but failed with "Unauthorized name". Packet capture showed the difference: ipmitool sends the RAKP1 privilege byte as `0x14` (admin + name-only lookup), while xCAT sent `0x04`.

The name-only lookup bit (bit 4, IPMI spec Table 13-17) tells the BMC to find the user by name alone rather than by name+privilege. Without it, some BMCs reject valid credentials.

This byte is also part of the HMAC input for RAKP2 verification, RAKP3 auth code, and SIK derivation, so all three had to use the updated value to keep the hashes correct.

### 3. cbc_pad crashes on bad padding (the original #7511)

`cbc_pad` in decrypt mode reads the last byte as a pad count and does `splice(@block, 0 - $count)`. If decryption produced garbage, the count could exceed the array length, crashing with "Modification of non-creatable array value attempted, subscript -16".

## What this PR does

Four commits:

1. Return empty string from `cbc_pad` when padding is invalid, so corrupted decryption is treated as a packet failure instead of crashing.

2. Accept message tag 0 in `got_rmcp_response`, `got_rakp2`, and `got_rakp4`, but only after verifying the remote console session ID matches our current sidm. This keeps the stale-response protection while letting OpenBMC responses through.

3. Set the name-only lookup bit in RAKP1 and use the same privilege byte in all HMAC calculations (RAKP2 check, RAKP3 auth code, SIK). Matches what ipmitool does.

4. Extend the sha256-to-sha1 fallback (already in `got_rmcp_response`) to also cover RAKP2 auth rejections.

## Tested on

| BMC | rpower | rsetboot | rinv | rvitals |
|-----|--------|----------|------|---------|
| IBM POWER9 AC922 (OpenBMC) | on | Hard Drive | SDR unsupported* | - |
| Lenovo XCC2 | on | boot override inactive | BMC Firmware: 2.81 | Ambient: 26 C |
| Supermicro X10DRW | on | boot override inactive | BMC Firmware: 3.89 | CPU1: 23 C |
| Dell iDRAC | on | boot override inactive | BMC Firmware: 7.20 | Exhaust: 44 C |

\* SDR reservation is an OpenBMC limitation, unrelated to this fix.

Before this PR, the POWER9 BMC timed out on every xCAT IPMI command. After, all four BMC types work. We don't have a Lenovo XCC3 or Intel/Mitac to test, so those need the reporter @nuttapongc or @Obihoernchen to verify.

Fixes #7511
