### PR TITLE
fix(networks): make IPv6 route filtering in donets() robust

### DIFF
--- a/xCAT-server/lib/xcat/plugins/networks.pm
+++ b/xCAT-server/lib/xcat/plugins/networks.pm
@@ -388,7 +388,7 @@ sub donets
         foreach (@ip6table)
         {
             my @ent = split /\s+/, $_;
-            if ($ent[0] eq 'fe80::/64' or $ent[0] eq 'unreachable' or
+            if ($ent[0] =~ m/^fe80::/ or $ent[0] eq 'unreachable' or
                 $ent[1] eq 'via' or $ent[2] eq 'lo') {
 
                 #Do not contemplate link-local, unreachable, gatewayed networks,

--- a/xCAT-server/lib/xcat/plugins/networks.pm
+++ b/xCAT-server/lib/xcat/plugins/networks.pm
@@ -388,7 +388,7 @@ sub donets
         foreach (@ip6table)
         {
             my @ent = split /\s+/, $_;
-            if ($ent[0] =~ m/^fe80::/ or $ent[0] eq 'unreachable' or
+            if ($ent[0] =~ m/^fe80::/ or $ent[0] eq 'unreachable' or $ent[1] eq 'nexthop' or $ent[0] eq 'default' or
                 $ent[1] eq 'via' or $ent[2] eq 'lo') {
 
                 #Do not contemplate link-local, unreachable, gatewayed networks,

--- a/xCAT-server/lib/xcat/plugins/networks.pm
+++ b/xCAT-server/lib/xcat/plugins/networks.pm
@@ -132,6 +132,19 @@ sub process_request
 =cut
 
 #-----------------------------------------------------------------------------
+sub _ignore_ipv6_route
+{
+    my $route = shift;
+    my @ent = split ' ', $route;
+
+    return 1 unless @ent;
+    return 1 if $ent[0] =~ m/^fe80::/;
+    return 1 if $ent[0] eq 'unreachable' or $ent[0] eq 'nexthop' or $ent[0] eq 'default';
+    return 1 if defined($ent[1]) and $ent[1] eq 'via';
+    return 1 if defined($ent[2]) and $ent[2] eq 'lo';
+    return 0;
+}
+
 sub donets
 {
     my $callback = shift;
@@ -387,15 +400,8 @@ sub donets
         #get ipv6 routes and in fact *cannot* dictate router via DHCPv6 at this specific moment.
         foreach (@ip6table)
         {
+            next if _ignore_ipv6_route($_);
             my @ent = split /\s+/, $_;
-            if ($ent[0] =~ m/^fe80::/ or $ent[0] eq 'unreachable' or $ent[1] eq 'nexthop' or $ent[0] eq 'default' or
-                $ent[1] eq 'via' or $ent[2] eq 'lo') {
-
-                #Do not contemplate link-local, unreachable, gatewayed networks,
-                #  or networks connected to loopback interface
-                #DHCPv6 relay will be manually entered into networks as was the case for IPv4
-                next;
-            }
             my $net = shift @ent;
             my $dev = shift @ent;
             if ($dev eq 'dev') {

--- a/xCAT-test/autotest/testcase/makenetworks/cases0
+++ b/xCAT-test/autotest/testcase/makenetworks/cases0
@@ -22,6 +22,15 @@ check:rc==0
 check:output=~Version
 end
 
+start:makenetworks_ipv6_route_filter_unit
+description:Run the makenetworks IPv6 route-filter unit test through xcattest.
+os:Linux
+label:mn_only,ci_test,network,unit,makenetworks_unit
+cmd:prove -I/opt/xcat/lib/perl /opt/xcat/share/xcat/tools/autotest/unit/networks_ipv6_route_filter.t
+check:rc==0
+check:output=~All tests successful
+end
+
 start:makenetworks_d
 os:Linux
 description:makenetworks_d

--- a/xCAT-test/unit/networks_ipv6_route_filter.t
+++ b/xCAT-test/unit/networks_ipv6_route_filter.t
@@ -24,7 +24,7 @@ BEGIN {
 }
 
 my $plugin = "$FindBin::Bin/../../xCAT-server/lib/xcat/plugins/networks.pm";
-$plugin = "$ENV{XCATROOT}/lib/perl/xcat/plugins/networks.pm" unless -f $plugin;
+$plugin = "$ENV{XCATROOT}/lib/perl/xCAT_plugin/networks.pm" unless -f $plugin;
 require $plugin;
 
 ok(

--- a/xCAT-test/unit/networks_ipv6_route_filter.t
+++ b/xCAT-test/unit/networks_ipv6_route_filter.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+## no critic (Modules::RequireFilenameMatchesPackage)
+
+use FindBin;
+use Test::More;
+
+BEGIN {
+    package xCAT::Table;
+    $INC{'xCAT/Table.pm'} = __FILE__;
+
+    package xCAT::Utils;
+    $INC{'xCAT/Utils.pm'} = __FILE__;
+
+    package xCAT::TableUtils;
+    $INC{'xCAT/TableUtils.pm'} = __FILE__;
+
+    package xCAT::NetworkUtils;
+    $INC{'xCAT/NetworkUtils.pm'} = __FILE__;
+
+    package xCAT::ServiceNodeUtils;
+    $INC{'xCAT/ServiceNodeUtils.pm'} = __FILE__;
+}
+
+my $plugin = "$FindBin::Bin/../../xCAT-server/lib/xcat/plugins/networks.pm";
+$plugin = "$ENV{XCATROOT}/lib/perl/xcat/plugins/networks.pm" unless -f $plugin;
+require $plugin;
+
+ok(
+    !xCAT_plugin::networks::_ignore_ipv6_route('2001:db8:1::/64 dev eth0 proto kernel'),
+    'a directly connected global IPv6 network is considered',
+);
+
+my @ignored_routes = (
+    [ 'fe80::/128 dev eth0 proto kernel',         'link-local prefix' ],
+    [ 'unreachable 2001:db8:2::/64 metric 1024', 'unreachable route' ],
+    [ 'default via 2001:db8::1 dev eth0',         'default route' ],
+    [ '  nexthop via fe80::1 dev eth0 weight 1',  'multipath nexthop continuation' ],
+    [ '2001:db8:3::/64 via 2001:db8::1 dev eth0', 'gatewayed route' ],
+    [ '::1 dev lo proto kernel metric 256',       'loopback route' ],
+);
+
+for my $case (@ignored_routes) {
+    ok(xCAT_plugin::networks::_ignore_ipv6_route($case->[0]), "$case->[1] is ignored");
+}
+
+done_testing();


### PR DESCRIPTION
When `donets()` scans the host route table to seed the networks table, it mis-classifies several route lines as networks: link-local routes with a prefix other than the exact `fe80::/64`, `ip -6 route` `nexthop` continuation lines, and the `default` route. Broaden the filter to exclude any `fe80::` prefix, nexthop lines, and default routes.

Recovered from the unmerged lenovobuild branch (8b79cf85 and 7094ba0c, bundled as both edit the same filter).
