### PR TITLE
fix(blade): only scan a node MPA during discovery if it is a blade

### DIFF
--- a/xCAT-server/lib/xcat/plugins/blade.pm
+++ b/xCAT-server/lib/xcat/plugins/blade.pm
@@ -4258,6 +4258,9 @@ sub preprocess_request {
     foreach my $node (@$noderange) {
         my $ent = $mptabhash->{$node}->[0]; #$mptab->getNodeAttribs($node,['mpa', 'id']);
         my $mpaent;
+        if ($request->{command}->[0] eq 'findme' and $ent->{nodetype} ne 'blade') {
+            next;
+        }
         if (defined($ent->{mpa})) {
             push @{ $mpa_hash{ $ent->{mpa} }{nodes} }, $node;
             unless ($mpatype{ $ent->{mpa} }) {


### PR DESCRIPTION
`blade.pm`'s `preprocess_request` iterates the `mp` table during `findme` discovery. Because many node types populate the mp table, non-blade nodes were being scanned as if they were BladeCenter/Flex blades. Skip a node during `findme` unless its `nodetype` is `blade`.

Scoped to `blade.pm`'s findme path and gated on `nodetype`, so only blade discovery is affected. (Master's other `findme` check — the already-processed short-circuit for the whole request — is a **separate** concern and is unchanged; this is a per-node guard, so it's not superseded by it.)

Not lab-validated (no BladeCenter/Flex MPA available).

Recovered from the unmerged lenovobuild branch (6573d8f9).
