### PR TITLE
fix(replaycons): print full usage on missing argument, document confluent log rotation

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/replaycons.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/replaycons.1.rst
@@ -36,6 +36,10 @@ the speed of the output play back.  (The logs are stored in /var/log/consoles.)
 \ **replaycons**\  must be run locally on the system on which the console log is stored.  This is normally
 that management node, but in a hierarchical cluster will usually be the service node.
 
+Note that when used with confluent, log rotation will cause older logs to have a filename that replaycons
+does not understand.  You can have replaycons process an older log by appending the suffix seen in
+/var/log/confluent/consoles/.  For example, 'replaycons n1.2018-02-02' will show the log file indicated.
+
 
 *******
 OPTIONS

--- a/xCAT-client/pods/man1/replaycons.1.pod
+++ b/xCAT-client/pods/man1/replaycons.1.pod
@@ -19,6 +19,10 @@ the speed of the output play back.  (The logs are stored in /var/log/consoles.)
 B<replaycons> must be run locally on the system on which the console log is stored.  This is normally
 that management node, but in a hierarchical cluster will usually be the service node.
 
+Note that when used with confluent, log rotation will cause older logs to have a filename that replaycons
+does not understand.  You can have replaycons process an older log by appending the suffix seen in
+/var/log/confluent/consoles/.  For example, 'replaycons n1.2018-02-02' will show the log file indicated.
+
 
 =head1 OPTIONS
 

--- a/xCAT-server/bin/replaycons
+++ b/xCAT-server/bin/replaycons
@@ -45,7 +45,7 @@ if ($::VERSION) {
 }
 
 if (@ARGV < 1) {
-    print "Please specify a node name.\n";
+    print "$usage_string\n";
     exit(1);
 }
 


### PR DESCRIPTION
Two small replaycons improvements: print the full usage statement on a missing argument instead of a terse "Please specify a node name.", and document in the man page that confluent log rotation renames older logs and how to replay one by appending the date suffix.

Recovered from the unmerged lenovobuild branch (1c1b23fac, 48a92b7d4).
