### PR TITLE
fix(enablekdump): stage the NFS dump setup under a per-node directory

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_kdump.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_kdump.rst
@@ -132,7 +132,11 @@ Check your Operating System specific documentation for the path where the kernel
 * **[RHELS6]** ::
 
     <kdump_path>/var/crash/<node_ip>-<time>/
-	
+
+* **[RHELS7, RHELS8]** ::
+
+    <kdump_path>/<node hostname>/var/crash/<node_ip>-<time>/
+
 * **[SLES11]** ::
 
     <kdump_path>/<node hostname>/<date>

--- a/xCAT-test/unit/enablekdump_per_node.t
+++ b/xCAT-test/unit/enablekdump_per_node.t
@@ -1,0 +1,105 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use File::Path qw(make_path);
+use File::Temp qw(tempdir);
+use FindBin;
+use Test::More;
+
+my $script = "$FindBin::Bin/../../xCAT/postscripts/enablekdump";
+plan skip_all => 'enablekdump not found' unless -r $script;
+# The postscript uses GNU sed -i, which behaves differently on BSD.
+plan skip_all => 'postscript targets Linux nodes' unless $^O eq 'linux';
+
+my $source = read_file($script);
+
+# Run the RHEL NFS path of enablekdump against a scratch tree. The dump target
+# is a local directory standing in for the mounted NFS export, so we can check
+# what the postscript writes to it and to /etc/kdump.conf.
+sub run_enablekdump {
+    my (%opt) = @_;
+    my $osver = $opt{osver};
+    my $node  = $opt{node} || 'n01';
+
+    my $root = tempdir(CLEANUP => 1);
+    make_path("$root/etc/sysconfig", "$root/target", "$root/bin");
+
+    # /etc/sysconfig/kdump must exist for the in-place seds to land.
+    write_file("$root/etc/sysconfig/kdump",
+        "KDUMP_COMMANDLINE=\"\"\nKDUMP_COMMANDLINE_APPEND=\"\"\n");
+    # xcatlib.sh is sourced; only restartservice is needed and is a no-op here.
+    write_file("$root/xcatlib.sh", "restartservice(){ :; }\n");
+    write_file("$root/bin/logger", "#!/bin/sh\nexit 0\n");
+    chmod 0755, "$root/bin/logger";
+
+    my $src = $source;
+    # Redirect everything the postscript touches into the scratch tree.
+    $src =~ s{/etc/kdump\.conf}{$root/etc/kdump.conf}g;
+    $src =~ s{/etc/sysconfig/kdump}{$root/etc/sysconfig/kdump}g;
+    $src =~ s{/etc/dracut\.conf}{$root/etc/dracut.conf}g;
+    $src =~ s{/tmp/dracut\.conf}{$root/tmp/dracut.conf}g;
+    # No real NFS server: make the version probe empty so the mount is skipped;
+    # the per-node mkdir and kdump.conf rendering still run against the target.
+    $src =~ s{/usr/sbin/rpcinfo}{/bin/false}g;
+    $src =~ s{/bin/mount}{true}g;
+    $src =~ s{/bin/umount}{true}g;
+    # Point the staging mount point at the scratch target that stands in for the
+    # mounted NFS export.
+    $src =~ s{/mnt/kdumpsetup}{$root/target}g;
+
+    write_file("$root/enablekdump", $src);
+    chmod 0755, "$root/enablekdump";
+
+    my $dump = "nfs://10.0.0.1/dumparea";
+    system(qq{cd '$root' && DUMP='$dump' XCAT='10.0.0.1:eth0' OSVER='$osver' }
+         . qq{ARCH='x86_64' NODE='$node' PATH="$root/bin:\$PATH" ./enablekdump >/dev/null 2>&1});
+
+    return {
+        root       => $root,
+        target     => "$root/target",
+        kdump_conf => read_file("$root/etc/kdump.conf"),
+        sysconfig  => read_file("$root/etc/sysconfig/kdump"),
+    };
+}
+
+sub read_file {
+    my ($p) = @_;
+    return '' unless -e $p;
+    open my $fh, '<', $p or die "open $p: $!";
+    local $/;
+    return <$fh>;
+}
+
+sub write_file {
+    my ($p, $c) = @_;
+    open my $fh, '>', $p or die "open $p: $!";
+    print {$fh} $c;
+    close $fh;
+    return;
+}
+
+# --- RHEL 8: per-node, no shared-root writes -------------------------------
+{
+    my $r = run_enablekdump(osver => 'rhels8.0', node => 'n01');
+
+    like($r->{kdump_conf}, qr{^path\s+/n01/var/crash$}m,
+        'kdump.conf points the dump path at the node subdirectory');
+    unlike($r->{kdump_conf}, qr{^path\s+/var/crash$}m,
+        'kdump.conf does not use the shared /var/crash path');
+    ok(-d "$r->{target}/n01/var/crash", 'the node subdirectory is created on the target');
+    ok(!-e "$r->{target}/var/crash", 'nothing is created at the shared export root');
+    ok(!-e "$r->{target}/proc", 'no dummy proc file is written on RHEL 8');
+}
+
+# --- RHEL 7: keeps the dracut workaround, but per-node ----------------------
+{
+    my $r = run_enablekdump(osver => 'rhels7.9', node => 'n07');
+
+    like($r->{sysconfig}, qr{root=nfs:10\.0\.0\.1:/dumparea/n07},
+        'the RHEL 7 root= workaround points at the node subdirectory');
+    ok(-e "$r->{target}/n07/proc", 'the RHEL 7 dummy proc is written under the node subdirectory');
+    ok(!-e "$r->{target}/proc", 'the RHEL 7 dummy proc is not written at the shared root');
+}
+
+done_testing();

