### PR TITLE
fix(rcons): resolve a conserver hostname before the local-address check

### DIFF
--- a/xCAT-client/bin/rcons
+++ b/xCAT-client/bin/rcons
@@ -115,6 +115,11 @@ if [ $USE_CONFLUENT == "1" ] && ([ -x "/opt/confluent/bin/confetty" ] || [ -x "/
     fi
     if [ -z "$CONSERVER" ]; then
         CONSERVER=`nodels $1 nodehm.conserver 2>/dev/null | awk -F: '{print $2}' | tr -d ' '`
+        # nodehm.conserver may be a hostname; resolve it so the local-address
+        # comparison below matches when the conserver is this host.
+        if [ ! -z "$CONSERVER" ]; then
+            CONSERVER=$(getent hosts $CONSERVER | awk '{print $1}')
+        fi
         declare -a ipaddrs=`ip -o a | awk {'print $4'} | cut -d/ -f1 | grep -v : | tr '\n' ' '`
         for IP in ${ipaddrs[*]}; do
             if [[ "${CONSERVER}" == "${IP}" ]]; then


### PR DESCRIPTION
When nodehm.conserver is a hostname, rcons compared the name directly against the management node's local IP addresses, so the "conserver is this host" check never matched and rcons connected through a remote confluent session even when the conserver was local. Resolve the name with getent first so the comparison works.

Recovered from the unmerged lenovobuild branch (faa767e5).
