### PR TITLE
fix(dhcp): boot unknown xNBA clients with Kea

### DIFF
--- a/perl-xCAT/xCAT/DHCP/Backend/Kea.pm
+++ b/perl-xCAT/xCAT/DHCP/Backend/Kea.pm
@@ -813,7 +813,8 @@ sub _render_client_class {
     delete @rendered{qw/additional_only only_in_additional_list only_if_required/};
     delete $rendered{'only-in-additional-list'};
     delete $rendered{'only-if-required'};
-    $rendered{ $self->_additional_class_flag_field() } = $additional_only if defined $additional_only;
+    $rendered{ $self->_additional_class_flag_field() } = _json_bool($additional_only)
+      if defined $additional_only;
 
     return \%rendered;
 }

--- a/perl-xCAT/xCAT/DHCP/BootPolicy.pm
+++ b/perl-xCAT/xCAT/DHCP/BootPolicy.pm
@@ -87,6 +87,43 @@ sub kea_xnba_node_classes {
     return \@classes;
 }
 
+sub kea_xnba_network_classes {
+    my ( $class, %opts ) = @_;
+
+    return [] unless $opts{net} && defined $opts{prefix} && $opts{next_server};
+
+    my $xnba_user_class = xnba_user_class_test();
+    my $uefi_x64_arch_match = uefi_x64_client_architecture_match_expr();
+    my $httpport = $opts{httpport} || '80';
+    my $portsuffix = ( $httpport eq '80' ) ? '' : ":$httpport";
+    my $network_id = $opts{net} . '_' . $opts{prefix};
+    my $safe_network = $network_id;
+    $safe_network =~ s/[^A-Za-z0-9_.-]/_/g;
+    my $base_url = 'http://' . $opts{next_server} . $portsuffix
+      . '/tftpboot/xcat/xnba/nets/' . $network_id;
+    my @classes;
+
+    if ( $opts{xnba_kpxe} ) {
+        push @classes, {
+            name             => "xcat-xnba-net-$safe_network-bios",
+            test             => "$xnba_user_class and option[93].hex == 0x0000",
+            'boot-file-name' => $base_url,
+            additional_only  => 1,
+        };
+    }
+
+    if ( $opts{xnba_efi} ) {
+        push @classes, {
+            name             => "xcat-xnba-net-$safe_network-uefi",
+            test             => "$xnba_user_class and ($uefi_x64_arch_match)",
+            'boot-file-name' => "$base_url.uefi",
+            additional_only  => 1,
+        };
+    }
+
+    return \@classes;
+}
+
 sub xnba_user_class_test {
     return "(option[77].exists and (option[77].text == 'xNBA' or option[77].hex == 0x784e4241 or substring(option[77].hex,1,4) == 'xNBA'))";
 }

--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -2580,7 +2580,7 @@ sub kea_build_dhcp4_intent
     }
 
     my @subnets;
-    my @opal_classes;
+    my @subnet_classes;
     my $id = 1;
     foreach my $route (@routes) {
         my ( $net, $netif, $mask, $flags ) = @$route;
@@ -2599,7 +2599,7 @@ sub kea_build_dhcp4_intent
 
         my $subnet = kea_subnet4_intent($nettab, $net, $mask, $interface, $remote, $id, $httpport);
         return $subnet if $subnet->{error};
-        push @opal_classes, @{ delete $subnet->{client_classes} || [] };
+        push @subnet_classes, @{ delete $subnet->{client_classes} || [] };
         push @subnets, $subnet;
         $id++;
     }
@@ -2610,7 +2610,7 @@ sub kea_build_dhcp4_intent
         valid_lifetime => kea_dhcp_lease_time(),
         'option-def'   => kea_option_defs(),
         'option-data'  => kea_global_option_data(),
-        'client-classes' => [ @{ kea_boot_client_classes() }, @opal_classes ],
+        'client-classes' => [ @{ kea_boot_client_classes() }, @subnet_classes ],
         subnets        => \@subnets,
     };
 
@@ -2999,6 +2999,17 @@ sub kea_subnet4_intent
     }
 
     my $opal_class = kea_opal_client_class($net, $prefix, $tftp, $httpport);
+    my $xnba_classes = [];
+    if ($dynamicrange) {
+        $xnba_classes = xCAT::DHCP::BootPolicy->kea_xnba_network_classes(
+            net         => $net,
+            prefix      => $prefix,
+            next_server => $tftp,
+            httpport    => $httpport,
+            xnba_kpxe   => -f "$tftpdir/xcat/xnba.kpxe" ? 1 : 0,
+            xnba_efi    => -f "$tftpdir/xcat/xnba.efi"  ? 1 : 0,
+        );
+    }
     my %subnet = (
         id            => $id,
         subnet        => "$net/$prefix",
@@ -3007,9 +3018,11 @@ sub kea_subnet4_intent
         next_server   => $tftp,
     );
     $subnet{interface} = $interface unless $remote;
