### PR TITLE
fix(tcons): make tcons work with modern tmux

### DIFF
--- a/xCAT-client/bin/tcons
+++ b/xCAT-client/bin/tcons
@@ -5,14 +5,15 @@ for i in `nodels "$1"`; do
     if [ "$f" = 1 ]; then
         f=0
     	qdate=$((`date +%s`+5))
-        tmux new-session -d -s tcons.$$ -x 800 -y 800 "rcons $i;if [ \`date +%s\` -lt $qdate ]; then echo Press enter to close; read qdate; fi"
+        tmux new-session -d -s tcons_$$ -x 800 -y 800 "rcons $i;if [ \`date +%s\` -lt $qdate ]; then echo Press enter to close; read qdate; fi"
         continue
     fi
-    tmux select-pane -t $p
+    tmux select-pane -t tcons_$$
+    tmux set-option -t tcons_$$:$p pane-border-status top > /dev/null 2>&1 | cat > /dev/null
     p=$((p+1))
     qdate=$((`date +%s`+5))
-    tmux split -h "rcons $i;if [ \`date +%s\` -lt $qdate ]; then echo Press enter to close; read qdate; fi"
-    tmux select-layout tiled
+    tmux split -h -t tcons_$$ "rcons $i;if [ \`date +%s\` -lt $qdate ]; then echo Press enter to close; read qdate; fi"
+    tmux select-layout -t tcons_$$ tiled
 done
 tmux select-pane -t 0
-tmux attach -t tcons.$$
+tmux attach -t tcons_$$


### PR DESCRIPTION
tcons fails on tmux 3.x (all current platforms): the session was named `tcons.$$`, but modern tmux parses `.` as the session:window.pane separator, so `tmux attach -t tcons.$$` cannot find the session. The per-node tmux commands also had no target, so running tcons from inside tmux acted on the caller's session. Rename the session to `tcons_$$`, target every tmux command at it, and set pane-border-status per pane.

Recovered from the unmerged lenovobuild branch (5107b6ba1, cefefa7d1, 6c72a2707, e040d24bb).
