### PR TITLE
fix(xCAT-server): declare Perl deps used only by xCAT-server code

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -47,6 +47,11 @@ BuildRequires: perl-generators
 BuildRequires: perl-generators
 %endif
 Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser perl-Digest-SHA1 perl(LWP::Protocol::https) perl-XML-LibXML
+# AutoReqProv is off (above). Modules used only by xCAT-server code are
+# therefore not auto-required, and (unlike SNMP, Expect, JSON, Net::Ping,
+# Time::HiRes and Text::Balanced) are not pulled in transitively by perl-xCAT
+# either. List them here or the affected subcommands die at load time.
+Requires: perl-Net-Telnet perl-Net-DNS perl-Crypt-CBC perl-Crypt-Rijndael perl-DB_File
 %endif
 Obsoletes: atftp-xcat
 %endif


### PR DESCRIPTION
`xCAT-server.spec` sets `AutoReqProv: no`, so RPM does not auto-generate
dependencies from the Perl modules this package ships. A module loaded with a
compile-time `use` **only** by xCAT-server code is therefore neither
auto-required here nor pulled in transitively by `perl-xCAT` — so on a host
where it is absent, the package installs cleanly and the affected subcommand
then dies at load time with `Can't locate <Module>.pm`.

(Modules also used by `perl-xCAT`, which *does* have `AutoReqProv` on —
`SNMP`, `Expect`, `JSON`, `Net::Ping`, `Time::HiRes`, `Text::Balanced` — are
already covered via the `perl-xCAT` dependency and are intentionally not
duplicated here.)

## Fix
Declare the five modules that are hard-`use`d by a shipped xCAT-server module
and used nowhere in `perl-xCAT`:

| Requires | used by | impact if missing |
|---|---|---|
| perl-Net-Telnet | xCAT/SSHInteract.pm | telnet switch/console management |
| perl-Net-DNS | plugins/activedirectory.pm | AD integration |
| perl-Crypt-CBC | xCAT/IPMI.pm | **IPMI 2.0 RMCP+ encryption** |
| perl-Crypt-Rijndael | xCAT/IPMI.pm | **IPMI 2.0 RMCP+ encryption** |
| perl-DB_File | Confluent/Client.pm | confluent console client |

The `Crypt::CBC` / `Crypt::Rijndael` gap is the significant one: `IPMI.pm`
fails to load without them, which disables all IPMI-based hardware control
(`rpower`, `rcons`, `rsetboot`) on a host lacking those modules.

## Provenance
Recovered from the unmerged `lenovobuild` branch (Jarrod Johnson; originals
807d30d3, c2e22f6f, 792e41727), reduced to the subset that master's current
packaging does not already satisfy.
