### PR TITLE
fix(NetworkUtils): guard formatNetmask against an undefined mask

### DIFF
--- a/perl-xCAT/xCAT/NetworkUtils.pm
+++ b/perl-xCAT/xCAT/NetworkUtils.pm
@@ -1389,6 +1389,7 @@ sub formatNetmask
     my $origType = shift;
     my $newType  = shift;
     my $maskn;
+    if (not defined $mask) { return undef; }
     if ($origType == 0)
     {
         $maskn = unpack("N", inet_aton($mask));


### PR DESCRIPTION
`formatNetmask()` uses its first argument immediately (`inet_aton($mask)`, `2**$mask`, `hex $mask`) with no check that it is defined, so callers passing an undefined mask get "Use of uninitialized value" warnings and a meaningless result. Return `undef` up front when `$mask` is not defined.

Recovered from the unmerged lenovobuild branch (acbbeb86).
