### PR TITLE
build(packaging): report a failed mknb at the end of an upgrade

### DIFF
--- a/xCAT/debian/postinst
+++ b/xCAT/debian/postinst
@@ -37,7 +37,19 @@ case "$1" in
             fi
             mkdir -p /var/log/xcat
             date >> /var/log/xcat/upgrade.log
-            xcatconfig -u -V >> /var/log/xcat/upgrade.log
+            xcatupgradeout=$(mktemp /tmp/xcat-upgrade.XXXXXX)
+            xcatconfig -u -V > "$xcatupgradeout" 2>&1
+            cat "$xcatupgradeout" >> /var/log/xcat/upgrade.log
+
+            # xcatconfig reports a failed mknb into the log, where an upgrade
+            # scrolls past it and the node is left without a genesis image for
+            # no apparent reason. Repeat it on the terminal. Only this run is
+            # examined, since the log is appended to.
+            if grep -q "command returned error code" "$xcatupgradeout"; then
+                echo "WARNING: mknb did not complete, so the Genesis netboot image may be missing or out of date."
+                echo "         See /var/log/xcat/upgrade.log, then rerun 'mknb <arch>' once the cause is resolved."
+            fi
+            rm -f "$xcatupgradeout"
             rm /tmp/xCAT_upgrade.tmp
         else
             xcatconfig -i

--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -264,7 +264,18 @@ fi
 
 mkdir -p /var/log/xcat
 date >> /var/log/xcat/upgrade.log
-$RPM_INSTALL_PREFIX0/sbin/xcatconfig -u -V >> /var/log/xcat/upgrade.log 2>&1
+xcatupgradeout=$(mktemp /tmp/xcat-upgrade.XXXXXX)
+$RPM_INSTALL_PREFIX0/sbin/xcatconfig -u -V > "$xcatupgradeout" 2>&1
+cat "$xcatupgradeout" >> /var/log/xcat/upgrade.log
+
+# xcatconfig reports a failed mknb into the log, where an upgrade scrolls past
+# it and the node is left without a genesis image for no apparent reason. Repeat
+# it on the terminal. Only this run is examined, since the log is appended to.
+if grep -q "command returned error code" "$xcatupgradeout"; then
+    echo "WARNING: mknb did not complete, so the Genesis netboot image may be missing or out of date."
+    echo "         See /var/log/xcat/upgrade.log, then rerun 'mknb <arch>' once the cause is resolved."
+fi
+rm -f "$xcatupgradeout"
 
 # The package replaces xcat.conf before this upgrade path runs.  Reload an
 # active web server so the new security headers and ServerTokens setting take

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -256,7 +256,10 @@ if [ -f "/proc/cmdline" ] && [ "x$(stat -c '%i %d' /)" == "x$(stat -c '%i %d' /p
     if [ "$SHAREDTFTP" != "1" ]; then
       . /etc/profile.d/xcat.sh
       echo Running '"'mknb `uname -m`'"', triggered by the installation/update of xCAT-genesis-scripts-x86_64 ...
-      mknb `uname -m`
+      if ! mknb `uname -m`; then
+        echo "WARNING: mknb did not complete, so the Genesis netboot image may be missing or out of date."
+        echo "         Rerun 'mknb `uname -m`' once the cause is resolved."
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
Upgrading xCAT regenerates the Genesis netboot image with mknb. When that fails, for example because the filesystem filled, the upgrade completes and says nothing, leaving the node without a current image for no visible reason.

On a management node `xcatconfig` already checks what mknb returned, but the upgrade sends its output to `/var/log/xcat/upgrade.log` where the line scrolls past. Repeat it on the terminal, in both the rpm and the Debian packaging. Only the current run is examined, since that log is appended to across upgrades.

A service node runs mknb directly rather than through `xcatconfig`, and nothing looked at what it returned at all, so add that check too.

Checked with real package builds and upgrades: rpm on a management node and on a service node, and dpkg on Ubuntu 24.04 where the maintainer script runs under dash. In each case a failing mknb warns and a succeeding one stays quiet, including when an earlier failure is still present in the log.

Inspired by cc8aec5ac on the unmerged lenovobuild branch, which reported the same problem on the management node only.