### PR TITLE
fix(xcatserver): keep the server-provided cfgloc before rewriting host=

### DIFF
--- a/xCAT/postscripts/xcatserver
+++ b/xCAT/postscripts/xcatserver
@@ -169,6 +169,10 @@ if [ $? -ne 0 ]; then
       # if not DB2
       grep "DB2" /etc/xcat/cfgloc  2>&1 1> /dev/null
       if [ $? -ne 0 ]; then
+        # keep the server-provided copy: rewriting host= to $MASTER discards the
+        # database location the credentials came with, which is the only record
+        # of it when the database does not live on the management node
+        cp -p /etc/xcat/cfgloc /etc/xcat/cfgloc.orig
         sed s/host=[^\|]*/host=$MASTER/ /etc/xcat/cfgloc > /etc/xcat/cfgloc.new
         mv /etc/xcat/cfgloc.new /etc/xcat/cfgloc
       else # DB2 cfgloc has different format


### PR DESCRIPTION
`xcatserver` rewrites `host=` in the freshly fetched `/etc/xcat/cfgloc` to point at `$MASTER`, discarding the database location the credentials came with. That is the only record of it when the database does not live on the management node.

Keep the server-provided copy as `cfgloc.orig` before rewriting; the existing `chmod 600 /etc/xcat/cfgloc*` covers it.

Recovered from the unmerged lenovobuild branch (10090a9d). The original also replaced the atomic write with mv-then-sed, which leaves `cfgloc` truncated if the sed fails, so the write itself is left alone.
