### PR TITLE
fix: use dnf for EL8+ RH genimage installroot

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -92,6 +92,38 @@ sub majversion {
     return $majorrel;
 }
 
+sub el_major_version {
+    my $version = shift;
+
+    if (defined($version)
+        && $version =~ /^(?:rhels?|centos|rocky|alma(?:linux)?|ol)\D*(\d+)/)
+    {
+        return $1;
+    }
+
+    return;
+}
+
+sub rpm_installroot_command {
+    my $non_interactive = shift || "";
+    my $majorrel = el_major_version($osver);
+    my $pkgmgr = "yum";
+
+    # EL8 and newer are dnf-native. Keep yum as the fallback for legacy
+    # systems and minimal environments that still provide only yum.
+    if (defined($majorrel) && $majorrel > 7 && -x "/usr/bin/dnf") {
+        $pkgmgr = "dnf";
+    }
+
+    my $cmd = "$pkgmgr $non_interactive -c /tmp/genimage.$$.yum.conf --installroot=$rootimg_dir/ --disablerepo=* ";
+    if (defined($majorrel) && $majorrel > 7) {
+        $cmd .= "--releasever=" . $majorrel . " ";
+        $cmd .= "--setopt=module_platform_id=platform:el" . $majorrel . " ";
+    }
+
+    return $cmd;
+}
+
 sub mount_chroot {
     my $rootimage_dir = shift;
 
@@ -374,15 +406,7 @@ if($onlyinitrd){
     my $non_interactive;
     if (!$prompt) { $non_interactive = "-y"; }
 
-    my $yumcmd = "yum $non_interactive -c /tmp/genimage.$$.yum.conf --installroot=$rootimg_dir/ --disablerepo=* ";
-
-    if ($osver =~ /^(?:rhel|rocky|alma|ol)\D*(\d*)[.\d]*.*$/) {
-        $majorrel = $1;
-        if ($majorrel > 7) {
-            $yumcmd .= "--releasever=" . $majorrel . " ";
-            $yumcmd .= "--setopt=module_platform_id=platform:el" . $majorrel . " ";
-        }
-    }
+    my $yumcmd = rpm_installroot_command($non_interactive);
 
     foreach (0 .. $repnum) {
         $yumcmd .= "--enablerepo=$osver-$arch-$_ ";
@@ -479,7 +503,7 @@ if($onlyinitrd){
         print "$envlist $yumcmd install $pkgnames\n";
         my $rc = system("$envlist $yumcmd install $pkgnames");
         if ($rc) {
-            print "yum invocation failed\n";
+            print "RPM package manager invocation failed\n";
             umount_chroot($rootimg_dir);
             exit 1;
         }
@@ -548,7 +572,7 @@ if($onlyinitrd){
         }
         close($yumconfig);
         $index--;
-        my $yumcmd_base = "yum $non_interactive -c /tmp/genimage.$$.yum.conf --installroot=$rootimg_dir/ --disablerepo=* ";
+        my $yumcmd_base = rpm_installroot_command($non_interactive);
 
         #yum/rpm/zypper has defect on calculating diskspace usage when installing rpm on a NFS mounted installroot
         if (isNFSdir("$rootimg_dir")) {
@@ -609,7 +633,7 @@ if($onlyinitrd){
                 print "$envlist $yumcmd\n";
                 my $rc = system("$envlist $yumcmd");
                 if ($rc) {
-                    print "yum invocation failed\n";
+                    print "RPM package manager invocation failed\n";
 
                     # remove the hacked uname file
                     unuse_hackuname();
@@ -2588,4 +2612,3 @@ sub usage {
 
     return 0;
 }
-

--- a/xCAT-test/unit/rh_genimage_package_manager.t
+++ b/xCAT-test/unit/rh_genimage_package_manager.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use File::Spec;
+use Test::More;
+
+my $repo_root = File::Spec->catdir( $FindBin::Bin, '..', '..' );
+
+sub read_file {
+    my ($file) = @_;
+    my $path = File::Spec->catfile( $repo_root, $file );
+
+    open( my $fh, '<', $path ) or die "Unable to read $path: $!";
+    my $contents = do { local $/; <$fh> };
+    close($fh);
+
+    return $contents;
+}
+
+my $genimage = read_file('xCAT-server/share/xcat/netboot/rh/genimage');
+
+like( $genimage, qr/sub el_major_version/, 'RH genimage has an EL major-version helper' );
+like( $genimage, qr/sub rpm_installroot_command/, 'RH genimage builds RPM installroot commands through one helper' );
+like( $genimage, qr/-x "\/usr\/bin\/dnf".*?\$pkgmgr = "dnf"/s, 'EL8+ genimage prefers dnf when it is available' );
+like( $genimage, qr/--releasever=.*?--setopt=module_platform_id=platform:el/s, 'EL8+ installroot commands keep releasever and module platform options' );
+like( $genimage, qr/my \$yumcmd = rpm_installroot_command\(\$non_interactive\);/, 'base package pass uses shared installroot command builder' );
+like( $genimage, qr/my \$yumcmd_base = rpm_installroot_command\(\$non_interactive\);/, 'otherpkgs pass uses shared installroot command builder' );
+unlike( $genimage, qr/my \$yumcmd(?:_base)? = "yum /, 'RH genimage no longer hardcodes yum in installroot command builders' );
+
+done_testing();


### PR DESCRIPTION
This PR fixes a long standing issue where we were using dnf and yum interchangeable which isn't actually true many times. 
  
- Updates the RH-family `genimage` installroot path to use dnf on EL8 and newer systems when `/usr/bin/dnf` is available, while keeping `yum` as the fallback for EL7 and older environments.
- The base package install pass and `otherpkgs` pass now share the same RPM `installroot` command builder, so EL8+ keeps the existing `--releasever` and `module_platform_id` options consistently.

Fixes: xcat2/xcat-core#6671