-    if ($opal_class) {
-        $subnet{additional_client_classes} = [ $opal_class->{name} ];
-        $subnet{client_classes} = [$opal_class];
+    my @client_classes = @$xnba_classes;
+    push @client_classes, $opal_class if $opal_class;
+    if (@client_classes) {
+        $subnet{additional_client_classes} = [ map { $_->{name} } @client_classes ];
+        $subnet{client_classes} = \@client_classes;
     }
 
     return \%subnet;

--- a/xCAT-test/unit/dhcp_boot_policy.t
+++ b/xCAT-test/unit/dhcp_boot_policy.t
@@ -81,4 +81,64 @@ my $combined_classes = xCAT::DHCP::BootPolicy->kea_client_classes(
 );
 is( $combined_classes->[0]{name}, 'xcat-xnba-cn01-52544b100011-bios', 'node-specific xNBA classes have priority over generic boot classes' );
 
+my $network_classes = xCAT::DHCP::BootPolicy->kea_xnba_network_classes(
+    net         => '192.0.2.0',
+    prefix      => 24,
+    next_server => '192.0.2.10',
+    httpport    => '8080',
+    xnba_kpxe   => 1,
+    xnba_efi    => 1,
+);
+is( scalar @$network_classes, 2, 'xNBA network policy renders BIOS and UEFI fallback classes' );
+my %network_by_name = map { $_->{name} => $_ } @$network_classes;
+my $network_bios = $network_by_name{'xcat-xnba-net-192.0.2.0_24-bios'};
+ok( $network_bios, 'xNBA network BIOS class is named by subnet' );
+is(
+    $network_bios->{'boot-file-name'},
+    'http://192.0.2.10:8080/tftpboot/xcat/xnba/nets/192.0.2.0_24',
+    'xNBA network BIOS class returns the subnet script URL'
+);
+like( $network_bios->{test}, qr/option\[77\]\.text == 'xNBA'/, 'xNBA network class matches the xNBA user class' );
+like( $network_bios->{test}, qr/option\[93\]\.hex == 0x0000/, 'xNBA network BIOS class matches BIOS clients' );
+unlike( $network_bios->{test}, qr/pkt4\.mac/, 'xNBA network fallback does not require a known MAC' );
+ok( $network_bios->{additional_only}, 'xNBA network fallback is limited to its owning subnet' );
+is(
+    $network_by_name{'xcat-xnba-net-192.0.2.0_24-uefi'}{'boot-file-name'},
+    'http://192.0.2.10:8080/tftpboot/xcat/xnba/nets/192.0.2.0_24.uefi',
+    'xNBA network UEFI class returns the subnet UEFI script URL'
+);
+like(
+    $network_by_name{'xcat-xnba-net-192.0.2.0_24-uefi'}{test},
+    qr/0x0010/,
+    'xNBA network UEFI class matches HTTP boot clients'
+);
+
+is_deeply(
+    xCAT::DHCP::BootPolicy->kea_xnba_network_classes(
+        net         => '192.0.2.0',
+        prefix      => 24,
+        next_server => '192.0.2.10',
+        xnba_kpxe   => 1,
+    ),
+    [
+        {
+            name             => 'xcat-xnba-net-192.0.2.0_24-bios',
+            test             => xCAT::DHCP::BootPolicy::xnba_user_class_test()
+              . ' and option[93].hex == 0x0000',
+            'boot-file-name' => 'http://192.0.2.10/tftpboot/xcat/xnba/nets/192.0.2.0_24',
+            additional_only  => 1,
+        },
+    ],
+    'xNBA network policy omits unavailable loaders and the default HTTP port'
+);
+is_deeply(
+    xCAT::DHCP::BootPolicy->kea_xnba_network_classes(
+        net       => '192.0.2.0',
+        prefix    => 24,
+        xnba_kpxe => 1,
+    ),
+    [],
+    'xNBA network policy requires a next server'
+);
+
 done_testing();

--- a/xCAT-test/unit/dhcp_kea_renderer.t
+++ b/xCAT-test/unit/dhcp_kea_renderer.t
@@ -194,6 +194,37 @@ ok( !exists $modern_subnet->{'require-client-classes'}, 'Kea 3.x output omits de
 is( $modern_class->{'only-in-additional-list'}, JSON::true, 'Kea 3.x renders modern class additional-evaluation flag' );
 ok( !exists $modern_class->{'only-if-required'}, 'Kea 3.x output omits deprecated class additional-evaluation flag' );
 
+my $numeric_additional_json = $backend->render_dhcp4_config(
+    {
+        subnets => [
+            {
+                id                        => 4,
+                subnet                    => '192.0.2.0/24',
+                pools                     => [],
+                additional_client_classes => ['xcat-xnba-net-192.0.2.0_24-bios'],
+            },
+        ],
+        'client-classes' => [
+            {
+                name            => 'xcat-xnba-net-192.0.2.0_24-bios',
+                test            => "option[77].text == 'xNBA'",
+                additional_only => 1,
+            },
+        ],
+    }
+);
+my $numeric_additional_config = decode_json($numeric_additional_json);
+is_deeply(
+    $numeric_additional_config->{Dhcp4}{subnet4}[0]{'require-client-classes'},
+    ['xcat-xnba-net-192.0.2.0_24-bios'],
+    'legacy Kea limits the xNBA fallback class to its owning subnet'
+);
+is(
+    $numeric_additional_config->{Dhcp4}{'client-classes'}[0]{'only-if-required'},
+    JSON::true,
+    'numeric additional-only intent is rendered as a JSON boolean'
+);
+
 my $empty_boot_json = $backend->render_dhcp4_config(
     {
         subnets => [


### PR DESCRIPTION
Kea creates xNBA second-stage classes for known nodes, but an unknown client using a dynamic range has no subnet script to continue discovery.

Add subnet-scoped BIOS and UEFI xNBA classes when the matching loader exists. These classes require the xNBA user class, so ordinary DHCP clients and static-only networks keep their current behavior.

Tests cover the fallback policy and its Kea JSON rendering.

Validation:
- Full unit suite: 1,439 tests
- Kea 3.0.2 generation and syntax
- Known and unknown BIOS and UEFI xNBA boots

Kea 2.4 compatibility is covered by renderer tests.