--- a/xCAT-test/unit/enablekdump_per_node.t
+++ b/xCAT-test/unit/enablekdump_per_node.t
@@ -109,7 +109,7 @@ sub write_file {
 # line, so leaving the legacy value behind would defeat the migration.
 {
     my $legacy = qq{KDUMP_COMMANDLINE=""\n}
-               . qq{KDUMP_COMMANDLINE_APPEND="root=nfs:10.0.0.1:/dumparea rd.neednet=1 rootflags=nofail"\n};
+               . qq{KDUMP_COMMANDLINE_APPEND="root=nfs:10.0.0.1:/dumparea rd.neednet=1 rootflags=nofail foo-root=bar rd.foo.root=bar"\n};
     my $r = run_enablekdump(osver => 'rhels7.9', node => 'n07',
         sysconfig => $legacy);
 
@@ -122,6 +122,10 @@ sub write_file {
         'unrelated options on the legacy line are preserved');
     like($append, qr{(?:^|\s)rootflags=nofail(?:\s|$)},
         'rootflags= is not mistaken for a root= token');
+    like($append, qr{(?:^|\s)foo-root=bar(?:\s|$)},
+        'a root= suffix after a dash is not stripped');
+    like($append, qr{(?:^|\s)rd\.foo\.root=bar(?:\s|$)},
+        'a root= suffix after a dot is not stripped');
 
     # Re-running against its own output must not stack another root=.
     my $r2 = run_enablekdump(osver => 'rhels7.9', node => 'n07',

--- a/xCAT-test/unit/enablekdump_per_node.t
+++ b/xCAT-test/unit/enablekdump_per_node.t
@@ -21,13 +21,14 @@ sub run_enablekdump {
     my (%opt) = @_;
     my $osver = $opt{osver};
     my $node  = $opt{node} || 'n01';
+    my $sysconfig = defined $opt{sysconfig} ? $opt{sysconfig}
+        : "KDUMP_COMMANDLINE=\"\"\nKDUMP_COMMANDLINE_APPEND=\"\"\n";
 
     my $root = tempdir(CLEANUP => 1);
     make_path("$root/etc/sysconfig", "$root/target", "$root/bin");
 
     # /etc/sysconfig/kdump must exist for the in-place seds to land.
-    write_file("$root/etc/sysconfig/kdump",
-        "KDUMP_COMMANDLINE=\"\"\nKDUMP_COMMANDLINE_APPEND=\"\"\n");
+    write_file("$root/etc/sysconfig/kdump", $sysconfig);
     # xcatlib.sh is sourced; only restartservice is needed and is a no-op here.
     write_file("$root/xcatlib.sh", "restartservice(){ :; }\n");
     write_file("$root/bin/logger", "#!/bin/sh\nexit 0\n");
@@ -100,6 +101,33 @@ sub write_file {
         'the RHEL 7 root= workaround points at the node subdirectory');
     ok(-e "$r->{target}/n07/proc", 'the RHEL 7 dummy proc is written under the node subdirectory');
     ok(!-e "$r->{target}/proc", 'the RHEL 7 dummy proc is not written at the shared root');
+}
+
+# --- RHEL 7 migration: a legacy shared root= is replaced, not kept ----------
+# A node configured by the previous script carries root=nfs:<server>:<export>
+# in KDUMP_COMMANDLINE_APPEND. dracut takes the last root= on the command
+# line, so leaving the legacy value behind would defeat the migration.
+{
+    my $legacy = qq{KDUMP_COMMANDLINE=""\n}
+               . qq{KDUMP_COMMANDLINE_APPEND="root=nfs:10.0.0.1:/dumparea rd.neednet=1 rootflags=nofail"\n};
+    my $r = run_enablekdump(osver => 'rhels7.9', node => 'n07',
+        sysconfig => $legacy);
+
+    my ($append) = $r->{sysconfig} =~ m{^KDUMP_COMMANDLINE_APPEND="([^"]*)"}m;
+    my @roots = grep { /^root=/ } split ' ', defined $append ? $append : '';
+    is(scalar @roots, 1, 'exactly one root= remains after migrating a legacy config');
+    is($roots[0], 'root=nfs:10.0.0.1:/dumparea/n07',
+        'the remaining root= points at the node subdirectory');
+    like($append, qr{(?:^|\s)rd\.neednet=1(?:\s|$)},
+        'unrelated options on the legacy line are preserved');
+    like($append, qr{(?:^|\s)rootflags=nofail(?:\s|$)},
+        'rootflags= is not mistaken for a root= token');
+
+    # Re-running against its own output must not stack another root=.
+    my $r2 = run_enablekdump(osver => 'rhels7.9', node => 'n07',
+        sysconfig => $r->{sysconfig});
+    my ($append2) = $r2->{sysconfig} =~ m{^KDUMP_COMMANDLINE_APPEND="([^"]*)"}m;
+    is($append2, $append, 'a second run leaves KDUMP_COMMANDLINE_APPEND unchanged');
 }
 
 done_testing();

--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -265,8 +265,10 @@ EOF
                    [ -e $MOUNTPATH/$NODE/proc ] || echo "xCAT: dummy /proc so RHEL7 dracut-cmdline accepts root=" > $MOUNTPATH/$NODE/proc
                    # Drop any root= a previous run left behind before adding this
                    # node's own: dracut takes the last root= on the command line,
-                   # so a stale shared-root value would win over the new one.
-                   sed -i -e '/^[\t ]*KDUMP_COMMANDLINE_APPEND="/s/\broot=[^ \t"]*[ \t]*//g' \
+                   # so a stale shared-root value would win over the new one. A
+                   # root= token starts after the opening quote or whitespace,
+                   # so suffixes of other options (foo-root=, rd.foo.root=) stay.
+                   sed -i -e '/^[\t ]*KDUMP_COMMANDLINE_APPEND="/{:a;s/\([" \t]\)root=[^ \t"]*[ \t]*/\1/;ta}' \
                           -e "s#^[\t ]*KDUMP_COMMANDLINE_APPEND=\"#KDUMP_COMMANDLINE_APPEND=\"root=nfs:$KDIP:$KDPATH/$NODE #" /etc/sysconfig/kdump
                fi
                [ -f /etc/dracut.conf ] && mv /etc/dracut.conf  /tmp/dracut.conf

--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -263,7 +263,11 @@ EOF
                    # names a valid filesystem, checked by dracut-cmdline at crash
                    # time, so give this node's subdir a dummy /proc for it.
                    [ -e $MOUNTPATH/$NODE/proc ] || echo "xCAT: dummy /proc so RHEL7 dracut-cmdline accepts root=" > $MOUNTPATH/$NODE/proc
-                   sed -i "s#^[\t ]*KDUMP_COMMANDLINE_APPEND=\"#KDUMP_COMMANDLINE_APPEND=\"root=nfs:$KDIP:$KDPATH/$NODE #" /etc/sysconfig/kdump
+                   # Drop any root= a previous run left behind before adding this
+                   # node's own: dracut takes the last root= on the command line,
+                   # so a stale shared-root value would win over the new one.
+                   sed -i -e '/^[\t ]*KDUMP_COMMANDLINE_APPEND="/s/\broot=[^ \t"]*[ \t]*//g' \
+                          -e "s#^[\t ]*KDUMP_COMMANDLINE_APPEND=\"#KDUMP_COMMANDLINE_APPEND=\"root=nfs:$KDIP:$KDPATH/$NODE #" /etc/sysconfig/kdump
                fi
                [ -f /etc/dracut.conf ] && mv /etc/dracut.conf  /tmp/dracut.conf
                restartservice kdump

--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -92,16 +92,13 @@ if [ ! -z "$DUMP" ]; then
         KDIP=${XCAT%:*}
     fi
 
-    # workaround for RHEL6
+    # xCAT sets NODE in the postscript environment; fall back to the short
+    # hostname so a per-node dump path is still used if run by hand.
+    [ -z "$NODE" ] && NODE=$(hostname -s)
+
     # the $KDIP:$KDPATH directory will be used to generate the initrd for kdump service
-    MOUNTPATH=""
-    if (pmatch $OSVER "*6\.*"); then
-	MOUNTPATH="/tmp"
-    elif (pmatch $OSVER "*[78]\.*"); then
-        MOUNTPATH="/mnt"
-    else
-	MOUNTPATH="/var/tmp"
-    fi
+    MOUNTPATH="/mnt/kdumpsetup"
+    mkdir -p $MOUNTPATH
 
     if [ "$KDPROTO" = "nfs" ]; then
 	if (pmatch $OSVER "sle*") || (pmatch $OSVER "suse*") || [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]; then
@@ -238,16 +235,14 @@ EOF
                else
                    /bin/echo "nfs server is not available"
                fi
-               [ -d $MOUNTPATH/var/crash ] || mkdir -p $MOUNTPATH/var/crash
-
-               #The initramfs used in kdump does not need "root", however, the initramfs refused to continue
-               #if no valid "root" provided in redhat7.1 kdump; As a workaround,we provide a fake "root=nfs:$KDIP:$KDPATH"
-               #with a dummy "proc" inside, which will fake "root=nfs:$KDIP:$KDPATH" as a valid root directory
-               [ -e $MOUNTPATH/proc ] || echo "Dummy file: fake the /proc to pass the checking of 'root=' inside dracut-cmdline " > $MOUNTPATH/proc
+               # Create only this node's own subdirectory on the dump target.
+               # kdump checks the dump path exists when it builds the initrd, so
+               # it must exist now, at deploy time.
+               mkdir -p $MOUNTPATH/$NODE/var/crash
 
                echo "nfs $KDIP:$KDPATH" > /etc/kdump.conf
                echo "default shell" >> /etc/kdump.conf
-               echo "path /var/crash" >> /etc/kdump.conf
+               echo "path /$NODE/var/crash" >> /etc/kdump.conf
                echo "core_collector makedumpfile -c --message-level 1 -d 31" >> /etc/kdump.conf
                #strip "xcat" out of the initramfs for kdump
                echo "dracut_args --omit \"xcat\"" >> /etc/kdump.conf
@@ -264,7 +259,11 @@ EOF
                done
                sed -i "s#^[\t ]*KDUMP_COMMANDLINE=\"#KDUMP_COMMANDLINE=\"$kdumpcmdline#" /etc/sysconfig/kdump
                if (pmatch $OSVER "rhel7*") || (pmatch $OSVER "rhels7*"); then
-                   sed -i "s#^[\t ]*KDUMP_COMMANDLINE_APPEND=\"#KDUMP_COMMANDLINE_APPEND=\"root=nfs:$KDIP:$KDPATH #" /etc/sysconfig/kdump
+                   # The RHEL7 kdump initramfs refuses to continue unless root=
+                   # names a valid filesystem, checked by dracut-cmdline at crash
+                   # time, so give this node's subdir a dummy /proc for it.
+                   [ -e $MOUNTPATH/$NODE/proc ] || echo "xCAT: dummy /proc so RHEL7 dracut-cmdline accepts root=" > $MOUNTPATH/$NODE/proc
+                   sed -i "s#^[\t ]*KDUMP_COMMANDLINE_APPEND=\"#KDUMP_COMMANDLINE_APPEND=\"root=nfs:$KDIP:$KDPATH/$NODE #" /etc/sysconfig/kdump
                fi
                [ -f /etc/dracut.conf ] && mv /etc/dracut.conf  /tmp/dracut.conf
                restartservice kdump


### PR DESCRIPTION
This PR fixes a long standing issue in RHEL 7/8 NFS path, enablekdump created `var/crash` and a dummy `proc` file at the root of the shared dump export, from every node at deploy, and mounted the export over a general-purpose directory like `/mnt`.

kdump checks that the dump path exists on the target when it builds the initrd, so the path has to exist at deploy time. This creates only the node's own subdirectory, `$NODE/var/crash`, and points `kdump.conf` at `path /$NODE/var/crash`. Each node now writes only under its own subdirectory, so nodes no longer share or collide at the export root, and the dump lands in the node's directory — the same layout SLES already uses. The setup mounts a dedicated `/mnt/kdumpsetup`.

The dummy `proc` file only ever mattered to the RHEL 7 dracut check. It is kept for RHEL 7, per node; RHEL 8 no longer writes it.

Nodes already deployed on the old behavior keep a `var/crash` and `proc` at the export root; leave those in place until every RHEL 7 node has re-run enablekdump, since their existing `root=` still points there.