### PR TITLE
fix(xcat-core): drop trailing blank line in rhels9 ppc64le pkglist

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels9.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels9.ppc64le.pkglist
@@ -27,4 +27,3 @@ vim-minimal
 rpm
 iputils
 perl-interpreter
-


### PR DESCRIPTION
PR #7677 added xCAT-server/share/xcat/netboot/rh/compute.rhels9.ppc64le.pkglist with a stray empty line at the end of the file. The reviewer asked for it to be removed before merge, but it slipped through. A trailing blank line in a pkglist is meaningless and inconsistent with the rest of the netboot package lists, so remove it.
