### PR TITLE
fix(genesis): stop ethtool link-wait loops from spinning forever

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/doxcat
+++ b/xCAT-genesis-scripts/usr/bin/doxcat
@@ -255,8 +255,8 @@ else
 	    NICSTOBRINGUP=`ip link|grep mtu|grep -v LOOPBACK|grep -v $bootnic|grep -v usb|grep -v ,UP|awk -F: '{print $2}'`
 	    export NICSTOBRINGUP
 	    for nic in $NICSTOBRINGUP; do
-		(while ! ethtool $nic | grep Link\ detected|grep yes > /dev/null; do sleep 5; done; dhclient -cf /etc/dhclient.conf -pf /var/run/dhclient.$nic.pid $nic ) &
-		(while ! ethtool $nic | grep Link\ detected|grep yes > /dev/null; do sleep 5; done; dhclient -cf /etc/dhclient.conf -6 -pf /var/run/dhclient6.$nic.pid -lf /var/lib/dhclient/dhclient6.leases $nic ) &
+		(while ! ethtool $nic | grep Link\ detected|grep yes > /dev/null && [ ! -f /tmp/netinitted ]; do sleep 5; done; dhclient -cf /etc/dhclient.conf -pf /var/run/dhclient.$nic.pid $nic ) &
+		(while ! ethtool $nic | grep Link\ detected|grep yes > /dev/null && [ ! -f /tmp/netinitted ]; do sleep 5; done; dhclient -cf /etc/dhclient.conf -6 -pf /var/run/dhclient6.$nic.pid -lf /var/lib/dhclient/dhclient6.leases $nic ) &
 	    done
 
             gripeiter=101
@@ -270,6 +270,9 @@ else
             done
         fi
 fi
+# secondary NICs whose link never comes up would otherwise wait forever;
+# let those backgrounded loops exit once the boot NIC has finished net init
+touch /tmp/netinitted
 
 openssl genrsa -out /etc/xcat/certkey.pem 4096 > /dev/null 2>&1 &
 


### PR DESCRIPTION
For each secondary NIC in `NICSTOBRINGUP`, `doxcat` backgrounds a loop that polls `ethtool $nic` until the link is detected. A NIC that is never connected keeps that loop (and its `sleep 5`) running for the life of the genesis environment. Add a second exit condition so each loop also stops once `/tmp/netinitted` exists, and touch that file once the boot NIC has finished network init.

Recovered from the unmerged lenovobuild branch (9ece12e4).
