### PR TITLE
fix(xcatprobe): prefer ss for listener checks

### DIFF
--- a/xCAT-probe/debian/control
+++ b/xCAT-probe/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.4
 
 Package: xcat-probe
 Architecture: all
-Depends: ${perl:Depends}
+Depends: ${perl:Depends}, iproute2 | net-tools
 Recommends: wget, dnsutils, tftp-hpa, tcpdump
 Description: Provides a toolkit to probe possible issues in xCAT

--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -183,6 +183,23 @@ sub _command_available {
     return 0;
 }
 
+sub _capture_command_output {
+    my @command = @_;
+    my $pid = open(my $fh, '-|');
+    return unless defined $pid;
+    if ($pid == 0) {
+        open(STDERR, '>', '/dev/null');
+        exec @command;
+        exit 1;
+    }
+
+    local $/;
+    my $output = <$fh>;
+    close $fh;
+    return if $?;
+    return defined($output) ? $output : '';
+}
+
 sub _networkd_config_dirs {
     return ('/run/systemd/network', '/etc/systemd/network');
 }
@@ -442,6 +459,65 @@ sub is_firewall_open {
 
 #------------------------------------------
 
+sub _tcp_listener_output {
+    my $include_process = shift;
+    my @commands = $include_process
+      ? (['ss', '-lntp'], ['netstat', '-tnlp'])
+      : (['ss', '-lnt'], ['netstat', '-ant']);
+
+    foreach my $command (@commands) {
+        next unless _command_available($command->[0]);
+        my $output = _capture_command_output(@$command);
+        return $output if defined $output;
+    }
+
+    return;
+}
+
+sub _tcp_listener_output_has_port {
+    my ($output, $port, $process_pattern) = @_;
+
+    return 0 unless defined($output) && defined($port);
+    return 0 unless $port =~ /^\d+$/ && $port > 0 && $port <= 65535;
+
+    foreach my $line (split /\n/, $output) {
+        $line =~ s/^\s+|\s+$//g;
+        my @fields = split /\s+/, $line;
+        next unless @fields >= 4;
+        next unless grep { $_ eq 'LISTEN' } @fields;
+        next unless $fields[3] =~ /:(\d+)$/ && $1 == $port;
+        next if defined($process_pattern) && $line !~ $process_pattern;
+        return 1;
+    }
+
+    return 0;
+}
+
+=head3
+    Description:
+        Test if a TCP port has a listening socket. Prefer ss on modern Linux
+        systems and fall back to netstat for older installations.
+    Arguments:
+        port: TCP port number
+        process_pattern: optional regular expression that must match the
+                         listener line
+    Returns:
+        1 : listening
+        0 : not listening or no supported inspection command is available
+=cut
+
+sub is_tcp_port_listening {
+    my $port = shift;
+    $port = shift if defined($port) && $port =~ /probe_utils/;
+    my $process_pattern = shift;
+
+    my $output = _tcp_listener_output(defined($process_pattern));
+    return 0 unless defined $output;
+    return _tcp_listener_output_has_port($output, $port, $process_pattern);
+}
+
+#------------------------------------------
+
 =head3
     Description:
         Test if http service is ready to use in current operating system
@@ -461,11 +537,7 @@ sub is_http_ready {
     my $installdir = shift;
     my $errormsg_ref = shift;
 
-    my $http_status = `netstat -tnlp | grep -e "httpd" -e "apache" 2>&1`;
-    if (!$http_status) {
-        $$errormsg_ref = "No HTTP listening status get by command 'netstat'";
-        return 0;
-    } elsif ($http_status !~ /\S*\s+\S*\s+\S*\s+\S*:$httpport\s+.+/) {
+    if (!is_tcp_port_listening($httpport, qr/(?:httpd|apache)/)) {
         $$errormsg_ref = "The port defined in 'site' table HTTP is not listening";
         return 0;
     }

--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -186,18 +186,35 @@ sub _command_available {
 sub _capture_command_output {
     my @command = @_;
     my $pid = open(my $fh, '-|');
-    return unless defined $pid;
+    unless (defined $pid) {
+        my $error = "unable to start '$command[0]': $!";
+        return wantarray ? (undef, $error) : undef;
+    }
     if ($pid == 0) {
         open(STDERR, '>', '/dev/null');
         exec @command;
-        exit 1;
+        exit 127;
     }
 
     local $/;
     my $output = <$fh>;
     close $fh;
-    return if $?;
-    return defined($output) ? $output : '';
+    my $status = $?;
+    if ($status) {
+        my $error;
+        if ($status == -1) {
+            $error = "failed to execute: $!";
+        } elsif ($status & 127) {
+            $error = 'terminated by signal ' . ($status & 127);
+        } else {
+            $error = 'exited with status ' . ($status >> 8);
+        }
+        $error = "'$command[0]' $error";
+        return wantarray ? (undef, $error) : undef;
+    }
+
+    $output = '' unless defined $output;
+    return wantarray ? ($output, undef) : $output;
 }
 
 sub _networkd_config_dirs {
@@ -460,17 +477,28 @@ sub is_firewall_open {
 #------------------------------------------
 
 sub _tcp_listener_output {
-    my $include_process = shift;
+    my ($include_process, $errormsg_ref) = @_;
     my @commands = $include_process
       ? (['ss', '-lntp'], ['netstat', '-tnlp'])
       : (['ss', '-lnt'], ['netstat', '-ant']);
+    my @available_commands;
+    my @errors;
 
     foreach my $command (@commands) {
         next unless _command_available($command->[0]);
-        my $output = _capture_command_output(@$command);
+        push @available_commands, $command->[0];
+        my ($output, $error) = _capture_command_output(@$command);
         return $output if defined $output;
+        push @errors, $error || "'$command->[0]' failed";
     }
 
+    if ($errormsg_ref) {
+        if (@available_commands) {
+            $$errormsg_ref = 'Unable to inspect TCP listeners: ' . join('; ', @errors);
+        } else {
+            $$errormsg_ref = "Unable to inspect TCP listeners: neither 'ss' nor 'netstat' is available";
+        }
+    }
     return;
 }
 
@@ -501,18 +529,22 @@ sub _tcp_listener_output_has_port {
         port: TCP port number
         process_pattern: optional regular expression that must match the
                          listener line
+        errormsg_ref: optional output reference populated when listener
+                      inspection cannot be performed
     Returns:
         1 : listening
-        0 : not listening or no supported inspection command is available
+        0 : inspected successfully and not listening
+        undef : listener inspection could not be performed
 =cut
 
 sub is_tcp_port_listening {
     my $port = shift;
     $port = shift if defined($port) && $port =~ /probe_utils/;
     my $process_pattern = shift;
+    my $errormsg_ref = shift;
 
-    my $output = _tcp_listener_output(defined($process_pattern));
-    return 0 unless defined $output;
+    my $output = _tcp_listener_output(defined($process_pattern), $errormsg_ref);
+    return unless defined $output;
     return _tcp_listener_output_has_port($output, $port, $process_pattern);
 }
 
@@ -537,7 +569,13 @@ sub is_http_ready {
     my $installdir = shift;
     my $errormsg_ref = shift;
 
-    if (!is_tcp_port_listening($httpport, qr/(?:httpd|apache)/)) {
+    my $listener_error;
+    my $http_listening = is_tcp_port_listening($httpport, qr/(?:httpd|apache)/, \$listener_error);
+    unless (defined $http_listening) {
+        $$errormsg_ref = $listener_error;
+        return 0;
+    }
+    if (!$http_listening) {
         $$errormsg_ref = "The port defined in 'site' table HTTP is not listening";
         return 0;
     }

--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -361,8 +361,7 @@ sub check_xcatd_receive_request {
         my $port = `lsdef -t site -i $port_attr -c 2>&1| awk -F'=' '{print \$2}'`;
         chomp($port);
         if ($port) {
-            my $cmdoutput = `netstat -ant 2>&1|grep LISTEN|grep $port`;
-            if ($?) {
+            if (!probe_utils->is_tcp_port_listening($port)) {
                 push @$error_ref, "Attribute '$port_attr' in 'site' table is set to $port, but xcatd isn't listening on $port";
                 $rst = 1;
             }

--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -361,7 +361,14 @@ sub check_xcatd_receive_request {
         my $port = `lsdef -t site -i $port_attr -c 2>&1| awk -F'=' '{print \$2}'`;
         chomp($port);
         if ($port) {
-            if (!probe_utils->is_tcp_port_listening($port)) {
+            my $listener_error;
+            my $listening = probe_utils->is_tcp_port_listening($port, undef, \$listener_error);
+            unless (defined $listening) {
+                push @$error_ref, $listener_error;
+                $rst = 1;
+                last;
+            }
+            if (!$listening) {
                 push @$error_ref, "Attribute '$port_attr' in 'site' table is set to $port, but xcatd isn't listening on $port";
                 $rst = 1;
             }
@@ -1496,6 +1503,5 @@ if ($hierarchy_instance->destory(\@error)) {
 $rst = summary_all_jobs_output();
 
 exit $rst;
-
 
 

--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -27,6 +27,12 @@ Requires: /usr/bin/tftp
 Requires: /usr/bin/wget
 # Tool detect_dhcpd requires tcpdump
 Requires: /usr/sbin/tcpdump
+# TCP listener checks use ss, which is packaged differently on SUSE.
+%if 0%{?suse_version}
+Requires: iproute2
+%else
+Requires: iproute
+%endif
 %endif
 
 %description

--- a/xCAT-test/autotest/testcase/xcatprobe_unit/cases0
+++ b/xCAT-test/autotest/testcase/xcatprobe_unit/cases0
@@ -1,0 +1,8 @@
+start:xcatprobe_tcp_listener_unit_tests
+description:Run the xCAT probe TCP listener Perl unit tests through xcattest
+os:Linux
+label:mn_only,ci_test,xcatprobe,unit,xcatprobe_unit
+cmd:prove -I/opt/xcat/probe/lib/perl /opt/xcat/share/xcat/tools/autotest/unit/probe_utils_tcp_listener.t
+check:rc==0
+check:output=~All tests successful
+end

--- a/xCAT-test/unit/probe_utils_tcp_listener.t
+++ b/xCAT-test/unit/probe_utils_tcp_listener.t
@@ -1,0 +1,114 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/../../xCAT-probe/lib/perl";
+
+use Test::More;
+
+require probe_utils;
+
+my $ss_output = <<'EOF';
+State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process
+LISTEN 0      128          0.0.0.0:3001      0.0.0.0:*
+LISTEN 0      128             [::]:3002         [::]:* users:(("xcatd",pid=100,fd=5))
+LISTEN 0      511                *:80               *:* users:(("httpd",pid=200,fd=4))
+EOF
+
+my $netstat_output = <<'EOF';
+Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
+tcp        0      0 0.0.0.0:3001            0.0.0.0:*               LISTEN      100/xcatd
+tcp6       0      0 :::3002                 :::*                    LISTEN      100/xcatd
+tcp6       0      0 :::80                   :::*                    LISTEN      200/apache2
+EOF
+
+ok(probe_utils::_tcp_listener_output_has_port($ss_output, 3001), 'ss IPv4 listener is detected');
+ok(probe_utils::_tcp_listener_output_has_port($ss_output, 3002), 'ss IPv6 listener is detected');
+ok(!probe_utils::_tcp_listener_output_has_port($ss_output, 300), 'ss listener requires an exact port match');
+ok(probe_utils::_tcp_listener_output_has_port($ss_output, 80, qr/httpd|apache/), 'ss listener process can be matched');
+ok(!probe_utils::_tcp_listener_output_has_port($ss_output, 80, qr/xcatd/), 'ss listener rejects the wrong process');
+
+ok(probe_utils::_tcp_listener_output_has_port($netstat_output, 3001), 'netstat IPv4 listener is detected');
+ok(probe_utils::_tcp_listener_output_has_port($netstat_output, 3002), 'netstat IPv6 listener is detected');
+ok(probe_utils::_tcp_listener_output_has_port($netstat_output, 80, qr/httpd|apache/), 'netstat listener process can be matched');
+ok(!probe_utils::_tcp_listener_output_has_port($netstat_output, 0), 'invalid port is rejected');
+ok(!probe_utils::_tcp_listener_output_has_port($netstat_output, 'http'), 'non-numeric port is rejected');
+
+{
+    no warnings 'redefine';
+    my @commands;
+    local *probe_utils::_command_available = sub { return 1; };
+    local *probe_utils::_capture_command_output = sub {
+        push @commands, [@_];
+        return $ss_output;
+    };
+
+    ok(probe_utils->is_tcp_port_listening(3001), 'class-style listener check succeeds with ss');
+    is_deeply($commands[0], ['ss', '-lnt'], 'listener check prefers ss');
+}
+
+{
+    no warnings 'redefine';
+    my @commands;
+    local *probe_utils::_command_available = sub { return 1; };
+    local *probe_utils::_capture_command_output = sub {
+        push @commands, [@_];
+        return $ss_output;
+    };
+
+    ok(probe_utils::is_tcp_port_listening(80, qr/httpd|apache/), 'process-aware listener check succeeds with ss');
+    is_deeply($commands[0], ['ss', '-lntp'], 'process-aware listener check requests ss process data');
+}
+
+{
+    no warnings 'redefine';
+    my @commands;
+    local *probe_utils::_command_available = sub { return 1; };
+    local *probe_utils::_capture_command_output = sub {
+        push @commands, [@_];
+        return $_[0] eq 'ss' ? $ss_output : $netstat_output;
+    };
+
+    ok(!probe_utils::is_tcp_port_listening(4000), 'successful ss output is authoritative when a port is absent');
+    is(scalar(@commands), 1, 'missing port in successful ss output does not consult netstat');
+}
+
+{
+    no warnings 'redefine';
+    my @commands;
+    local *probe_utils::_command_available = sub { return 1; };
+    local *probe_utils::_capture_command_output = sub {
+        push @commands, [@_];
+        return if $_[0] eq 'ss';
+        return $netstat_output;
+    };
+
+    ok(probe_utils::is_tcp_port_listening(3002), 'listener check falls back when ss fails');
+    is_deeply(
+        \@commands,
+        [['ss', '-lnt'], ['netstat', '-ant']],
+        'failed ss invocation falls back to netstat'
+    );
+}
+
+{
+    no warnings 'redefine';
+    my @commands;
+    local *probe_utils::_command_available = sub { return $_[0] eq 'netstat'; };
+    local *probe_utils::_capture_command_output = sub {
+        push @commands, [@_];
+        return $netstat_output;
+    };
+
+    ok(probe_utils::is_tcp_port_listening(80, qr/httpd|apache/), 'process-aware listener check uses netstat fallback');
+    is_deeply($commands[0], ['netstat', '-tnlp'], 'process-aware fallback preserves legacy netstat options');
+}
+
+{
+    no warnings 'redefine';
+    local *probe_utils::_command_available = sub { return 0; };
+    ok(!probe_utils::is_tcp_port_listening(3001), 'missing socket inspection commands fail cleanly');
+}
+
+done_testing();

--- a/xCAT-test/unit/probe_utils_tcp_listener.t
+++ b/xCAT-test/unit/probe_utils_tcp_listener.t
@@ -9,6 +9,16 @@ use Test::More;
 
 require probe_utils;
 
+is(
+    probe_utils::_capture_command_output($^X, '-e', 'print "captured output\\n"'),
+    "captured output\n",
+    'command output is captured without a shell'
+);
+ok(
+    !defined(probe_utils::_capture_command_output($^X, '-e', 'exit 1')),
+    'failed command does not return listener output'
+);
+
 my $ss_output = <<'EOF';
 State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process
 LISTEN 0      128          0.0.0.0:3001      0.0.0.0:*

--- a/xCAT-test/unit/probe_utils_tcp_listener.t
+++ b/xCAT-test/unit/probe_utils_tcp_listener.t
@@ -14,9 +14,13 @@ is(
     "captured output\n",
     'command output is captured without a shell'
 );
-ok(
-    !defined(probe_utils::_capture_command_output($^X, '-e', 'exit 1')),
-    'failed command does not return listener output'
+my ($failed_output, $capture_error) =
+  probe_utils::_capture_command_output($^X, '-e', 'exit 7');
+ok(!defined($failed_output), 'failed command does not return listener output');
+like(
+    $capture_error,
+    qr/^'\Q$^X\E' exited with status 7$/,
+    'failed command reports its exit status'
 );
 
 my $ss_output = <<'EOF';
@@ -80,7 +84,11 @@ ok(!probe_utils::_tcp_listener_output_has_port($netstat_output, 'http'), 'non-nu
         return $_[0] eq 'ss' ? $ss_output : $netstat_output;
     };
 
-    ok(!probe_utils::is_tcp_port_listening(4000), 'successful ss output is authoritative when a port is absent');
+    is(
+        probe_utils::is_tcp_port_listening(4000),
+        0,
+        'successful ss output reports that an absent port is not listening'
+    );
     is(scalar(@commands), 1, 'missing port in successful ss output does not consult netstat');
 }
 
@@ -118,7 +126,42 @@ ok(!probe_utils::_tcp_listener_output_has_port($netstat_output, 'http'), 'non-nu
 {
     no warnings 'redefine';
     local *probe_utils::_command_available = sub { return 0; };
-    ok(!probe_utils::is_tcp_port_listening(3001), 'missing socket inspection commands fail cleanly');
+    my $error;
+    my $listening = probe_utils::is_tcp_port_listening(3001, undef, \$error);
+    ok(!defined($listening), 'missing socket inspection commands report inspection failure');
+    like(
+        $error,
+        qr/neither 'ss' nor 'netstat' is available/,
+        'missing socket inspection commands provide a diagnostic'
+    );
+}
+
+{
+    no warnings 'redefine';
+    local *probe_utils::_command_available = sub { return 1; };
+    local *probe_utils::_capture_command_output = sub {
+        return (undef, "'$_[0]' exited with status 1");
+    };
+    my $error;
+    my $listening = probe_utils::is_tcp_port_listening(3001, undef, \$error);
+    ok(!defined($listening), 'failed socket inspection commands report inspection failure');
+    like($error, qr/'ss' exited with status 1/, 'ss failure is included in the diagnostic');
+    like($error, qr/'netstat' exited with status 1/, 'netstat failure is included in the diagnostic');
+}
+
+{
+    no warnings 'redefine';
+    local *probe_utils::_command_available = sub { return 0; };
+    my $error;
+    ok(
+        !probe_utils::is_http_ready('127.0.0.1', 80, 'install', \$error),
+        'HTTP readiness fails when listeners cannot be inspected'
+    );
+    like(
+        $error,
+        qr/neither 'ss' nor 'netstat' is available/,
+        'HTTP readiness preserves the listener inspection diagnostic'
+    );
 }
 
 done_testing();

--- a/xCAT-test/unit/xcat_probe_package_payload.t
+++ b/xCAT-test/unit/xcat_probe_package_payload.t
@@ -23,6 +23,8 @@ my @affected_subcommands = qw(
 );
 
 my $builder = read_file('buildrpms.pl');
+my $rpm_spec = read_file('xCAT-probe/xCAT-probe.spec');
+my $debian_control = read_file('xCAT-probe/debian/control');
 like($builder, qr/sub prepare_xcat_probe_source_tar\b/, 'RPM builder has dedicated xCAT-probe source preparation');
 like(
     $builder,
@@ -43,6 +45,17 @@ my $worker_fanout = index($builder, 'Parallel::ForkManager->new');
 ok(
     $prepare_call >= 0 && $worker_fanout >= 0 && $prepare_call < $worker_fanout,
     'xCAT-probe source preparation runs before worker processes fork'
+);
+
+like(
+    $rpm_spec,
+    qr/%if 0%\{\?suse_version\}\s+Requires: iproute2\s+%else\s+Requires: iproute\s+%endif/s,
+    'RPM package requires the distro-specific provider of ss'
+);
+like(
+    $debian_control,
+    qr/^Depends:.*\biproute2\s*\|\s*net-tools\b/m,
+    'Debian package requires ss or the legacy netstat provider'
 );
 
 for my $helper (@helpers) {


### PR DESCRIPTION
`xcatprobe xcatmn` uses `netstat` to check whether the xcatd ports are listening. Since `netstat` is not installed by default on SLES 15 SP3, the probe reports ports 3001 and 3002 as unavailable even when xcatd is running normally.

Use `ss` when available and keep `netstat` as a fallback for older systems. Port matching is now exact, and the HTTP listener check uses the same helper.

Fixes #7093