### PR TITLE
fix(xcat-server): remove the unreachable deprecated provisioning paths

### DIFF
--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -287,40 +287,6 @@ sub setdestiny {
         if ($state ne 'osimage') {
             $callback->({ error => "The options \"install\", \"netboot\", and \"statelite\" have been deprecated, use \"osimage=<osimage_name>\" instead.", errorcode => [1], errorabort => [1] });
             return;
-
-            my $updateattribs;
-            if ($target) {
-                my $archentries = $nodetypetable->getNodesAttribs($req->{node}, ['supportedarchs']);
-                if ($target =~ /^([^-]*)-([^-]*)-(.*)/) {
-                    $updateattribs->{os}      = $1;
-                    $updateattribs->{arch}    = $2;
-                    $updateattribs->{profile} = $3;
-                    my $nodearch = $2;
-                    foreach (@{ $req->{node} }) {
-                        if ($archentries->{$_}->[0]->{supportedarchs} and $archentries->{$_}->[0]->{supportedarchs} !~ /(^|,)$nodearch(\z|,)/) {
-                            xCAT::MsgUtils->report_node_error($callback, $_,
-                                "Requested architecture " . $nodearch . " is not one of the architectures supported by $_  (per nodetype.supportedarchs, it supports " . $archentries->{$_}->[0]->{supportedarchs} . ")"
-                                );
-                            $failurenodes{$_} = 1;
-                            next;
-                        }
-                    }    #end foreach
-                } else {
-                    $updateattribs->{profile} = $target;
-                }
-            }    #end if($target)
-
-            $updateattribs->{provmethod} = $state;
-            my @tmpnodelist = ();
-            foreach (@{ $req->{node} }) {
-                if ($failurenodes{$_}) {
-                    delete $state_hash{$_};
-                    next;
-                }
-                push @tmpnodelist, $_;
-            }
-            $nodetypetable->setNodesAttribs(\@tmpnodelist, $updateattribs);
-
         } else {    #state is osimage
             if ($target) {
                 if (@{ $req->{node} } == 0) { return; }

--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -132,10 +132,6 @@ sub process_request {
 
     if (@ARGV > 0) {
         $imagename = $ARGV[0];
-        if ($arch or $osver or $profile) {
-            $callback->({ error => ["-o, -p and -a options are not allowed when a image name is specified."], errorcode => [1] });
-            return 1;
-        }
 
         # load the module in memory
         eval { require("$::XCATROOT/lib/perl/xCAT/Table.pm") };
@@ -186,21 +182,8 @@ sub process_request {
         $exlistloc = $ref1->{'exlist'};
         $destdir   = $ref1->{'rootimgdir'};
     } else {
-        $provmethod = "netboot";
-        unless ($osver) {
-            $callback->({ error => ["Please specify a os version with the -o flag"], errorcode => [1] });
-            return 1;
-        }
-        unless ($arch) {
-            $arch = `uname -m`;
-            chomp($arch);
-            $arch = "x86" if ($arch =~ /i.86$/);
-        }
-
-        unless ($profile) {
-            $callback->({ error => ["Please specify a profile name with -p flag"], errorcode => [1] });
-            return 1;
-        }
+        $callback->({ error => ["An image name is required, use 'packimage <osimage name>'."], errorcode => [1] });
+        return 1;
     }
 
     unless ($destdir) {
@@ -233,17 +216,6 @@ sub process_request {
         return 1;
     }
     my $oldpath = cwd();
-    unless ($imagename) {
-        $exlistloc = xCAT::SvrUtils->get_exlist_file_name("$installroot/custom/netboot/$distname", $profile, $osver, $arch);
-        unless ($exlistloc) { $exlistloc = xCAT::SvrUtils->get_exlist_file_name("$::XCATROOT/share/xcat/netboot/$distname", $profile, $osver, $arch); }
-
-        #save the settings into DB, it will not update if the image already exist
-        my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($osver, $arch, $profile, "netboot");
-        unless ($ret[0] eq 0) {
-            $callback->({ error => [ "Error when updating the osimage tables: " . $ret[1] ], errorcode => [1] });
-            return 1;
-        }
-    }
 
     #before generating rootimg.$suffix, copy $installroot/postscripts into the image at /xcatpost
     if (-e "$rootimg_dir/xcatpost") {

--- a/xCAT-test/unit/deprecated_provisioning_reachability.t
+++ b/xCAT-test/unit/deprecated_provisioning_reachability.t
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use File::Spec;
+use Test::More;
+
+my $repo_root = File::Spec->catdir( $FindBin::Bin, '..', '..' );
+
+sub slurp {
+    my ($rel) = @_;
+    my $path = File::Spec->catfile( $repo_root, $rel );
+    return unless -r $path;
+    open( my $fh, '<', $path ) or die "Unable to read $path: $!";
+    my $c = do { local $/; <$fh> };
+    close($fh);
+    return $c;
+}
+
+# Report statements that sit after an unconditional return inside the same
+# block. Those are unreachable, which is how the deprecated provisioning paths
+# survived in the tree for years after they stopped running.
+sub unreachable_after_return {
+    my ($source) = @_;
+    my @lines = split( /\n/, $source, -1 );
+    my @found;
+    for my $i ( 0 .. $#lines ) {
+        my ($indent) = $lines[$i] =~ /^(\s*)(?:return\s*;|return\s+\d+\s*;)\s*$/;
+        next unless defined $indent;
+        my $depth = length($indent);
+        for my $j ( $i + 1 .. $#lines ) {
+            my $next = $lines[$j];
+            next if $next =~ /^\s*$/ || $next =~ /^\s*#/;
+            my ($ni) = $next =~ /^(\s*)/;
+            last if length($ni) < $depth;
+            last if $next =~ /^\s*[}\]\)]/;
+            push @found, ( $j + 1 ) . ": $next";
+            last;
+        }
+    }
+    return @found;
+}
+
+my $destiny = slurp('xCAT-server/lib/xcat/plugins/destiny.pm');
+my $packimage = slurp('xCAT-server/lib/xcat/plugins/packimage.pm');
+
+plan skip_all => 'destiny.pm or packimage.pm not found'
+  unless defined($destiny) && defined($packimage);
+
+my @destiny_dead = unreachable_after_return($destiny);
+is_deeply( \@destiny_dead, [], 'destiny.pm has no statements after an unconditional return' );
+
+my @packimage_dead = unreachable_after_return($packimage);
+is_deeply( \@packimage_dead, [], 'packimage.pm has no statements after an unconditional return' );
+
+# The deprecated states must still be rejected. Removing the dead path below the
+# rejection must not remove the rejection itself.
+like(
+    $destiny,
+    qr/have been deprecated, use \\"osimage=/,
+    'the deprecated nodeset states are still rejected'
+);
+
+# packimage rejects -o, -p and -a up front, so nothing after that point can ask
+# for them again. The old no-imagename branch demanded -o, which could never be
+# supplied, and reported that as the error.
+unlike(
+    $packimage,
+    qr/Please specify a os version with the -o flag/,
+    'packimage no longer asks for an option it rejects earlier'
+);
+like(
+    $packimage,
+    qr/-o, -p and -a options are obsoleted/,
+    'packimage still rejects the deprecated options'
+);
+like(
+    $packimage,
+    qr/An image name is required/,
+    'packimage reports the missing image name instead'
+);
+
+done_testing();


### PR DESCRIPTION
`setdestiny` reports the deprecated install, netboot and statelite states and returns. The legacy path below that return has not run since 57aa41798.

`packimage` rejects `-o`, `-p` and `-a` up front, which strands three things below it. The branch for a missing image name asks for `-o`:

    $ packimage -o rhels9 -a x86_64 -p compute
    Error: -o, -p and -a options are obsoleted, please use 'packimage <osimage name>' instead.

    $ packimage
    Error: Please specify a os version with the -o flag

It now reports the missing image name. The other two cannot be entered and are removed.

With xCAT 2.18.2: the deprecated states are still rejected, and `nodeset <node> osimage=<name>` and `packimage <osimage name>` are unchanged.