### PR TITLE
fix(ipmi): recognize additional Lenovo IMM firmware prefixes and energy code

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -3361,7 +3361,7 @@ sub got_bmc_fw_info {
         my @returnd = (@{ $rsp->{data} });
         my @a       = ($fw_rev2);
         my $prefix  = pack("C*", @returnd[ 0 .. 3 ]);
-        if ($prefix =~ /yuoo/i or $prefix =~ /1aoo/i or $prefix =~ /tcoo/i) { #we have an imm
+        if ($prefix =~ /yuoo/i or $prefix =~ /1aoo/i or $prefix =~ /tcoo/i or $prefix =~ /tei/i or $prefix =~ /cdi/i or $prefix =~ /psi/i) { #we have an imm
             $isanimm = 1;
         }
         $mprom = sprintf("%d.%s (%s)", $fw_rev1, decodebcd(\@a), getascii(@returnd));

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -6186,7 +6186,7 @@ sub execute_iem_commands {
 sub executed_iem_command {
     my $rsp      = $_[0];
     my $sessdata = $_[1];
-    if ($rsp->{code} == 0xcb) {
+    if ($rsp->{code} == 0xcb or $rsp->{code} == 0xc1) {
         $sessdata->{abortediem}       = 1;
         $sessdata->{abortediemreason} = "Not Present";
         $sessdata->{iemcallback}->($sessdata);


### PR DESCRIPTION
Two small additive recognitions in the IPMI plugin for Lenovo hardware:

- **rinv**: detect an IMM when its firmware build-ID prefix is `tei`, `cdi` or `psi` (in addition to the existing `yuoo`/`1aoo`/`tcoo`).
- **rvitals**: treat energy-manager (IEM) response code `0xc1` as "not supported / not present", the same as the already-handled `0xcb`.

Both are purely additive, since a node whose firmware prefix or energy response doesn't match is unaffected, so there is no impact on other hardware.

Recovered from the unmerged lenovobuild branch (e50cf37, 201b2de, 06d7097).
