### PR TITLE
fix(buildrpms): only write xCAT-release-latest alias when the rpm exists

### DIFF
--- a/buildrpms.pl
+++ b/buildrpms.pl
@@ -654,9 +654,13 @@ sub write_release_alias {
     my ($repodir) = @_;
     my $alias = "$repodir/xCAT-release-latest.noarch.rpm";
 
-    my @release_rpms = glob("$repodir/xCAT-release-$VERSION-$RELEASE.noarch.rpm");
+    # glob() returns a wildcard-free pattern verbatim even when the file does not exist, so
+    # guard on the rpm actually being present. Without this, a partial build that does not
+    # produce xCAT-release (e.g. buildrpms.pl --package xCAT-genesis-base) would try to cp a
+    # nonexistent rpm here and die.
+    my @release_rpms = grep { -f } glob("$repodir/xCAT-release-$VERSION-$RELEASE.noarch.rpm");
     if (@release_rpms == 1) {
-        cp $release_rpms[0], $alias;
+        cp $release_rpms[0], $alias or die "cp $release_rpms[0] -> $alias: $!";
         chmod 0644, $alias;
     }
 }


### PR DESCRIPTION
write_release_alias() finds the release rpm with
glob("$repodir/xCAT-release-$VERSION-$RELEASE.noarch.rpm"). That pattern has no wildcard, and glob() returns a wildcard-free pattern verbatim even when the file does not exist -- so @release_rpms == 1 is true and cp runs against a nonexistent file. A partial build that does not produce xCAT-release (e.g. buildrpms.pl --package xCAT-genesis-base, the way the xcat-dep pipeline builds the OS-dependent genesis image) then dies with:

  Can't cp('dist/alma+epel-8-x86_64/rpms/xCAT-release-2.19.0-snap202607261133.noarch.rpm',
    'dist/alma+epel-8-x86_64/rpms/xCAT-release-latest.noarch.rpm'):
    No such file or directory at .../buildrpms.pl line 659

Guard the alias write on the rpm actually existing (grep { -f }), and die with the real error if the cp itself fails. A build that does not produce xCAT-release now simply skips the alias instead of failing.