### PR TITLE
fix(xcatd): block XML external entities on the legacy parser path

### DIFF
--- a/xCAT-server/lib/perl/xCAT/XML.pm
+++ b/xCAT-server/lib/perl/xCAT/XML.pm
@@ -56,6 +56,7 @@ sub build_tree_xml_parser {
                                no_network => 1,
                                expand_entities => 0,
                              ]);
+  $xp->setHandlers(ExternEnt => sub { return $_[2] });
   my($tree);
   if($filename) {
       # $tree = $xp->parsefile($filename);  # Changed due to prob w/mod_perl

--- a/xCAT-test/unit/xml_external_entity.t
+++ b/xCAT-test/unit/xml_external_entity.t
@@ -1,0 +1,72 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use File::Temp qw(tempfile);
+use Test::More;
+
+my $libdir = "$FindBin::Bin/../../xCAT-server/lib/perl";
+my $xmlpm  = "$libdir/xCAT/XML.pm";
+plan skip_all => 'xCAT::XML not found' unless -r $xmlpm;
+eval { require XML::Simple; require XML::Parser; 1 }
+    or plan skip_all => 'XML::Simple and XML::Parser are required';
+
+# xCAT::XML loads xCAT::MsgUtils, which loads much of the xCAT tree. The parser
+# paths never call it. Stub it before loading xCAT::XML.
+BEGIN { $INC{'xCAT/MsgUtils.pm'} = 1; }
+{ package xCAT::MsgUtils; }
+
+# Prepend so the source-tree module wins over any installed xCAT::XML.
+unshift @INC, $libdir;
+require xCAT::XML;
+require Data::Dumper;
+
+my ($sfh, $secret_path) = tempfile('xcat_xxe_XXXXXX', TMPDIR => 1, UNLINK => 1);
+print {$sfh} "SECRET-CONTENT-DO-NOT-LEAK";
+close $sfh;
+
+my $payload = <<"XML";
+<?xml version="1.0"?>
+<!DOCTYPE r [ <!ENTITY xxe SYSTEM "file://$secret_path"> ]>
+<data>&xxe;</data>
+XML
+
+sub parsed_tree {
+    my $parser = xCAT::XML->new;
+    my $tree = eval { $parser->XMLin($payload, SuppressEmpty => undef, ForceArray => 1) };
+    return ($tree, $@);
+}
+
+# A parser path must parse the payload, replace the external entity with its
+# system identifier, and never read the file contents.
+sub check_path {
+    my ($label) = @_;
+    my ($tree, $error) = parsed_tree();
+    is($error, '', "$label: the payload parses without error");
+    ok(defined($tree), "$label: the parser returns a tree");
+    my $dump = defined($tree) ? Data::Dumper::Dumper($tree) : '';
+    like($dump, qr{\Q$secret_path\E},
+        "$label: the external entity is replaced by its system identifier");
+    unlike($dump, qr/SECRET-CONTENT-DO-NOT-LEAK/,
+        "$label: the external entity content is not read");
+}
+
+# The modern path: XML::Simple with new_xml_parser.
+SKIP: {
+    skip 'XML::Simple lacks new_xml_parser on this system', 4
+        unless exists &{'XML::Simple::new_xml_parser'};
+    check_path('modern path');
+}
+
+# Force the older compatibility path (build_tree_xml_parser's own code) by
+# removing new_xml_parser, as on XML::Simple 2.20-2.24.
+{
+    no strict 'refs';
+    no warnings 'redefine';
+    undef *{'XML::Simple::new_xml_parser'} if exists &{'XML::Simple::new_xml_parser'};
+}
+ok(!exists &{'XML::Simple::new_xml_parser'}, 'compatibility path is forced');
+check_path('compatibility path');
+
+done_testing();


### PR DESCRIPTION
xCAT::XML wraps XML::Simple to block XML external entities. An external
entity can read a local file or a network resource.

The new_xml_parser() override installs an ExternEnt handler. The handler
returns the system id, not the content.

XML::Simple 2.20 to 2.24 has no new_xml_parser(). On these versions xCAT
uses build_tree_xml_parser() instead. This function did not install the
handler. A SYSTEM entity then expanded. It leaked a local file into the
parsed data. This change adds the same handler to build_tree_xml_parser().

## Validation

The leak was reproduced on a genuine XML::Simple 2.20 system, where
new_xml_parser() is absent and the legacy path runs. The master parser
leaked the file content. The patched parser returned the system id and read
nothing. The new unit test covers both parser paths. It passes on the fix
and fails on master. The patched module was also loaded into a running
xcatd (xCAT 2.18.2): the daemon restarted and parsed requests with no
regression.

This fix was recovered from the lenovobuild branch. See #6505.