### PR TITLE
fix(ci): make package validation noninteractive

### DIFF
--- a/.github/workflows/xcat_test.yml
+++ b/.github/workflows/xcat_test.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
-        run: sudo apt-get install -y --no-install-recommends --no-install-suggests build-essential fakeroot reprepro devscripts debhelper libcapture-tiny-perl libjson-perl libsoap-lite-perl libdbi-perl libcgi-pm-perl quilt openssh-server dpkg looptools genometools software-properties-common
+        run: sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests build-essential fakeroot reprepro devscripts debhelper libcapture-tiny-perl libjson-perl libsoap-lite-perl libdbi-perl libcgi-pm-perl quilt openssh-server dpkg looptools genometools software-properties-common
       - name: Run tests
         run: perl github_action_xcat_test.pl

--- a/github_action_xcat_test.pl
+++ b/github_action_xcat_test.pl
@@ -475,6 +475,7 @@ sub check_syntax{
         foreach my $file (@files) {
             next if($file =~ /\/opt\/xcat\/share\/xcat\/netboot\/genesis\//);
             next if($file =~ /\/opt\/xcat\/probe\//);
+            next if($file =~ /\/opt\/xcat\/share\/xcat\/tools\/autotest\/unit\//);
 
             @output = runcmd("file $file");
             if($output[0] =~ /perl /i){

--- a/github_action_xcat_test.pl
+++ b/github_action_xcat_test.pl
@@ -369,7 +369,7 @@ sub install_xcat{
         }
     }
 
-    my $cmd = "sudo apt-get install xcat --allow-remove-essential --allow-unauthenticated";
+    my $cmd = "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y xcat --allow-remove-essential --allow-unauthenticated";
     @output = runcmd("$cmd");
     if($::RUNCMD_RC){
         my $lastline = $output[-1];
@@ -404,7 +404,7 @@ sub install_xcat{
                print "[install_xcat] $cmd....[Pass]\n";
             }
         }
-        $cmd = "sudo apt-get install xcat-probe --allow-remove-essential --allow-unauthenticated";
+        $cmd = "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y xcat-probe --allow-remove-essential --allow-unauthenticated";
         @output = runcmd("$cmd");
         if($::RUNCMD_RC){
             print RED "[install_xcat] $cmd ....[Failed]\n";
@@ -509,7 +509,7 @@ sub check_syntax{
 # Return code:
 #--------------------------------------------------------
 sub run_fast_regression_test{
-    my $cmd = "sudo apt-get install xcat-test --allow-remove-essential --allow-unauthenticated";
+    my $cmd = "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y xcat-test --allow-remove-essential --allow-unauthenticated";
     my @output = runcmd("$cmd");
     if($::RUNCMD_RC){
          print RED "[run_fast_regression_test] $cmd ....[Failed]\n";

--- a/xCAT-test/unit/github_action_noninteractive_install.t
+++ b/xCAT-test/unit/github_action_noninteractive_install.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use File::Spec;
+use FindBin;
+use Test::More;
+
+my $script = File::Spec->catfile(
+    $FindBin::Bin, '..', '..', 'github_action_xcat_test.pl'
+);
+open( my $fh, '<', $script ) or die "Unable to read $script: $!";
+my $contents = do { local $/; <$fh> };
+close($fh);
+
+for my $package (qw(xcat xcat-probe xcat-test)) {
+    like(
+        $contents,
+        qr{sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \Q$package\E\b},
+        "$package installation is noninteractive"
+    );
+}
+
+unlike( $contents, qr{yes\s*\|\s*(?:sudo\s+)?apt-get},
+    'package input is not piped into maintainer scripts' );
+
+done_testing();

--- a/xCAT-test/unit/github_action_noninteractive_install.t
+++ b/xCAT-test/unit/github_action_noninteractive_install.t
@@ -13,6 +13,14 @@ open( my $fh, '<', $script ) or die "Unable to read $script: $!";
 my $contents = do { local $/; <$fh> };
 close($fh);
 
+my $workflow = File::Spec->catfile(
+    $FindBin::Bin, '..', '..', '.github', 'workflows', 'xcat_test.yml'
+);
+open( my $workflow_fh, '<', $workflow )
+  or die "Unable to read $workflow: $!";
+my $workflow_contents = do { local $/; <$workflow_fh> };
+close($workflow_fh);
+
 for my $package (qw(xcat xcat-probe xcat-test)) {
     like(
         $contents,
@@ -23,5 +31,11 @@ for my $package (qw(xcat xcat-probe xcat-test)) {
 
 unlike( $contents, qr{yes\s*\|\s*(?:sudo\s+)?apt-get},
     'package input is not piped into maintainer scripts' );
+
+like(
+    $workflow_contents,
+    qr{sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y\b},
+    'workflow dependency installation is noninteractive'
+);
 
 done_testing();

--- a/xCAT-test/unit/github_action_noninteractive_install.t
+++ b/xCAT-test/unit/github_action_noninteractive_install.t
@@ -38,4 +38,10 @@ like(
     'workflow dependency installation is noninteractive'
 );
 
+like(
+    $contents,
+    qr{next if\(\$file =~ /\\/opt\\/xcat\\/share\\/xcat\\/tools\\/autotest\\/unit\\//\);},
+    'installed source-layout tests are excluded from syntax checks'
+);
+
 done_testing();


### PR DESCRIPTION
- make Ubuntu package and dependency installs noninteractive
- keep source-layout unit tests out of the installed-tree syntax scan

The syntax scan was compiling unit tests from `/opt/xcat`, where their source fixtures do not exist. The unit suite still runs from the preserved checkout.