### PR TITLE
fix: csh syntax error in /etc/profile.d/xcat.csh

### DIFF
--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -343,9 +343,9 @@ endif
 setenv PERL_BADLANG 0
 # If /usr/local/share/perl5 is not already in @INC, add it to PERL5LIB
 perl -e "print \"@INC\"" | grep -E "(^|\W)/usr/local/share/perl5($| )" > /dev/null
-if [ \$? = 1 ]; then
+if ( \$? == 1 ) then
     setenv PERL5LIB /usr/local/share/perl5:\${PERL5LIB}
-fi
+endif
 EOF
 chmod 755 /etc/profile.d/xcat.*
 


### PR DESCRIPTION
Easy one: used bash if-then-fi syntax instead of csh if-then-endif syntax, causing "Illegal variable name" errors for tcsh/csh users logging into the xCAT manager node.

Fixes: #7379
