### PR TITLE
fix(netboot): allow the rootfs image to be downloaded over HTTPS

### DIFF
--- a/xCAT-server/share/xcat/netboot/fedora/dracut_009/xcatroot
+++ b/xCAT-server/share/xcat/netboot/fedora/dracut_009/xcatroot
@@ -22,7 +22,7 @@ if [ $NODESTATUS -ne 0 ];then
 fi
 
 if [ ! -z "$imgurl" ]; then
-	if [ xhttp = x${imgurl%%:*} ]; then
+	if [ xhttp = x${imgurl%%:*} ] || [ xhttps = x${imgurl%%:*} ]; then
 		NFS=0
 		FILENAME=${imgurl##*/}
 		while [ ! -r "$FILENAME" ]; do

--- a/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
@@ -27,7 +27,7 @@ if [ "$NODESTATUS" != "0" ]; then
 fi
 
 if [ ! -z "$imgurl" ]; then
-	if [ xhttp = x${imgurl%%:*} ]; then
+	if [ xhttp = x${imgurl%%:*} ] || [ xhttps = x${imgurl%%:*} ]; then
 		NFS=0
 		FILENAME=${imgurl##*/}
 		while [ ! -r "$FILENAME" ]; do

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -33,7 +33,7 @@ fi
 
 imgurl="$(getarg imgurl=)";
 if [ ! -z "$imgurl" ]; then
-    if [ xhttp = x${imgurl%%:*} ]; then
+    if [ xhttp = x${imgurl%%:*} ] || [ xhttps = x${imgurl%%:*} ]; then
         logger $SYSLOGHOST -t $log_label -p local4.info "Downloading rootfs image from $imgurl..."
         NFS=0
         FILENAME=${imgurl##*/}

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
@@ -33,7 +33,7 @@ fi
 
 imgurl="$(getarg imgurl=)";
 if [ ! -z "$imgurl" ]; then
-    if [ xhttp = x${imgurl%%:*} ]; then
+    if [ xhttp = x${imgurl%%:*} ] || [ xhttps = x${imgurl%%:*} ]; then
         logger $SYSLOGHOST -t $log_label -p local4.info "Downloading rootfs image from $imgurl..."
         NFS=0
         FILENAME=${imgurl##*/}

--- a/xCAT-server/share/xcat/netboot/rh/dracut_105/stateless/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_105/stateless/xcatroot
@@ -33,7 +33,7 @@ fi
 
 imgurl="$(getarg imgurl=)";
 if [ ! -z "$imgurl" ]; then
-    if [ xhttp = x${imgurl%%:*} ]; then
+    if [ xhttp = x${imgurl%%:*} ] || [ xhttps = x${imgurl%%:*} ]; then
         logger $SYSLOGHOST -t $log_label -p local4.info "Downloading rootfs image from $imgurl..."
         NFS=0
         FILENAME=${imgurl##*/}

--- a/xCAT-server/share/xcat/netboot/rh/dracut_105/statelite/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_105/statelite/xcatroot
@@ -33,7 +33,7 @@ fi
 
 imgurl="$(getarg imgurl=)";
 if [ ! -z "$imgurl" ]; then
-    if [ xhttp = x${imgurl%%:*} ]; then
+    if [ xhttp = x${imgurl%%:*} ] || [ xhttps = x${imgurl%%:*} ]; then
         logger $SYSLOGHOST -t $log_label -p local4.info "Downloading rootfs image from $imgurl..."
         NFS=0
         FILENAME=${imgurl##*/}

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
@@ -37,7 +37,7 @@ if [ $NODESTATUS -ne 0 ];then
 fi
 
 if [ ! -z "$imgurl" ]; then
-	if [ xhttp = x${imgurl%%:*} ]; then
+	if [ xhttp = x${imgurl%%:*} ] || [ xhttps = x${imgurl%%:*} ]; then
                 logger $SYSLOGHOST -t $log_label -p local4.info "Downloading rootfs image from $imgurl..."
 		NFS=0
 		FILENAME=${imgurl##*/}

--- a/xCAT-server/share/xcat/netboot/ubuntu/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/ubuntu/dracut/xcatroot
@@ -4,7 +4,7 @@ RWDIR=.statelite
 XCATMASTER=$XCAT
 
 if [ ! -z "$imgurl" ]; then
-	if [ xhttp = x${imgurl%%:*} ]; then
+	if [ xhttp = x${imgurl%%:*} ] || [ xhttps = x${imgurl%%:*} ]; then
 		NFS=0
 		FILENAME=${imgurl##*/}
 		while [ ! -r "$FILENAME" ]; do


### PR DESCRIPTION
The diskless/statelite xcatroot scripts only recognize an `http://` rootfs image URL; an `https://` imgurl falls through to the "unsupported" path even though the download already uses wget/curl, which handle TLS. Accept `xhttps` alongside `xhttp` in the protocol test, across every current xcatroot variant (rh dracut/dracut_033/dracut_047/dracut_105 stateless and statelite, plus fedora, sles and ubuntu).

Recovered from the unmerged lenovobuild branch (751bce24, extended to the dracut generations and distros that postdate it).
