### PR TITLE
fix(packaging): install the xcat logrotate config with sane permissions

### DIFF
--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -177,6 +177,7 @@ cd $RPM_BUILD_ROOT
 
 %ifos linux
 tar zxf %{SOURCE8}
+chmod 644 etc/logrotate.d/xcat
 %endif
 
 cd -


### PR DESCRIPTION
The payload's `etc/logrotate.d/xcat` inherits whatever mode the build umask produced. logrotate silently skips config files that are group- or world-writable, so a loose umask can disable xCAT log rotation entirely. chmod the file to 644 after extraction.

Recovered from the unmerged lenovobuild branch (cb8d671d).
