### PR TITLE
fix(dhcp): avoid infinite loop building IPv6 reverse zones

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -3629,7 +3629,13 @@ sub getzonesfornet {
             $rev .= $_ . ".";
             $nibbs--;
         }
-        while ($nibbs) {
+        if ($nibbs < 0) {
+            # a sub-nibble (not 4-bit-aligned) IPv6 mask leaves $nibbs negative;
+            # bail rather than spin forever in the loop below. $nibbs == 0 is the
+            # normal nibble-aligned case (e.g. a /64) and must still emit a zone.
+            return ();
+        }
+        while ($nibbs > 0) {
             $rev .= "0.";
             $nibbs--;
         }


### PR DESCRIPTION
`getzonesfornet()` derives the reverse-zone nibble count as `$maskbits / 4` and decrements it per hex nibble of the prefix. For a maskless or sub-nibble IPv6 subnet `$nibbs` reaches zero or goes negative before the padding loop, and `while ($nibbs)` never terminates — it spins forever appending "0." until the process is killed. Return early when `$nibbs < 1` and make the padding loop `while ($nibbs > 0)`.

Recovered from the unmerged lenovobuild branch (0e070cd2).
