### PR TITLE
fix(ipmi): never rate-limit packets to an FPC during reseat

### DIFF
--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -1203,7 +1203,7 @@ sub sendpayload {
             #push integrity data
         }
     }
-    unless ($args{nowait} or $self->{nowait}) { #if nowait indicated, the packet will be sent regardless of maxpending
+    unless ($args{nowait} or $self->{nowait} or $self->{neverwait}) { #if nowait indicated, the packet will be sent regardless of maxpending
          #primary use case would be retries that should represent no delta to pending sessions in aggregate and therefore couldn't exceed maxpending anywy
          #if we did do this on timedout, waitforrsp may recurse, which is a complicated issue.  Theoretically, if waitforrsp protected itself, it
          #would act the same, but best be explicit about nowait if practice does not match theory

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2753,7 +2753,7 @@ sub reseat_node {
 		    data => [ $sessdata->{slotnumber}, 2 ],
 		    callback => \&fpc_node_reseat_complete, callback_args => $sessdata);
 	} else {
-            $sessdata->{fpcipmisession} = xCAT::IPMI->new(bmc => $mpent->{mpa}, userid => $nodeuser, password => $nodepass);
+            $sessdata->{fpcipmisession} = xCAT::IPMI->new(bmc => $mpent->{mpa}, userid => $nodeuser, password => $nodepass, neverwait => 1);
 	    $fpcsessions{$mpent->{mpa}} = $sessdata->{fpcipmisession};
             $sessdata->{fpcipmisession}->login(callback => \&fpc_node_reseat, callback_args => $sessdata);
         }


### PR DESCRIPTION
`reseat_node` opens an IPMI session to the FPC/CMM to reseat a node. The FPC needs packets sent without maxpending flow-control, but that state was only held transiently. Add a persistent per-session `neverwait` flag, set it on the FPC reseat session, and honor it in `sendpayload`.

The flag defaults off, so it's a **no-op for every other IPMI session** — only the FPC reseat path opts in.

**Note:** the lenovobuild original also removed the `nowait` setup in the shared `login`/`admin_level_set`, which would change IPMI flow-control for *all* BMCs. That part is intentionally **left out**; only the flag-gated `neverwait` addition is included, and it works alongside master's existing `nowait`.

Not lab-validated (no NeXtScale FPC/CMM available).

Recovered from the unmerged lenovobuild branch (eda85df3, neverwait hunks only).
