### PR TITLE
fix(MacMap): discover nodes on Cumulus breakout ports (swpNsM)

### DIFF
--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -733,29 +733,11 @@ sub refresh_switch {
             }
         }else{
             foreach (@res){
-                if($_ =~ m/^([0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}) dev swp([0-9]+) vlan ([0-9]+) .*/){
+                if($_ =~ m/^([0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}) dev (swp[^ ]+) vlan ([0-9]+) .*/){
                     $mymac=$1;
                     $myport=$2;
-                    $myport=sprintf("%d",$myport);
                     my $macport=$2;
                     my $macvlan=$3;
-
-                    #try all the possible port number formats
-                    #e.g, "5","swp5","05","swp05"
-                    unless(exists $self->{switches}->{$switch}->{$myport}){
-                        if(exists $self->{switches}->{$switch}->{"swp".$myport}){
-                            $myport="swp".$myport;
-                        }else{
-                            $myport=sprintf("%02d",$myport);
-                            unless(exists $self->{switches}->{$switch}->{$myport}){
-                                if(exists $self->{switches}->{$switch}->{"swp".$myport}){
-                                    $myport="swp".$myport;
-                                }else{
-                                    $myport="";
-                                }
-                            }
-                        }
-                    }
 
                     if($myport){
                         if($output){


### PR DESCRIPTION
Cumulus switch MAC discovery matched the fdb port with a regex that only accepted a plain numeric swp name (`dev swp([0-9]+)`), then guessed among `swp5`/`05`/`swp05` formats. A node on a **breakout port** (`swp1s0`, `swp1s1`, …) never matched, so it was silently not discovered. Match any swp name (`dev (swp[^ ]+)`) and use it directly, dropping the format-guessing.

**Gated — no cross-system risk.** This whole block runs only inside `if switchtype eq 'onie'` (Cumulus/ONIE switches); SNMP switches use a separate path and are unaffected.

**Validated** against real `bridge fdb show` output — the stock iproute2 command Cumulus runs over SSH:
```
44:38:39:00:00:01 dev swp1   vlan 100 master br0 static   <- old & new: parsed
44:38:39:00:00:02 dev swp1s0 vlan 100 master br0 static   <- old: DROPPED, new: parsed
```
The environment was confirmed on a booted NVIDIA Cumulus VX 5.10.

Recovered from the unmerged lenovobuild branch (72d68bc7).
