### PR TITLE
fix(nodestat): report a clear error when fping is missing

### DIFF
--- a/xCAT-server/lib/xcat/plugins/nodestat.pm
+++ b/xCAT-server/lib/xcat/plugins/nodestat.pm
@@ -796,7 +796,18 @@ sub process_request_port {
     if (@nodes > 0) {
         my $node;
         my $fping;
-        open($fping, "fping " . join(' ', @nodes) . " 2> /dev/null|") or die("Can't start fping: $!");
+        my $fpingcmd;
+        for my $fp (qw(/usr/sbin/fping /usr/bin/fping /sbin/fping /bin/fping /usr/local/sbin/fping /usr/local/bin/fping)) {
+            if (-x $fp) { $fpingcmd = $fp; last; }
+        }
+        unless ($fpingcmd) {
+            my $rsp = {};
+            $rsp->{error}->[0] =
+              "Unable to find fping on system, must install fping package to use nodestat -f";
+            xCAT::MsgUtils->message("E", $rsp, $callback, 1);
+            return $status;
+        }
+        open($fping, "$fpingcmd " . join(' ', @nodes) . " 2> /dev/null|") or die("Can't start fping: $!");
         while (<$fping>) {
             my %rsp;
             my $node = $_;


### PR DESCRIPTION
`nodestat -f` runs fping to reach the nodes; if fping is not installed the pipe yields no output and nodestat silently returned an empty result. Check that an fping binary exists before running it and emit an explicit "must install fping" error otherwise. (The original lenovobuild commit inferred fping's presence from pipe output, which false-positived when fping was present but every node was unresolvable; this checks for the binary directly.)

Recovered from the unmerged lenovobuild branch (f0c88182, reworked).
