### PR TITLE
fix(xcatd): only call a same-release build difference a build difference

### DIFF
--- a/perl-xCAT/xCAT/Version.pm
+++ b/perl-xCAT/xCAT/Version.pm
@@ -54,4 +54,34 @@ sub Version
 
 }
 
+#-------------------------------------------------------------------------------
+
+=head3   Release
+    Arguments:
+        Optional version string; defaults to Version();
+    Returns:
+        the release part of the version, without the build-specific
+        decoration the build stamps on, such as " (git commit <hash>)",
+        so two nodes at the same release built from different snapshots
+        compare equal.
+    Globals:
+        none
+    Error:
+        none
+    Example:
+         $release=xCAT::Version->Release($someversion);
+    Comments:
+        none
+=cut
+
+#-------------------------------------------------------------------------------
+sub Release
+{
+    my $class = shift;
+    my $version = shift;
+    $version = $class->Version() unless defined $version;
+    $version =~ s/\s*\(.*//s;
+    return $version;
+}
+
 1;

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -2945,9 +2945,13 @@ sub service_connection {
                 #if the 2 versions are different, a warning message is included in the response
                 if($req->{'_xcatver'} and $req->{'_xcatver'}->[0]){
                     my $myxcatver=xCAT::Version->Version();
-                    if($req->{'_xcatver'}->[0] ne $myxcatver){
+                    my $peerxcatver=$req->{'_xcatver'}->[0];
+                    if($peerxcatver ne $myxcatver){
                         my $myhostname=Sys::Hostname::hostname;
-                        my $resp = { warning => ["xCAT Version mismatch! \n         $myhostname: $myxcatver\n         $peerhost: $req->{'_xcatver'}->[0]\n"]};
+                        my $label = (xCAT::Version->Release($peerxcatver) ne xCAT::Version->Release($myxcatver))
+                            ? "xCAT Version mismatch!"
+                            : "xCAT build level differs (same release):";
+                        my $resp = { warning => ["$label \n         $myhostname: $myxcatver\n         $peerhost: $peerxcatver\n"]};
                         send_response($resp, $sock);
                     }
                 }

--- a/xCAT-test/unit/version_release.t
+++ b/xCAT-test/unit/version_release.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use Test::More;
+
+use lib "$FindBin::Bin/../../perl-xCAT";
+require xCAT::Version;
+
+# xcatd tells a real version mismatch (different release) from a same-release
+# build difference by comparing xCAT::Version->Release. Release must strip the
+# build-specific decoration the build stamps onto the version string, so nodes
+# at the same release built from different snapshots are not reported as a
+# version mismatch.
+
+my $va = "Version 2.18.2 (git commit aaaaaaaaaaaaaaaa)";
+my $vb = "Version 2.18.2 (git commit bbbbbbbbbbbbbbbb)";
+my $vc = "Version 2.19.0 (git commit cccccccccccccccc)";
+
+is(xCAT::Version->Release($va), "Version 2.18.2",
+    'Release strips the git-commit decoration');
+is(xCAT::Version->Release($va), xCAT::Version->Release($vb),
+    'the same release built from different snapshots compares equal');
+isnt(xCAT::Version->Release($va), xCAT::Version->Release($vc),
+    'a real release difference is still reported');
+
+# A string with no decoration is returned unchanged.
+is(xCAT::Version->Release("Version 2.18.2"), "Version 2.18.2",
+    'a version without decoration is left as is');
+
+done_testing();


### PR DESCRIPTION
xcatd warns "xCAT Version mismatch!" on a version difference, comparing the full strings including the " (git commit <hash>)" build suffix. So two nodes at the same release built from different snapshots warned on every request.

Now a different release is still "xCAT Version mismatch!", while the same release from a different commit reports "xCAT build level differs (same release):" — the build difference stays visible, just not called a mismatch. Adds xCAT::Version->Release for the distinction.

Recovered from the lenovobuild branch (which dropped the same-release warning entirely); reimplemented for the current version format.