### PR TITLE
fix(postscripts): disable xcatpostinit1 before running the postscripts

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -360,11 +360,22 @@ fi
 #create the xcatinstallpost
 mkdir -p /opt/xcat
 cat >/opt/xcat/xcatinstallpost << 'EOF'
-#INCLUDE:#TABLE:site:key=installdir:value#/postscripts/xcatinstallpost#
-
+#!/bin/bash
+# Disable the xcatpostinit1 service *before* running the postscripts (the
+# INCLUDE at the end).  If a postscript reboots the node, the service is
+# already disabled, so the whole postscript set is not run again on reboot.
+# The disable decision needs OSVER, RUNBOOTSCRIPTS and NODESTATUS, which the
+# included script would otherwise set; read them up front (it re-reads them),
+# and source xcatlib.sh so msgutil_r is available for the debug messages.
+[ -f /xcatpost/xcatlib.sh ] && . /xcatpost/xcatlib.sh
 if [ -f /xcatpost/mypostscript.post ]; then
+    OSVER=`grep '^OSVER=' /xcatpost/mypostscript.post |cut -d= -f2|sed s/\'//g`
     RUNBOOTSCRIPTS=`grep 'RUNBOOTSCRIPTS=' /xcatpost/mypostscript.post |cut -d= -f2 | tr -d \'\" | tr A-Z a-z`
+    XCATDEBUGMODE=`grep 'XCATDEBUGMODE=' /xcatpost/mypostscript.post |cut -d= -f2 | tr -d \'\" | tr A-Z a-z`
+    MASTER_IP=`grep '^MASTER_IP=' /xcatpost/mypostscript.post |cut -d= -f2|sed s/\'//g`
 fi
+[ -f /xcatpost/mypostscript ] && NODESTATUS=`grep 'NODESTATUS=' /xcatpost/mypostscript |awk -F = '{print $2}'|tr -d \'\" | tr A-Z a-z `
+[ -z "$NODESTATUS" ] && NODESTATUS="1"
 
 if [[ $OSVER == ubuntu* ]]; then
     if [[ ! "$RUNBOOTSCRIPTS" =~ ^(1|yes|y)$ ]]; then
@@ -382,6 +393,8 @@ else
     fi
 
 fi
+
+#INCLUDE:#TABLE:site:key=installdir:value#/postscripts/xcatinstallpost#
 
 EOF
 chmod 755 /opt/xcat/xcatinstallpost

--- a/xCAT-server/share/xcat/install/scripts/post.xcat.ng
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat.ng
@@ -355,12 +355,22 @@ chmod 0755 /opt/xcat/xcatpostinit1
 # Create the xcatinstallpost
 mkdir -p /opt/xcat
 cat >/opt/xcat/xcatinstallpost <<'EOF'
-#INCLUDE:#TABLE:site:key=installdir:value#/postscripts/xcatinstallpost#
-
+#!/bin/bash
+# Disable the xcatpostinit1 service *before* running the postscripts (the
+# INCLUDE at the end).  If a postscript reboots the node, the service is
+# already disabled, so the whole postscript set is not run again on reboot.
+# The disable decision needs RUNBOOTSCRIPTS and NODESTATUS, which the included
+# script would otherwise set; read them up front (it re-reads them), and source
+# xcatlib.sh so msgutil_r is available for the debug message.
+[ -f /xcatpost/xcatlib.sh ] && . /xcatpost/xcatlib.sh
 if [ -f /xcatpost/mypostscript.post ]
 then
     RUNBOOTSCRIPTS=`grep 'RUNBOOTSCRIPTS=' /xcatpost/mypostscript.post | cut -d= -f2 | tr -d \'\" | tr A-Z a-z`
+    XCATDEBUGMODE=`grep 'XCATDEBUGMODE=' /xcatpost/mypostscript.post | cut -d= -f2 | tr -d \'\" | tr A-Z a-z`
+    MASTER_IP=`grep '^MASTER_IP=' /xcatpost/mypostscript.post | cut -d= -f2 | sed s/\'//g`
 fi
