### PR TITLE
fix(bmcsetup): enable BMC setup for Lenovo SR635/SR655

### DIFF
--- a/xCAT-genesis-scripts/etc/udev/rules.d/99-tsm.rules
+++ b/xCAT-genesis-scripts/etc/udev/rules.d/99-tsm.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ATTRS{idVendor}=="046b", ATTRS{idProduct}=="ffb0", RUN+="/sbin/setuptsmnic"

--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -227,6 +227,25 @@ if [ "$IPMIMFG" == 2 ]; then #IBM
     fi
 elif [ "$IPMIMFG" == 19046 -a "$XPROD" == 13616 ] ; then
    LOCKEDUSERS=1
+elif [ "$IPMIMFG" = "19046" -a "$XPROD" = "1287" ]; then
+    # Lenovo SR635/SR655: bring up the TSM LAN-over-USB and select the BMC LAN channel
+    BMCPORT=`grep bmcport /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'`
+    echo -n "Initializing TSM network...."
+    if [ "$BMCPORT" = 0 ]; then
+        ipmitool raw 0x32 0x71 0 1 0
+        sleep 15
+        ipmitool raw 0x32 0x71 0 0 3
+        LANCHAN=$(ipmitool raw 0x32 0x72 4 0 0|sed -e 's/^ 0//')
+    else
+        ipmitool raw 0x32 0x71 0 0 0
+        sleep 15
+        ipmitool raw 0x32 0x71 0 1 3
+        LANCHAN=$(ipmitool raw 0x32 0x72 4 1 0|sed -e 's/^ 0//')
+    fi
+    echo -n "Ready"
+    ipmitool raw 0x3c 0x70 0 1 2> /dev/null
+    ipmitool raw 0x3c 0x70 1 1 2> /dev/null
+    USBSTATE=$(ipmitool raw 0x32 0xab)
 elif [ "$IPMIMFG" == 20301 -o "$IPMIMFG" == 19046 ] ; then
     IBMVPDV=`ipmitool raw 0x3a 0xb 2 0 16 1`
     logger -s -t $log_label -p local4.info "XPROD is $XPROD, IBMVPDV is $IBMVPDV"
@@ -505,8 +524,8 @@ for user in $BMCUS; do
     if [ -z "$USERSLOT" ]; then
         USERSLOT=$((`ipmitool raw 6 0x44 1 1|awk '{print $3}'` + 1))
     fi
-    if [ "$USERSLOT" == 0 ]; then
-        # automatically find first unlocked user slot
+    if [ "$USERSLOT" == 0 ] && ! [ "$IPMIMFG" = 19046 -a "$XPROD" = 1287 ]; then
+        # automatically find first unlocked user slot (skipped on SR635/SR655)
         for slot in {1..16}; do
             USERLOCKED=`ipmitool channel getaccess $LANCHAN $slot | grep Fixed | awk '{print $4}'`
             if [ "$USERLOCKED" == "No" ]; then
@@ -765,6 +784,26 @@ while [ $idev -gt 0 ]; do
         done &
     fi
 done
+
+if [ ! -z "$USBSTATE" ]; then  # Continuation of SR635/SR655 specific code
+    echo -n "Restarting TSM networking...."
+    if [ "$BMCPORT" = 0 ]; then
+        sleep 45
+        ipmitool raw 0x32 0x71 0 0 0
+        sleep 45
+        ipmitool raw 0x32 0x71 0 0 3
+        sleep 45
+        ipmitool raw 0x32 0x71 0 0 3
+    else
+        sleep 45
+        ipmitool raw 0x32 0x71 0 1 0
+        sleep 45
+        ipmitool raw 0x32 0x71 0 1 3
+        sleep 45
+        ipmitool raw 0x32 0x71 0 1 3
+    fi
+    echo "Done"
+fi
 
 # remove the bmc configuration information before exit
 rm -f /tmp/ipmicfg.xml

--- a/xCAT-genesis-scripts/usr/sbin/setuptsmnic
+++ b/xCAT-genesis-scripts/usr/sbin/setuptsmnic
@@ -1,0 +1,5 @@
+#!/bin/sh
+/sbin/ip link set $INTERFACE up
+/sbin/ip addr add dev $INTERFACE 169.254.0.120/24
+/sbin/ip route add 169.254.0.0/24 dev $INTERFACE
+echo -n $INTERFACE > /tmp/tsmhostnic

--- a/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
+++ b/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
@@ -106,7 +106,9 @@ touch /etc/xcat/genesis-scripts-updated
 %{rpminstallroot}/usr/bin/restart
 %{rpminstallroot}/etc/init.d/functions
 %{rpminstallroot}/etc/udev/rules.d/99-imm.rules
+%{rpminstallroot}/etc/udev/rules.d/99-tsm.rules
 %{rpminstallroot}/etc/udev/rules.d/98-mlx.rules
 %{rpminstallroot}/usr/sbin/setupimmnic
+%{rpminstallroot}/usr/sbin/setuptsmnic
 %{rpminstallroot}/usr/sbin/loadmlxeth
 %exclude %{rpminstallroot}/debian/*


### PR DESCRIPTION
The original Lenovo SR635/SR655 (IPMI manufacturer 19046, product 1287) use an AMI "TSM" BMC reached over a LAN-over-USB interface. It needs OEM raw commands to bring the interface up, select the LAN channel, and restart TSM networking once configured. This adds a dedicated vendor branch for it, plus a udev rule and helper that bring up the USB NIC (169.254.0.120) so in-band ipmitool can reach the TSM; the user-slot auto-scan is skipped for these machines (fixed slot).

Recovered from the unmerged lenovobuild branch (922dfe18, 42357f9d, 02da8a6b, 765e2ad3, 408cf2b3), adapted to master's bmcsetup structure.
