### PR TITLE
fix(template): fall back to $::XCATROOT when XCATROOT is not in %ENV

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -1617,6 +1617,10 @@ sub envvar
         $envvar =~ s/^\$//;
     }
 
+    # $XCATROOT is reliably set as a package global even when it is absent from
+    # %ENV, so a template referencing it does not expand to undef.
+    if ($envvar eq 'XCATROOT') { return $::XCATROOT; }
+
     return ($ENV{$envvar});
 }
 

--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -1617,9 +1617,7 @@ sub envvar
         $envvar =~ s/^\$//;
     }
 
-    # $XCATROOT is reliably set as a package global even when it is absent from
-    # %ENV, so a template referencing it does not expand to undef.
-    if ($envvar eq 'XCATROOT') { return $::XCATROOT; }
+    return $::XCATROOT if $envvar eq 'XCATROOT' && !exists $ENV{XCATROOT};
 
     return ($ENV{$envvar});
 }

--- a/xCAT-test/autotest/testcase/template_unit/cases0
+++ b/xCAT-test/autotest/testcase/template_unit/cases0
@@ -1,0 +1,8 @@
+start:template_envvar_unit_tests
+description:Run the template environment-variable unit test through xcattest.
+os:Linux
+label:mn_only,ci_test,unit,template_unit
+cmd:prove -I/opt/xcat/lib/perl /opt/xcat/share/xcat/tools/autotest/unit/template_envvar.t
+check:rc==0
+check:output=~All tests successful
+end

--- a/xCAT-test/unit/template_envvar.t
+++ b/xCAT-test/unit/template_envvar.t
@@ -1,0 +1,50 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/../../perl-xCAT";
+use lib "$FindBin::Bin/../../xCAT-server/lib/perl";
+use Test::More;
+use xCAT::Template;
+
+local $::XCATROOT = '/opt/xcat-from-package';
+
+{
+    local $ENV{XCATROOT} = '/opt/xcat-from-environment';
+    is(
+        xCAT::Template::envvar('XCATROOT'),
+        '/opt/xcat-from-environment',
+        'an explicit XCATROOT environment value keeps precedence',
+    );
+}
+
+{
+    local $ENV{XCATROOT};
+    delete $ENV{XCATROOT};
+    is(
+        xCAT::Template::envvar('$XCATROOT'),
+        '/opt/xcat-from-package',
+        'the package global supplies XCATROOT when the environment omits it',
+    );
+}
+
+{
+    local $ENV{XCATROOT} = '';
+    is(
+        xCAT::Template::envvar('XCATROOT'),
+        '',
+        'an explicitly empty XCATROOT is not replaced by the fallback',
+    );
+}
+
+{
+    local $ENV{TEMPLATE_ENVVAR_TEST} = 'from-environment';
+    is(
+        xCAT::Template::envvar('TEMPLATE_ENVVAR_TEST'),
+        'from-environment',
+        'other template environment variables remain unchanged',
+    );
+}
+
+done_testing();


### PR DESCRIPTION
`envvar()` resolves a template variable purely from `%ENV`, so a template referencing `$XCATROOT` expands to empty whenever `XCATROOT` is not in the process environment. `$::XCATROOT` is set as a package global at module load and is reliably available, so use it for that one variable before falling back to `%ENV`.

Recovered from the unmerged lenovobuild branch (da72c6b8).
