### PR TITLE
xCAT 2.18.0 Release 

### DIFF
--- a/docs/source/overview/_files/2.18.x.csv
+++ b/docs/source/overview/_files/2.18.x.csv
@@ -1,0 +1,2 @@
+Version,Release Date,New OS Supported,Release Notes
+2.18.0,2026-06-22,"RHEL 10,AlmaLinux 10",`2.18.0 Release Notes <https://github.com/xcat2/xcat-core/wiki/XCAT_2.18_Release_Notes>`_

--- a/docs/source/overview/xcat2_release.rst
+++ b/docs/source/overview/xcat2_release.rst
@@ -6,6 +6,15 @@ The following tables documents the xCAT release versions and release dates. For 
 
 .. tabularcolumns:: |p{1cm}|p{4cm}|p{7cm}|p{7cm}
 
+xCAT 2.18.x
+-----------
+
+.. csv-table:: 2.18.x Release Information
+   :file: _files/2.18.x.csv
+   :header-rows: 1
+   :class: longtable
+   :widths: 1 1 1 1
+
 xCAT 2.17.x
 -----------
 


### PR DESCRIPTION
This PR add information for the 2.18.0 release

The tag 2.18 and Release information [1] should be created next

https://github.com/xcat2/xcat-core/wiki/XCAT_2.18_Release_Notes