### PR TITLE
fix: strip R:: prefix from netboot config

### DIFF
--- a/xCAT-server/lib/xcat/plugins/pxe.pm
+++ b/xCAT-server/lib/xcat/plugins/pxe.pm
@@ -119,9 +119,10 @@ sub setstate {
             $cmdhashref = xCAT::Utils->splitkcmdline($kcmdlinehack);
         }
 
-        if ($cmdhashref and $cmdhashref->{volatile})
-        {
-            $kcmdlinehack = $cmdhashref->{volatile};
+        if ($cmdhashref) {
+            # Use only volatile options for netboot; persistent (R::) options
+            # are handled separately for the installed OS via PERSKCMDLINE
+            $kcmdlinehack = $cmdhashref->{volatile} // "";
         }
 
 

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -186,9 +186,10 @@ sub setstate {
                 $cmdhashref = xCAT::Utils->splitkcmdline($kcmdlinehack);
             }
 
-            if ($cmdhashref and $cmdhashref->{volatile})
-            {
-                $kcmdlinehack = $cmdhashref->{volatile};
+            if ($cmdhashref) {
+                # Use only volatile options for netboot; persistent (R::) options
+                # are handled separately for the installed OS via PERSKCMDLINE
+                $kcmdlinehack = $cmdhashref->{volatile} // "";
             }
 
 


### PR DESCRIPTION
This PR fixes the behaviour when all `addkcmdline` options have R:: prefix (persistent options for the installed OS), the volatile check in `xnba.pm` and `pxe.pm` would fail because volatile was undefined. This left the original R::-prefixed string in the netboot config instead of stripping it.

Fixes #7442