### PR TITLE
fix(xnba): use the iPXE-native MAC format on the BIOS boot path

### DIFF
--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -337,7 +337,7 @@ sub setstate {
                 print $pcfg "imgfetch -n kernel http://" . '${next-server}:' . $httpport.'/tftpboot/' . $kern->{kernel} . "\n";
                 print $pcfg "imgload kernel\n";
                 if ($kern->{kcmdline}) {
-                    print $pcfg "imgargs kernel " . $kern->{kcmdline} . ' BOOTIF=01-${netX/machyp}' . "\n";
+                    print $pcfg "imgargs kernel " . $kern->{kcmdline} . ' BOOTIF=01-${netX/mac:hexhyp}' . "\n";
                 } else {
                     print $pcfg "imgargs kernel BOOTIF=" . '${netX/mac}' . "\n";
                 }


### PR DESCRIPTION
The BIOS (pcfg) boot config emits the kernel BOOTIF as `${netX/machyp}`, a legacy gPXE spelling, while the UEFI config for the same node already uses the iPXE-native `${netX/mac:hexhyp}`. xNBA is built from iPXE, whose documented format is `mac:hexhyp`. This is a consistency alignment, not a bug fix — the shipped xNBA still honours the old `machyp` alias (confirmed by a real legacy-BIOS PXE boot) — bringing the BIOS path in line with the UEFI path.

Recovered from the unmerged lenovobuild branch (85ce5b7e).
