### PR TITLE
fix(xnba): warn instead of failing when pxelinux.0 is unavailable

### DIFF
--- a/docs/source/advanced/mixed_cluster/power/diskless.rst
+++ b/docs/source/advanced/mixed_cluster/power/diskless.rst
@@ -4,12 +4,11 @@ Provision x86 Diskless
 Troubleshooting
 ---------------
 
-**Error:** The following Error message comes out when running nodeset: ::
+**Warning:** The following warning appears when ``nodeset`` generates a configuration that chains pxelinux: ::
 
-    Error: Unable to find pxelinux.0 at /opt/xcat/share/xcat/netboot/syslinux/pxelinux.0
+    Warning: Unable to find pxelinux.0 from syslinux; nodes whose xNBA configuration chains pxelinux will not boot until it is available
 
 **Resolution:**
 
 The syslinux network booting files are missing.
-Install the sylinux-xcat package provided in the xcat-deps repository: ``yum -y install syslinux-xcat``
-
+Install the syslinux-xcat package provided in the xcat-deps repository: ``yum -y install syslinux-xcat``

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -762,16 +762,15 @@ sub process_request {
 
     #back to normal business
     if (!-r "$globaltftpdir/xcat/pxelinux.0") {
-        unless (-r $::XCATROOT . "/share/xcat/netboot/syslinux/pxelinux.0") {
-            $::XNBA_callback->({ error => [ "Unable to find pxelinux.0 at " . $::XCATROOT . "/share/xcat/netboot/syslinux/pxelinux.0" ], errorcode => [1] });
-            return;
+        if (-r $::XCATROOT . "/share/xcat/netboot/syslinux/pxelinux.0") {
+            copy($::XCATROOT . "/share/xcat/netboot/syslinux/pxelinux.0", "$globaltftpdir/xcat/pxelinux.0");
+            chmod(0644, "$globaltftpdir/xcat/pxelinux.0");
         }
-        copy($::XCATROOT . "/share/xcat/netboot/syslinux/pxelinux.0", "$globaltftpdir/xcat/pxelinux.0");
-        chmod(0644, "$globaltftpdir/xcat/pxelinux.0");
     }
     unless (-r "$globaltftpdir/xcat/pxelinux.0") {
-        $::XNBA_callback->({ error => ["Unable to find pxelinux.0 from syslinux"], errorcode => [1] });
-        return;
+        # only legacy BIOS clients chain pxelinux, and not every distribution
+        # still ships syslinux, so warn instead of failing the whole request
+        $::XNBA_callback->({ warning => ["Unable to find pxelinux.0 from syslinux, legacy BIOS nodes that chain pxelinux will not boot until it is available"] });
     }
 
 

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -91,6 +91,14 @@ sub getstate {
     }
 }
 
+sub _requires_pxelinux {
+    my $kern = shift;
+    return 0 unless ($kern and ref($kern) eq 'HASH');
+
+    my $kernel = $kern->{kernel} || '';
+    return ($kernel =~ /!/ or $kernel =~ /\.c32\z/ or $kernel =~ /memdisk\z/) ? 1 : 0;
+}
+
 my %efistubcache;
 sub has_efistub {
     my $kern = shift;
@@ -285,6 +293,7 @@ sub setstate {
         close($pcfg);
         _write_uefi_exit_script($bootloader_root, $node, $cref->{currstate});
     } elsif ($kern and $kern->{kernel}) {
+        $::XNBA_pxelinux_required = 1 if (_requires_pxelinux($kern));
         if ($kern->{kernel} =~ /!/) { #TODO: deprecate this, do stateless Xen like stateless ESXi
             my $hypervisor;
             my $kernel;
@@ -610,6 +619,7 @@ sub process_request {
     $::XNBA_callback = shift;
     my $sub_req = shift;
     undef $::XNBA_addkcmdlinehandled;    # clear out any previous value
+    undef $::XNBA_pxelinux_required;
     my @args;
     my @rnodes;
     undef %failurenodes;
@@ -760,21 +770,6 @@ sub process_request {
         }
     }
 
-    #back to normal business
-    if (!-r "$globaltftpdir/xcat/pxelinux.0") {
-        if (-r $::XCATROOT . "/share/xcat/netboot/syslinux/pxelinux.0") {
-            copy($::XCATROOT . "/share/xcat/netboot/syslinux/pxelinux.0", "$globaltftpdir/xcat/pxelinux.0");
-            chmod(0644, "$globaltftpdir/xcat/pxelinux.0");
-        }
-    }
-    unless (-r "$globaltftpdir/xcat/pxelinux.0") {
-        # only legacy BIOS clients chain pxelinux, and not every distribution
-        # still ships syslinux, so warn instead of failing the whole request
-        $::XNBA_callback->({ warning => ["Unable to find pxelinux.0 from syslinux, legacy BIOS nodes that chain pxelinux will not boot until it is available"] });
-    }
-
-
-
     my $inittime = 0;
     if (exists($::XNBA_request->{inittime})) { $inittime = $::XNBA_request->{inittime}->[0]; }
     if (!$inittime) { $inittime = 0; }
@@ -843,6 +838,19 @@ sub process_request {
             }
         }
     }
+
+    if ($::XNBA_pxelinux_required) {
+        if (!-r "$globaltftpdir/xcat/pxelinux.0") {
+            if (-r $::XCATROOT . "/share/xcat/netboot/syslinux/pxelinux.0") {
+                copy($::XCATROOT . "/share/xcat/netboot/syslinux/pxelinux.0", "$globaltftpdir/xcat/pxelinux.0");
+                chmod(0644, "$globaltftpdir/xcat/pxelinux.0");
+            }
+        }
+        unless (-r "$globaltftpdir/xcat/pxelinux.0") {
+            $::XNBA_callback->({ warning => ["Unable to find pxelinux.0 from syslinux; nodes whose xNBA configuration chains pxelinux will not boot until it is available"] });
+        }
+    }
+
     xCAT::MsgUtils->trace($verbose_on_off, "d", "xnba: Finish to handle configurations");
 
     #dhcp stuff -- inittime is set when xcatd on sn is started

--- a/xCAT-test/unit/xnba_semicolon.t
+++ b/xCAT-test/unit/xnba_semicolon.t
@@ -34,4 +34,18 @@ like($src, qr/sub _use_efistub_for_uefi\b/, 'UEFI EFI-stub selection helper exis
 like($src, qr/sles\?11/, 'SLES 11 UEFI compatibility rule matches sle11 and sles11 images');
 like($src, qr/if \(_use_efistub_for_uefi\(\$kern\)\)/, 'UEFI boot path uses compatibility helper before direct EFI-stub boot');
 
+# pxelinux is only needed for multiboot, COMBOOT, and memdisk configurations.
+# Missing syslinux must not warn for ordinary direct-kernel nodeset requests.
+like($src, qr/sub _requires_pxelinux\b/, 'pxelinux requirement helper exists');
+like(
+    $src,
+    qr/\$::XNBA_pxelinux_required = 1 if \(_requires_pxelinux\(\$kern\)\)/,
+    'generated boot configuration records when pxelinux is required'
+);
+like(
+    $src,
+    qr/if \(\$::XNBA_pxelinux_required\) \{.*?Unable to find pxelinux\.0/s,
+    'missing pxelinux warning is limited to requests that generate a pxelinux chain'
+);
+
 done_testing();


### PR DESCRIPTION
`nodeset` aborts with "Unable to find pxelinux.0 from syslinux" when neither the copy under the tftp directory nor the one under `$XCATROOT` exists. Only legacy BIOS clients chain pxelinux, and not every distribution still ships syslinux, so a UEFI-only environment cannot run `nodeset` at all.

Copy pxelinux.0 when it is available, and warn rather than fail when it is not.

Recovered from the unmerged lenovobuild branch (4f0a5106), which skipped silently; this warns so the missing loader is still reported.
