### PR TITLE
fix(build): describe git version from lightweight tags too

### DIFF
--- a/buildcore.sh
+++ b/buildcore.sh
@@ -195,7 +195,7 @@ fi
 
 function setversionvars {
     if [ ! -z "$USEGITVER" ]; then
-        VER=`git describe`
+        VER=`git describe --tags`
         VER=${VER/-/.post}
         VER=${VER/-/.}
     else


### PR DESCRIPTION
A `USEGITVER=1` build derives its version with `git describe`, which only considers annotated tags. xCAT tags releases with lightweight tags, so without a reachable annotated tag `git describe` fails and `VER` comes out empty. Use `git describe --tags`.

Recovered from the unmerged lenovobuild branch (25248d19). The commit's `.post`→`.POST` rename and its `makegenesisbuilderrpm` hunk are omitted (unrelated, and the latter targets a script no longer on master).
