### PR TITLE
fix(postscripts): schedule the reboot with a systemd timer on SUSE

### DIFF
--- a/xCAT/postscripts/reboot
+++ b/xCAT/postscripts/reboot
@@ -3,7 +3,14 @@
 #(C)IBM Corp
 #
 
-(sleep 75;/sbin/reboot) &
+# On SUSE the backgrounded "sleep then reboot" can fire while the installer is
+# still finishing and reboot the node mid-install. Schedule the reboot with a
+# systemd timer there instead, which the installer teardown does not race.
+if grep NAME /etc/os-release | egrep '(SLE|SUSE)' > /dev/null && [ -x /usr/bin/systemd-run ]; then
+    systemd-run --on-active=90 --timer-property=AccuracySec=10s /sbin/reboot
+else
+    (sleep 75;/sbin/reboot) &
+fi
 
 exit 0
 


### PR DESCRIPTION
The `reboot` postscript backgrounds `(sleep 75; /sbin/reboot) &`. On SUSE that can fire while the installer is still finishing, rebooting the node mid-install. Use a systemd timer (`systemd-run --on-active=90 /sbin/reboot`) on SUSE, which the installer teardown doesn't race; EL and Ubuntu keep the existing backgrounded sleep.

Gated on SUSE **and** the presence of `systemd-run`, so no other platform changes behavior.

Recovered from the unmerged lenovobuild branch (`6785eb3a`, `4fe2a72c`, `ac04f5ad` — net effect, consolidated; the vendor copyright comment from the originals is dropped).
