### PR TITLE
fix(rinv): sort FRU output deterministically

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -3203,7 +3203,7 @@ sub fru_initted {
     my @types  = @{ $sessdata->{invtypes} };
     my $format = "%-20s %s";
 
-    foreach $key (sort { $a <=> $b } keys %{ $sessdata->{fru_hash} }) {
+    foreach $key (sort { $a <=> $b or $a cmp $b } keys %{ $sessdata->{fru_hash} }) {
         my $fru = $sessdata->{fru_hash}->{$key};
         my $type;
         foreach $type (split /,/, $fru->rec_type) {


### PR DESCRIPTION
The FRU key sort used only `$a <=> $b`, a numeric comparison that returns 0 for the non-numeric FRU field names, leaving them in per-process randomized hash order — so `rinv <node> all` printed its fields in a different order on each run. Add `$a cmp $b` as a tiebreaker for stable output.

Recovered from the unmerged lenovobuild branch (9cd3fac6).
