### PR TITLE
ci: automate backports to release branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,23 @@
+name: backport
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport merged PR
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        github.event.action == 'closed' ||
+        startsWith(github.event.label.name, 'backport ')
+      )
+    steps:
+      - uses: actions/checkout@v6
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v3


### PR DESCRIPTION
Add a label-driven backport workflow using [korthout/backport-action](https://github.com/korthout/backport-action).

How it works:

- Label a PR `backport <branch>` (e.g. `backport 2.18`).
- When the PR merges (or when the label is added to an already-merged PR), the workflow cherry-picks the PR's commits onto that branch and opens the backport PR automatically, referencing the original.
- On cherry-pick conflict, the action comments on the original PR so the backport can be done by hand.

This supports the release model where master is the next minor (2.19) and 2.18.x fixes are backported to the `2.18` maintenance branch.
