### PR TITLE
fix(genesis): only wait 20s for NIC init on ppc64

### DIFF
--- a/xCAT-genesis-builder/dracut_105/el/xcat-cmdline.sh
+++ b/xCAT-genesis-builder/dracut_105/el/xcat-cmdline.sh
@@ -46,11 +46,11 @@ while :; do tmux new-session < /dev/tty2 &> /dev/tty2 ; done &
 
 # The section below is just for System P LE hardware discovery
 
-# Need to wait for NIC initialization
-sleep 20
 ARCH="$(uname -m)"
 
 if [[ ${ARCH} =~ ppc64 ]]; then
+    # Need to wait for NIC initialization (System P LE discovery only)
+    sleep 20
     # load all network driver modules listed in /lib/modules/<kernel>/modules.dep file
     KERVER=`uname -r`
     for line in `cat /lib/modules/$KERVER/modules.dep | awk -F: '{print \$1}' | sed -e "s/\(.*\)\.ko.*/\1/"`; do

--- a/xCAT-genesis-builder/dracut_105/ubuntu/xcat-cmdline.sh
+++ b/xCAT-genesis-builder/dracut_105/ubuntu/xcat-cmdline.sh
@@ -46,11 +46,11 @@ while :; do screen -ln < /dev/tty2 &> /dev/tty2 ; done &
 
 # The section below is just for System P LE hardware discovery
 
-# Need to wait for NIC initialization
-sleep 20
 ARCH="$(uname -m)"
 
 if [[ ${ARCH} =~ ppc64 ]]; then
+    # Need to wait for NIC initialization (System P LE discovery only)
+    sleep 20
     # load all network driver modules listed in /lib/modules/<kernel>/modules.dep file
     KERVER=`uname -r`
     for line in `cat /lib/modules/$KERVER/modules.dep | awk -F: '{print \$1}' | sed -e "s/\(.*\)\.ko.*/\1/"`; do

--- a/xCAT-genesis-builder/xcat-cmdline.sh
+++ b/xCAT-genesis-builder/xcat-cmdline.sh
@@ -46,11 +46,11 @@ while :; do screen -ln < /dev/tty2 &> /dev/tty2 ; done &
 
 # The section below is just for System P LE hardware discovery
 
-# Need to wait for NIC initialization
-sleep 20
 ARCH="$(uname -m)"
 
 if [[ ${ARCH} =~ ppc64 ]]; then
+    # Need to wait for NIC initialization (System P LE discovery only)
+    sleep 20
     # load all network driver modules listed in /lib/modules/<kernel>/modules.dep file
     KERVER=`uname -r`
     for line in `cat /lib/modules/$KERVER/modules.dep | awk -F: '{print \$1}' | sed -e "s/\(.*\)\.ko.*/\1/"`; do


### PR DESCRIPTION
The genesis boot script sleeps 20 seconds unconditionally to "wait for NIC initialization", but that wait exists solely for System P LE (ppc64) discovery — every x86_64 and aarch64 node pays a needless 20s delay per boot. Move the sleep inside the `[[ ${ARCH} =~ ppc64 ]]` block (the regex still matches ppc64le). Applied to the base script and both dracut_105 variants.

Recovered from the unmerged lenovobuild branch (d0916d9d).