+[ -f /xcatpost/mypostscript ] && NODESTATUS=`grep 'NODESTATUS=' /xcatpost/mypostscript | awk -F = '{print $2}' | tr -d \'\" | tr A-Z a-z`
+[ -z "$NODESTATUS" ] && NODESTATUS="1"
 
 if [[ ! "$RUNBOOTSCRIPTS" =~ ^(1|yes|y)$ ]] && [[ ! "$NODESTATUS" =~ ^(1|yes|y)$ ]]; then
     systemctl disable xcatpostinit1.service
@@ -370,6 +380,8 @@ if [[ ! "$RUNBOOTSCRIPTS" =~ ^(1|yes|y)$ ]] && [[ ! "$NODESTATUS" =~ ^(1|yes|y)$
         ;;
     esac
 fi
+
+#INCLUDE:#TABLE:site:key=installdir:value#/postscripts/xcatinstallpost#
 
 EOF
 

--- a/xCAT-server/share/xcat/install/scripts/post.xcat.rhels10
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat.rhels10
@@ -355,12 +355,22 @@ chmod 0755 /opt/xcat/xcatpostinit1
 # Create the xcatinstallpost
 mkdir -p /opt/xcat
 cat >/opt/xcat/xcatinstallpost <<'EOF'
-#INCLUDE:#TABLE:site:key=installdir:value#/postscripts/xcatinstallpost#
-
+#!/bin/bash
+# Disable the xcatpostinit1 service *before* running the postscripts (the
+# INCLUDE at the end).  If a postscript reboots the node, the service is
+# already disabled, so the whole postscript set is not run again on reboot.
+# The disable decision needs RUNBOOTSCRIPTS and NODESTATUS, which the included
+# script would otherwise set; read them up front (it re-reads them), and source
+# xcatlib.sh so msgutil_r is available for the debug message.
+[ -f /xcatpost/xcatlib.sh ] && . /xcatpost/xcatlib.sh
 if [ -f /xcatpost/mypostscript.post ]
 then
     RUNBOOTSCRIPTS=`grep 'RUNBOOTSCRIPTS=' /xcatpost/mypostscript.post | cut -d= -f2 | tr -d \'\" | tr A-Z a-z`
+    XCATDEBUGMODE=`grep 'XCATDEBUGMODE=' /xcatpost/mypostscript.post | cut -d= -f2 | tr -d \'\" | tr A-Z a-z`
+    MASTER_IP=`grep '^MASTER_IP=' /xcatpost/mypostscript.post | cut -d= -f2 | sed s/\'//g`
 fi
+[ -f /xcatpost/mypostscript ] && NODESTATUS=`grep 'NODESTATUS=' /xcatpost/mypostscript | awk -F = '{print $2}' | tr -d \'\" | tr A-Z a-z`
+[ -z "$NODESTATUS" ] && NODESTATUS="1"
 
 if [[ ! "$RUNBOOTSCRIPTS" =~ ^(1|yes|y)$ ]] && [[ ! "$NODESTATUS" =~ ^(1|yes|y)$ ]]; then
     systemctl disable xcatpostinit1.service
@@ -370,6 +380,8 @@ if [[ ! "$RUNBOOTSCRIPTS" =~ ^(1|yes|y)$ ]] && [[ ! "$NODESTATUS" =~ ^(1|yes|y)$
         ;;
     esac
 fi
+
+#INCLUDE:#TABLE:site:key=installdir:value#/postscripts/xcatinstallpost#
 
 EOF
 


### PR DESCRIPTION
The generated /opt/xcat/xcatinstallpost ran the install postscripts before disabling the xcatpostinit1 service, so a postscript that rebooted the node (firmware/kernel update) caused the whole set to run again on the next boot. Disable the service before running the postscripts instead.

The disable decision reads OSVER/RUNBOOTSCRIPTS/NODESTATUS, which the included script would otherwise set, so those are read up front (the included script re-reads them) and xcatlib.sh is sourced for msgutil_r. The original lenovobuild change touched only the legacy post.xcat; the reorder is applied to the systemd variants post.xcat.ng (EL8/9) and post.xcat.rhels10 (EL10) too.

Tested with a full AlmaLinux 9.8 install: postscripts run once, the node reaches booted, and with the default NODESTATUS=1 the service is left enabled as before.

Recovered from the unmerged lenovobuild branch (9184cbe0).
