### PR TITLE
fix(nodech): support comma-delimited values in the ,= and ^= operators

### DIFF
--- a/xCAT-server/lib/xcat/plugins/tabutils.pm
+++ b/xCAT-server/lib/xcat/plugins/tabutils.pm
@@ -1765,11 +1765,14 @@ sub nodech
                                     if ($cent) { $curval = $cent->{$key}; }
                                 }
                                 if ($curval) {
-                                    my @vals = split(/,/, $curval);
-                                    if (grep /^$val$/, @vals) { #only bother if there
-                                        @vals = grep(!/^$val$/, @vals);
-                                        my $newval = join(',', @vals);
-                                        $uhsh{$key} = $newval;
+                                    foreach my $subval (split /,/, $val) {
+                                        my @vals = split(/,/, $curval);
+                                        if (grep /^$subval$/, @vals) { #only bother if there
+                                            @vals = grep(!/^$subval$/, @vals);
+                                            my $newval = join(',', @vals);
+                                            $uhsh{$key} = $newval;
+                                            $curval = $newval;
+                                        }
                                     }
                                 }  #else, what they asked for is the case alredy
                             }

--- a/xCAT-server/lib/xcat/plugins/tabutils.pm
+++ b/xCAT-server/lib/xcat/plugins/tabutils.pm
@@ -1742,11 +1742,14 @@ sub nodech
                                     if ($cent) { $curval = $cent->{$key}; }
                                 }
                                 if ($curval) {
-                                    my @vals = split(/,/, $curval);
-                                    unless (grep /^$val$/, @vals) {
-                                        unshift @vals, $val;
-                                        my $newval = join(',', @vals);
-                                        $uhsh{$key} = $newval;
+                                    foreach my $subval (split /,/, $val) {
+                                        my @vals = split(/,/, $curval);
+                                        unless (grep /^$subval$/, @vals) {
+                                            unshift @vals, $subval;
+                                            my $newval = join(',', @vals);
+                                            $uhsh{$key} = $newval;
+                                            $curval = $newval;
+                                        }
                                     }
                                 } else {
                                     $uhsh{$key} = $val;

--- a/xCAT-test/autotest/testcase/nodech/cases0
+++ b/xCAT-test/autotest/testcase/nodech/cases0
@@ -14,26 +14,27 @@ end
 
 
 start:nodech_noderange_table_comma
-description:nodech testnode groups,=rhels5.5.Check nodech command with ,=.
+description:Append multiple comma-delimited groups without duplicating an existing group.
 label:mn_only,ci_test,db
-cmd:chdef -t node -o testnode groups=all
+cmd:chdef -t node -o testnode groups=all,rhels5.5
 check:rc==0
-cmd:nodech testnode groups,=rhels5.5
+cmd:nodech testnode groups,=rhels5.5,rhels5.6
 check:rc==0
 cmd:lsdef -t node -i groups testnode
-check:output=~groups=rhels5.5,all
+check:output=~groups=rhels5.6,all,rhels5.5
 cmd:rmdef -t node testnode
 end
 
 
 start:nodech_noderange_table_arrow
+description:Remove multiple comma-delimited groups while ignoring a group that is absent.
 label:mn_only,ci_test,db
-cmd:chdef -t node -o testnode groups=all,rhels5.5
+cmd:chdef -t node -o testnode groups=all,rhels5.5,rhels5.6
 check:rc==0
-cmd:nodech testnode groups^=rhels5.5
+cmd:nodech testnode groups^=rhels5.4,rhels5.5
 check:rc==0
 cmd:lsdef -t node -i groups testnode
-check:output!=rhels5.5
+check:output=~groups=all,rhels5.6
 cmd:rmdef -t node testnode
 end
 


### PR DESCRIPTION
`nodech`'s `,=` (append) and `^=` (remove) operators treated the right-hand side as a single opaque value, so a comma-delimited list was mishandled: `,=` appended the literal `"a,b"` (and compared duplicates against the combined string), and `^=` tried to strip the combined `"a,b"` and left the individual groups in place. Split the value on commas in both operators and add/remove each element individually.

Recovered from the unmerged lenovobuild branch (086b0c0d and 95c78b33).
