### PR TITLE
fix(ddns): recognize a routed local nameserver address

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -443,18 +443,17 @@ sub process_request {
         if ($net and $net->{nameservers})
         {
             my $valid = 0;
-            my @myips;
-            my @myipsd   = xCAT::NetworkUtils->my_ip_facing($net->{net});
-            my $myipsd_l = @myipsd;
-            unless ($myipsd[0]) { @myips = @myipsd[ 1 .. ($myipsd_l - 1) ]; }
             foreach (split /,/, $net->{nameservers})
             {
                 chomp $_;
-                foreach my $myip (@myips) {
-                    if (($_ eq $myip) || ($_ eq '<xcatmaster>') || ($_ eq $sitens))
-                    {
-                        $valid += 1;
-                    }
+                # my_ip_facing() only returns addresses on the interface directly
+                # facing this network, so a nameserver that is a local address on
+                # another (routed) interface was wrongly treated as external.
+                # thishostisnot() recognizes any local address; keep the existing
+                # <xcatmaster> and site-nameserver special cases.
+                if (!xCAT::NetworkUtils->thishostisnot($_) || $_ eq '<xcatmaster>' || $_ eq $sitens)
+                {
+                    $valid += 1;
                 }
             }
             unless ($valid > 0)


### PR DESCRIPTION
The DNS-managed-networks check in `process_request()` used `my_ip_facing()`, which only returns local addresses on the interface directly facing that network, so a nameserver reachable via a different (routed) interface was treated as external and the network wrongly dropped from ddns management. Use `thishostisnot()`, which recognizes any local address regardless of interface, and keep the existing `<xcatmaster>` and site-nameserver special cases (the original lenovobuild commit dropped them, which would regress any network using the `<xcatmaster>` token).

Recovered from the unmerged lenovobuild branch (3c343f83, adapted).
