### PR TITLE
fix(genesis): find the boot NIC over InfiniBand (IPoIB)

### DIFF
--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -51,6 +51,8 @@ BuildRequires: ipmitool
 BuildRequires: iproute
 BuildRequires: kexec-tools
 BuildRequires: kernel-core
+BuildRequires: kernel-modules
+BuildRequires: kernel-modules-extra
 BuildRequires: lldpad
 BuildRequires: lvm2
 BuildRequires: mdadm

--- a/xCAT-genesis-scripts/usr/bin/doxcat
+++ b/xCAT-genesis-scripts/usr/bin/doxcat
@@ -32,6 +32,7 @@ logger -s -t $log_label -p local4.info "Beginning doxcat process..."
 
 modprobe acpi_cpufreq 2>/dev/null		# on some machines this fails
 modprobe cpufreq_ondemand
+modprobe ib_ipoib
 if ls /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor &>/dev/null; then
     if grep -q ondemand /sys/devices/system/cpu/cpu*/cpufreq/scaling_available_governors; then
         for gov in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
@@ -41,10 +42,14 @@ if ls /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor &>/dev/null; then
 fi
 if [ ! -z "$BOOTIF" ]; then
 	BOOTIF=`echo $BOOTIF|sed -e s/01-// -e s/-/:/g`
+	IBOOTIF=`echo $BOOTIF|sed -e s/^..//`
 	logger -s -t $log_label -p local4.info "Waiting for device with address $BOOTIF to appear.."
 	gripeiter=6000
 	while [ -z "$bootnic" ]; do
 		bootnic=`ip link show|grep -B1 $BOOTIF|grep mtu|awk '{print $2}'|sed -e 's/:$//'`
+		if [ -z "$bootnic" ]; then
+			bootnic=`ip link show|grep -B1 infiniband|grep -B1 $IBOOTIF|grep mtu|awk '{print $2}'|sed -e 's/:$//'`
+		fi
 		sleep 0.1
 		if [ $gripeiter = 0 ]; then
 			logger -s -t $log_label -p local4.err "Unable to find boot device (Maybe the xCAT genesis kernel is missing the driver for your NIC?)"

--- a/xCAT-test/unit/genesis_ib_modules.t
+++ b/xCAT-test/unit/genesis_ib_modules.t
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use File::Spec;
+use FindBin;
+use Test::More;
+
+my $repo_root = File::Spec->rel2abs(File::Spec->catdir($FindBin::Bin, '..', '..'));
+
+my $spec = read_file('xCAT-genesis-builder/xCAT-genesis-base.spec');
+like($spec, qr/^BuildRequires:\s+kernel-core$/m, 'genesis build installs the kernel core');
+like($spec, qr/^BuildRequires:\s+kernel-modules$/m, 'genesis build installs the standard kernel modules');
+like($spec, qr/^BuildRequires:\s+kernel-modules-extra$/m, 'genesis build installs the extra kernel modules');
+
+my $dracut_module = read_file('xCAT-genesis-builder/dracut_105/el/module-setup.sh');
+like(
+    $dracut_module,
+    qr/installkernel\(\) \{.*?modules_dep=.*?while IFS= read -r modfile;.*?instmods "\$modname".*?done < "\$modules_dep"/s,
+    'genesis dracut module installs every module available to the build'
+);
+
+my $doxcat = read_file('xCAT-genesis-scripts/usr/bin/doxcat');
+like($doxcat, qr/^modprobe ib_ipoib$/m, 'genesis loads the IP over InfiniBand module');
+like(
+    $doxcat,
+    qr/if \[ -z "\$bootnic" \]; then\s+bootnic=`ip link show\|grep -B1 infiniband/s,
+    'genesis checks InfiniBand addresses only after the Ethernet lookup misses'
+);
+
+done_testing();
+
+sub read_file {
+    my ($file) = @_;
+    my $path = File::Spec->catfile($repo_root, split m{/}, $file);
+    open(my $fh, '<', $path) or die "open $path: $!";
+    my $contents = do { local $/; <$fh> };
+    close($fh) or die "close $path: $!";
+    return $contents;
+}


### PR DESCRIPTION
When a node boots from an InfiniBand interface, doxcat could not match `BOOTIF` to the netdev, so boot-NIC detection failed. Load `ib_ipoib` and, if the normal Ethernet lookup finds nothing, fall back to matching the InfiniBand device by its (shorter) IPoIB address.

`modprobe ib_ipoib` is harmless where there is no IB hardware (the module simply loads no devices), and the IB lookup only runs when the Ethernet lookup fails — so non-IB nodes are unaffected.

Not lab-validated (no InfiniBand fabric available).

Recovered from the unmerged lenovobuild branch (aeeebd5f).
