### PR TITLE
fix(esx): stage esxboot-x64.efi from the install media if missing

### DIFF
--- a/xCAT-server/lib/xcat/plugins/esx.pm
+++ b/xCAT-server/lib/xcat/plugins/esx.pm
@@ -5010,6 +5010,11 @@ sub mkcommonboot {
             xCAT::SvrUtils::sendmsg([ 1, "Please run copycds first for $osver or create custom image in $custprofpath/" ], $output_handler);
         }
 
+        # If the ESXi UEFI boot loader was not staged, copy it from the install media
+        if (not -r "$tftpdir/xcat/esxboot-x64.efi" and -r "$installroot/$osver/$arch/efi/boot/bootx64.efi") {
+            copy("$installroot/$osver/$arch/efi/boot/bootx64.efi", "$tftpdir/xcat/esxboot-x64.efi");
+        }
+
         my @reqmods = qw/vmkboot.gz vmk.gz sys.vgz cim.vgz/; #Required modules for an image to be considered complete
         if (-r "$custprofpath/b.z") { #if someone hand extracts from imagedd, a different name scheme is used
             @reqmods = qw/b.z k.z s.z c.z/;


### PR DESCRIPTION
UEFI ESXi netboot needs `esxboot-x64.efi` under `$tftpdir/xcat`. When it wasn't already staged, `mkcommonboot` left it missing; copy it from the install media's `efi/boot/bootx64.efi` if that exists and the target doesn't.

Additive and ESXi-only (`esx.pm` `mkcommonboot`): it only copies when the target is absent and the source is present, so nothing else is affected.

**Note:** the original commit also *removed* a `bootmode ne "install"` guard whose own comment warns "installer croaks currently". That hunk is intentionally **left out** — it changes ESXi install-time serial behavior and carries a regression risk. Only the additive esxboot copy is included here.

Not lab-validated (no ESXi provisioning environment available).

Recovered from the unmerged lenovobuild branch (6931200d, esxboot hunk only).
