### PR TITLE
fix(genimage): explain the harmless bus messages from the image chroot

### DIFF
--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -1007,6 +1007,10 @@ if ($dracutmode) {
     mkinitrd("stateless");
 }
 
+# systemd tooling run inside the image chroot has no bus to talk to, so it
+# complains even though the image builds correctly
+print "It is safe to ignore the message 'Failed to connect to bus: No such file or directory' that may have appeared above one or more times.\n";
+
 sub getlibs {
     my $file    = shift;
     my $liblist = `chroot $rootimg_dir ldd $file`;


### PR DESCRIPTION
systemd tooling run inside the image chroot has no bus to talk to and prints `Failed to connect to bus: No such file or directory`, sometimes several times. The image builds correctly, so say so at the end of the run instead of leaving it to be guessed.

Recovered from the unmerged lenovobuild branch (e372fb5b).
