### PR TITLE
fix(packaging): capture xcatconfig stderr in the upgrade log

### DIFF
--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -261,7 +261,7 @@ fi
 
 mkdir -p /var/log/xcat
 date >> /var/log/xcat/upgrade.log
-$RPM_INSTALL_PREFIX0/sbin/xcatconfig -u -V >> /var/log/xcat/upgrade.log
+$RPM_INSTALL_PREFIX0/sbin/xcatconfig -u -V >> /var/log/xcat/upgrade.log 2>&1
 fi
 exit 0
 


### PR DESCRIPTION
The RPM `%post` runs `xcatconfig -u -V >> /var/log/xcat/upgrade.log` with only stdout redirected, so errors and warnings go to the package manager's output and are lost from the log. Redirect stderr into the same log with `2>&1`.

Recovered from the unmerged lenovobuild branch (51d87d4d).
