### PR TITLE
fix: typo in confignetwork preventing SETINSTALLNIC from working

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -96,7 +96,7 @@ do
     fi
 done
 if [ "$SETINSTALLNIC" = "1" ] || [ "$SETINSTALLNIC" = "yes" ]; then
-    bool_install_nic=1
+    boot_install_nic=1
 fi
 
 ######################################################################


### PR DESCRIPTION
Typo... how did that get away?

Fixes: #7472  
