### PR TITLE
fix(rspconfig): clearer error when no option is given

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -8404,6 +8404,15 @@ sub preprocess_request {
                     $option = $_;
                     $optset = 0;
                 }
+                if ($option eq '') {
+                    foreach (@$all_noderange) {
+                        $error_data .= "\n" if ($error_data);
+                        $error_data .= "$_: options are required when using mgt=ipmi, see -h or the man page";
+                    }
+                    $callback->({ errorcode => [1], data => [ $error_data ] });
+                    $request = {};
+                    return;
+                }
                 unless ($option =~ /^USERID$|^ip$|^netmask$|^gateway$|^vlan$|^userid$|^username$|^password$|^snmpdest|^thermprofile$|^alert$|^garp$|^community$|^backupgateway$/) {
                     foreach (@$all_noderange) {
                         $error_data .= "\n" if ($error_data);


### PR DESCRIPTION
Running `rspconfig` against an `mgt=ipmi` node with no option fell through to the generic `Unsupported command: rspconfig ` message with an empty option, which does not tell the user what is wrong. Detect the empty option in `preprocess_request` and report that options are required.

Recovered from the unmerged lenovobuild branch (08ae94bd).
