### PR TITLE
fix(pasu): filter more OneCLI status banner lines from command output

### DIFF
--- a/xCAT-client/bin/pasu
+++ b/xCAT-client/bin/pasu
@@ -219,7 +219,13 @@ sub processoutput {      #This way, one arbiter handles output, no interrupting
                     $line !~ /Connected to BMC by IP address/i &&
                     $line !~ /Succeeded running the command /i &&
                     $line !~ /Based on module version /i &&
-                    $line !~ /Succeed running command /i)) {
+                    $line !~ /Succeed running command /i &&
+                    $line !~ /Connected to BMC at IP address/i &&
+                    $line !~ /Succeed in running the command:/i &&
+                    $line !~ /start to convert cmd./i &&
+                    $line !~ /Start to connect /i &&
+                    $line !~ /Connected to the node/i &&
+                    $line !~ /^Succeed\.\s*$/i)) {
                 print $nodehdl{$readyh} . ": " . $line . "\n";
             }
         }


### PR DESCRIPTION
pasu strips OneCLI's banner and status lines so only the requested settings are shown, but OneCLI has grown several status lines over the years that were not filtered and leaked into the output. Add the missing patterns.

Recovered from the unmerged lenovobuild branch (229533cb, a6932bb4), which added `Connected to BMC at IP address` (master only matched "by"), `Succeed in running the command:` and `start to convert cmd.`. Extended after testing a current OneCLI 5.3.0 on a Lenovo ThinkSystem SR635, which also emits `Start to connect ...`, `Connected to the node(N) by KCS` and a trailing `Succeed.` — now filtered too.

Validated by running a real OneCLI 5.3.0 `config show` through the filter: every banner/footer line is removed and all 756 setting lines pass unchanged.
