### PR TITLE
fix: non-local networks being skipped in makedhcp

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -1937,9 +1937,7 @@ sub process_request
         my $netif = $line[1];
         if ($netif =~ /!remote!\S+/) {
             $netif =~ s/!remote!\s*(.*)$/$1/;
-            if (!defined($activenics{"!remote!"})) {
-                next;
-            } elsif (!defined($activenics{$netif})) {
+            if (!defined($activenics{$netif})) {
                 addnic($netif, \@dhcpconf);
                 $activenics{$netif} = 1;
             }


### PR DESCRIPTION
This PR removes the dead check so remote networks are processed correctly, which effectively supercedes #7242.

Based on the original analysis and report by @lebonez in xcat2/xcat-core#7242.

