### PR TITLE
fix(getinstdisk): use an Intel RSTe/VROC RAID when no other disk is found

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/getinstdisk
+++ b/xCAT-server/share/xcat/install/scripts/getinstdisk
@@ -234,6 +234,14 @@ if [ -z "$install_disk" ]; then
 fi
 rm -rf $tmpdir;
 
+# Auto-sense an Intel RSTe/VROC software RAID and use it if no other install
+# disk was found, before falling back to the hard-coded default below.
+if [ -z "$install_disk" ] && [ -b /dev/md/Volume0_0 ]; then
+    install_disk="/dev/md/Volume0_0"
+elif [ -z "$install_disk" ] && [ -b /dev/md/Volume0 ]; then
+    install_disk="/dev/md/Volume0"
+fi
+
 # Cannot find proper disk for OS install, select the default one "/dev/sda"
 if [ -z "$install_disk" ]; then
     install_disk="/dev/sda"


### PR DESCRIPTION
On a node whose OS disk is an Intel RSTe/VROC software RAID (`/dev/md/Volume0_0` or `/dev/md/Volume0`), disk auto-detection finds nothing and getinstdisk falls back to the hard-coded `/dev/sda`. Prefer the VROC volume over that default.

It only fires when no install disk was otherwise selected **and** the VROC device actually exists, so it cannot mis-select over a real disk and has no effect on non-VROC systems.

The original commit hooked into a lenovobuild-specific "thinksystem m.2" detection block that isn't in master; this is adapted to master's own fallback point (right before the `/dev/sda` default).

Not lab-validated (no VROC hardware available).

Recovered from the unmerged lenovobuild branch (c6c70e5).
