### PR TITLE
fix(xcat-core): stop go-xcat aborting the install on obsolete/missing…

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.53
+# Version 1.0.54
 #
 # Copyright (C) 2016 - 2021 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)
@@ -46,6 +46,12 @@
 #     - Check for EPEL and CRB repository on EL9 family of OSes
 # 2023-01-19 Mark Gurevich <gurevich@us.ibm.com>
 #     - Add support for Alma Linux
+# 2026-07-20 Daniel Hilst <392820+dhilst@users.noreply.github.com>
+#     - Drop obsolete yaboot-xcat from the install list (kept in the uninstall
+#       list so existing installs are still cleaned up)
+#     - Do not let one unavailable package abort the whole EL install: pass
+#       `dnf --setopt=strict=0` so missing arch-specific packages are warned
+#       and skipped instead of failing the transaction
 #
 
 
@@ -188,7 +194,7 @@ GO_XCAT_DEP_PACKAGE_LIST=()
 GO_XCAT_INSTALL_LIST=(perl-xCAT xCAT-client xCAT xCAT-buildkit
 	xCAT-genesis-scripts-ppc64 xCAT-genesis-scripts-x86_64 xCAT-server
 	elilo-xcat grub2-xcat ipmitool-xcat syslinux-xcat
-	xCAT-genesis-base-ppc64 xCAT-genesis-base-x86_64 xnba-undi yaboot-xcat)
+	xCAT-genesis-base-ppc64 xCAT-genesis-base-x86_64 xnba-undi)
 # For Debian/Ubuntu, it will need a slightly different package list
 type dpkg >/dev/null 2>&1 &&
 GO_XCAT_INSTALL_LIST=(perl-xcat xcat-client xcat xcat-buildkit
@@ -199,7 +205,7 @@ GO_XCAT_INSTALL_LIST=(perl-xcat xcat-client xcat xcat-buildkit
 GO_XCAT_UNINSTALL_LIST=("${GO_XCAT_INSTALL_LIST[@]}"
 	goconserver xCAT-SoftLayer xCAT-confluent xCAT-csm xCAT-genesis-builder
 	xCAT-openbmc-py xCAT-probe xCAT-test xCAT-vlan xCATsn xCAT-UI-deps
-    xCAT-buildkit conserver-xcat)
+    xCAT-buildkit conserver-xcat yaboot-xcat)
 # For Debian/Ubuntu, it will need a slightly different package list
 type dpkg >/dev/null 2>&1 &&
 GO_XCAT_UNINSTALL_LIST=("${GO_XCAT_INSTALL_LIST[@]}"
@@ -1718,7 +1724,7 @@ function install_packages_dnf()
 	local -a yes=()
 	[[ "$1" = "-y" ]] && yes=("-y") && shift
 	dnf --nogpgcheck "${yes[@]}" install initscripts
-	dnf --nogpgcheck "${yes[@]}" install "$@"
+	dnf --nogpgcheck --setopt=strict=0 "${yes[@]}" install "$@"
 }
 
 function install_packages_yum()


### PR DESCRIPTION
go-xcat's install list still named yaboot-xcat, which was obsoleted in the xcat-dep 2.18 rebuild and is no longer published. It also lists the cross-arch ppc64 genesis packages, which the arch-split 2.18 dep repo no longer places in the x86_64 view an x86 management node reads. Because EL dnf is strict by default, any one of these unresolvable names aborts the entire `dnf install` transaction, so `go-xcat install` fails outright on EL9/EL10 even though every package the node actually needs is available.

Drop yaboot-xcat from the install list (kept in the uninstall list so existing installs are still cleaned up) and pass `dnf --setopt=strict=0` so a package missing from the enabled repository is warned and skipped instead of failing the whole install. The existing post-install smoke test still catches a genuinely broken install.

### The PR is to fix issue #7610

The --strict=0 will bypass xCAT-genesis-base-ppc64 missing in xcat-dep repositories as this has to be fixed in the xcat-dep pipeline  