### PR TITLE
build(spec): drop the mandatory elilo-xcat dependency

### DIFF
--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -86,11 +86,6 @@ Requires: perl-IO-Stty >= 0.04-5
 Requires: goconserver >= 0.3.3-snap202011021058
 %endif
 
-#support mixed cluster
-%if %nots390x
-Requires: elilo-xcat >= 3.14-6
-%endif
-
 %ifarch i386 i586 i686 x86 x86_64
 Requires: xnba-undi >= 1.21.1-1
 Requires: syslinux-xcat >= 6.03-1

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -69,11 +69,6 @@ Requires: perl-IO-Stty
 Requires: goconserver >= 0.3.3
 %endif
 
-#support mixed cluster
-%ifnarch s390x
-Requires: elilo-xcat
-%endif
-
 %ifarch i386 i586 i686 x86 x86_64
 Requires: xnba-undi
 Requires: syslinux-xcat


### PR DESCRIPTION
xCAT and xCATsn hard-required `elilo-xcat` on every non-s390x install. elilo only provides the ia64 (Itanium) UEFI loader; modern x86-64 UEFI netboot uses `xnba.efi` and aarch64 uses grub2, so the dependency pulls a loader no current platform needs. Drop the Requires (`xnba-undi`, which the UEFI path does use, is kept). elilo-xcat can still be installed by hand for legacy ia64.

An OVMF x86-64 UEFI client netboots through `xnba.efi` with no elilo involved.

Recovered from the unmerged lenovobuild branch (e53b62e0).
