### PR TITLE
fix(sle): give the SUSE root partition the whole disk (align with RHEL/Ubuntu)

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/pre.sle
+++ b/xCAT-server/share/xcat/install/scripts/pre.sle
@@ -193,7 +193,7 @@ fi
 
 msgutil_r "$MASTER_IP" "info" "Found $instdisk, generate partition file..." "/var/log/xcat/xcat.log" "$log_label"
 if [ -d /sys/firmware/efi ]; then
-	sed -e 's!<device>XCATPARTITIONHOOK</device>!<device>'$instdisk'</device><partitions config:type="list"><partition><filesystem config:type="symbol">vfat</filesystem><mount>/boot/efi</mount><size>128mb</size></partition><partition><mount>swap</mount><size>auto</size></partition><partition><mount>/</mount><size>auto</size></partition></partitions>!' /tmp/profile/autoinst.xml > /tmp/profile/modified.xml
+	sed -e 's!<device>XCATPARTITIONHOOK</device>!<device>'$instdisk'</device><partitions config:type="list"><partition><filesystem config:type="symbol">vfat</filesystem><mount>/boot/efi</mount><size>128mb</size></partition><partition><mount>swap</mount><size>auto</size></partition><partition><mount>/</mount><size>max</size></partition></partitions>!' /tmp/profile/autoinst.xml > /tmp/profile/modified.xml
 else
 	sed -e 's!<device>XCATPARTITIONHOOK</device>!<device>'$instdisk'</device>!' /tmp/profile/autoinst.xml > /tmp/profile/modified.xml
 fi


### PR DESCRIPTION
The SLE AutoYaST profile sized the root partition with `<size>auto</size>`, which lets YaST pick a size and can leave the rest of the disk unused. Both other supported distros give root the whole disk — RHEL uses `part / --grow`, Ubuntu "uses the rest of the space for the root partition" — so this makes SUSE consistent with `<size>max</size>`. Swap stays `auto`.

SLE-only (`pre.sle`), so no other distro is affected.

Recovered from the unmerged lenovobuild branch (9a8679f4).
