### PR TITLE
fix(bmcsetup): settle after IBM port change and support long BMC passwords

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -196,6 +196,7 @@ if [ "$IPMIMFG" == 2 ]; then #IBM
                     # Get the LAN Configuration Parameters (OEM)
                     CURBMCPORT=`ipmitool -d $idev raw 0xc 2 1 0xc0 0 0 | awk '{print $2}'`
                 done
+                sleep 15
                 let idev=idev+1
             done
             unset IFS
@@ -219,6 +220,7 @@ if [ "$IPMIMFG" == 2 ]; then #IBM
                         sleep 1
                         CURBMCPORT=`ipmitool -d $idev raw 0xc 2 1 0xc0 0 0 | awk '{print $2}'`
                     done
+                    sleep 15
                     let idev=idev+1
                 done
                 unset IFS
@@ -600,8 +602,12 @@ for bmcp in $BMCPW; do
     if [ "$bmcp" = "" ]; then continue; fi
 
     TRIES=0
-    # Set the password for the specified user
-    while ! ipmitool -d $idev user set password $USERSLOT "$bmcp"; do
+    # Set the password for the specified user. A password longer than 16 chars
+    # needs the 20-byte IPMI 2.0 form; shorter ones use the default so a
+    # 16-byte-only BMC is not asked for a length it cannot store.
+    PWSIZE=""
+    if [ ${#bmcp} -gt 16 ]; then PWSIZE=20; fi
+    while ! ipmitool -d $idev user set password $USERSLOT "$bmcp" $PWSIZE; do
         sleep 1
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi


### PR DESCRIPTION
Two small robustness fixes for bmcsetup:

- **IBM port-change settle** — after changing the BMC network port on IBM boards (`IPMIMFG 2`), the BMC LAN configuration wasn't yet ready; add a 15s settle before continuing. Gated inside the IBM branch, so no other vendor is affected.
- **Long BMC passwords** — set a password longer than 16 characters using ipmitool's 20-byte form, but **only when the password actually exceeds 16 chars**, so a BMC that supports only 16-byte passwords is never asked for a length it can't store. (The original forced the 20-byte form for every password, which is the shared-path risk; this adapts it to be length-gated.)

Not lab-validated (no IBM BMC available); the IBM sleep is vendor-gated and the password change is length-gated.

Recovered from the unmerged lenovobuild branch (949532f3, 78fa7758).
