### PR TITLE
fix(ci): keep no-op backport runs green

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -91,5 +91,7 @@ jobs:
               });
             }
       - name: Fail when a backport needs intervention
-        if: steps.backport.outputs.was_successful != 'true'
+        if: >
+          steps.backport.outputs.was_successful_by_target != '' &&
+          steps.backport.outputs.was_successful != 'true'
         run: exit 1


### PR DESCRIPTION
Fix the post-merge failure seen on #7661. The intervention guard now runs only when the backport action reports per-target results, so no-label merges stay green while failed backports still require manual handling.