### PR TITLE
fix: retry on HTTP 503 from OpenBMC REST API instead of failing

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2991,6 +2991,12 @@ sub deal_with_response {
         }
 
         if ($response->status_line eq $::RESPONSE_SERVICE_UNAVAILABLE) {
+            $node_info{$node}{_503_retries} = ($node_info{$node}{_503_retries} || 0) + 1;
+            if ($node_info{$node}{_503_retries} <= 3) {
+                $node_info{$node}{cur_status} =~ s/_RESPONSE$/_REQUEST/;
+                $node_wait{$node} = time() + 3;
+                return;
+            }
             $error = $::RESPONSE_SERVICE_UNAVAILABLE;
         } elsif ($response->status_line eq $::RESPONSE_METHOD_NOT_ALLOWED) {
             if ($node_info{$node}{cur_status} eq "REVENTLOG_RESOLVED_RESPONSE") {


### PR DESCRIPTION
This PR adds some tolerance with non-responsive OpenBMC during transient status, as described on #4264.

OpenBMC BMCs sometimes return HTTP 503 when the REST service is busy or recovering from a reboot. xCAT reported the error and gave up, making the user retry manually. Second attempt usually worked.

When openbmc.pm gets a 503, retry the same request up to 3 times with a 3-second wait. If all retries fail, report the error as before. The existing 504 handling for bmcreboot is not touched.

## Validation

IBM POWER9 AC922 (OpenBMC). No regressions.

Fixes #4264
