### PR TITLE
fix(mknb): render Genesis boot paths correctly

### DIFF
--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -42,8 +42,9 @@ sub process_request {
     my $serialspeed;
     my $serialflow;
     my %nobootnicips = ();
-    my $initrd_file = undef;
-    my $xcatdport   = 3001;
+    my $initrd_file    = undef;
+    my $invisibletouch = 0;
+    my $xcatdport      = 3001;
     my @entries     = xCAT::TableUtils->get_site_attribute("defserialport");
     my $t_entry     = $entries[0];
     if (defined($t_entry)) {
@@ -202,7 +203,6 @@ sub process_request {
         mkpath("$tftpdir/xcat");
     }
     my $rc;
-    my $invisibletouch = 0;
     if (-e "$::XCATROOT/share/xcat/netboot/genesis/$arch") {
         $rc = system("shopt -s dotglob; GLOBIGNORE=\".:..\" cp -a $::XCATROOT/share/xcat/netboot/genesis/$arch/fs/* $tempdir");
         $rc = system("cp -a $::XCATROOT/share/xcat/netboot/genesis/$arch/kernel $tftpdir/xcat/genesis.kernel.$arch");
@@ -292,8 +292,10 @@ sub process_request {
         }
         if (-e "$tftpdir/xcat/genesis.fs.$arch.lzma") {
             $initrd_file = "$tftpdir/xcat/genesis.fs.$arch.lzma";
+            $invisibletouch = 1;
         } elsif (-e "$tftpdir/xcat/genesis.fs.$arch.gz") {
             $initrd_file = "$tftpdir/xcat/genesis.fs.$arch.gz";
+            $invisibletouch = 1;
         } elsif (-e "$tftpdir/xcat/nbfs.$arch.gz") {
             $initrd_file = "$tftpdir/xcat/nbfs.$arch.gz";
         } else {
@@ -443,11 +445,13 @@ sub process_request {
             }
         }
         if ($dopxe) {
-            my ($ignored, $tftp_initrd) = split /\/tftpboot\//, $initrd_file, 2;
+            my $tftp_initrd = $initrd_file;
+            $tftp_initrd =~ s{^\Q$tftpdir\E/?}{};
+            my $kernel_file = $invisibletouch ? "genesis.kernel.$arch" : "nbk.$arch";
             open($cfgfile, ">", "$tftpdir/pxelinux.cfg/" . uc($_));
             print $cfgfile "DEFAULT xCAT\n";
             print $cfgfile "  LABEL xCAT\n";
-            print $cfgfile "  KERNEL xcat/nbk.$arch\n";
+            print $cfgfile "  KERNEL xcat/$kernel_file\n";
             print $cfgfile "  APPEND initrd=$tftp_initrd xcatd=" . $xcatd_address . ":$xcatdport $consolecmdline\n";
             close($cfgfile);
         } elsif ($arch =~ /ppc/) {

--- a/xCAT-test/unit/mknb_xcatd_address.t
+++ b/xCAT-test/unit/mknb_xcatd_address.t
@@ -116,16 +116,22 @@ is_deeply(
 );
 
 sub prepare_tftpdir {
-    my ($root, $name, $arch) = @_;
+    my ($root, $name, $arch, $image_type) = @_;
+    $image_type //= 'genesis';
     $xCAT::TableUtils::tftpdir = "$root/$name";
     make_path(
         "$xCAT::TableUtils::tftpdir/xcat",
         "$xCAT::TableUtils::tftpdir/etc",
     );
-    foreach my $file (
-        "$xCAT::TableUtils::tftpdir/xcat/genesis.kernel.$arch",
-        "$xCAT::TableUtils::tftpdir/xcat/genesis.fs.$arch.gz",
-    ) {
+    my @files = ("$xCAT::TableUtils::tftpdir/xcat/genesis.kernel.$arch");
+    if ($image_type eq 'legacy') {
+        push @files,
+          "$xCAT::TableUtils::tftpdir/xcat/nbk.$arch",
+          "$xCAT::TableUtils::tftpdir/xcat/nbfs.$arch.gz";
+    } else {
+        push @files, "$xCAT::TableUtils::tftpdir/xcat/genesis.fs.$arch.gz";
+    }
+    foreach my $file (@files) {
         open(my $fh, '>', $file) or die "Unable to create $file: $!";
         close($fh);
     }
@@ -186,6 +192,25 @@ prepare_tftpdir($tmpdir, 'tftpboot-x86', 'x86_64');
 my $responses = run_mknb('x86_64');
 generation_succeeded($responses, 'x86 configuration generation succeeds');
 
+my $genesis_pxe = read_config(
+    "$xCAT::TableUtils::tftpdir/pxelinux.cfg/C0A89"
+);
+like(
+    $genesis_pxe,
+    qr/^  KERNEL xcat\/genesis\.kernel\.x86_64$/m,
+    'PXELINUX selects the Genesis kernel',
+);
+like(
+    $genesis_pxe,
+    qr/^  APPEND initrd=xcat\/genesis\.fs\.x86_64\.gz /m,
+    'PXELINUX makes the Genesis initramfs relative to the configured TFTP root',
+);
+unlike(
+    $genesis_pxe,
+    qr/\Q$xCAT::TableUtils::tftpdir\E/,
+    'PXELINUX does not expose the configured TFTP root',
+);
+
 foreach my $relative_path (
     'xcat/xnba/nets/192.168.144.0_20',
     'pxelinux.cfg/C0A89',
@@ -202,6 +227,25 @@ foreach my $relative_path (
         "$relative_path does not use the later floating address as the xcatd endpoint",
     );
 }
+
+use_reporter_address_maps();
+prepare_tftpdir($tmpdir, 'tftpboot-x86-legacy', 'x86_64', 'legacy');
+$responses = run_mknb('x86_64');
+generation_succeeded($responses, 'legacy x86 configuration generation succeeds');
+
+my $legacy_pxe = read_config(
+    "$xCAT::TableUtils::tftpdir/pxelinux.cfg/C0A89"
+);
+like(
+    $legacy_pxe,
+    qr/^  KERNEL xcat\/nbk\.x86_64$/m,
+    'PXELINUX keeps the legacy kernel',
+);
+like(
+    $legacy_pxe,
+    qr/^  APPEND initrd=xcat\/nbfs\.x86_64\.gz /m,
+    'PXELINUX keeps the legacy initramfs path',
+);
 
 use_reporter_address_maps();
 prepare_tftpdir($tmpdir, 'tftpboot-power', 'ppc64');


### PR DESCRIPTION
mknb can generate an invalid PXELINUX entry when site.tftpdir is not /tftpboot, leaving the initramfs path empty. It also points existing Genesis images at xcat/nbk.<arch> instead of the Genesis kernel.

Use the configured TFTP root when deriving the initramfs path and select genesis.kernel.<arch> only when publishing a Genesis image. The legacy non-Genesis path remains unchanged.

Regression tests cover custom TFTP roots and both Genesis and legacy boot artifacts.