### PR TITLE
fix(ci): bound the apt network steps with timeouts and retries

### DIFF
--- a/github_action_xcat_test.pl
+++ b/github_action_xcat_test.pl
@@ -352,7 +352,7 @@ sub install_xcat{
                "sudo chmod 777 /etc/apt/sources.list",
                "sudo echo \"deb [arch=amd64 allow-insecure=yes] http://xcat.org/files/xcat/repos/apt/latest/xcat-dep noble main\" >> /etc/apt/sources.list",
                "sudo echo \"deb [arch=ppc64el allow-insecure=yes] http://xcat.org/files/xcat/repos/apt/latest/xcat-dep noble main\" >> /etc/apt/sources.list",
-               "sudo apt-get -qq --allow-insecure-repositories update");
+               "sudo timeout 600 apt-get -qq -o Acquire::Retries=3 -o Acquire::http::Timeout=30 --allow-insecure-repositories update");
     chdir $ENV{RUNNER_WORKSPACE};;
 
     my @output;
@@ -369,7 +369,7 @@ sub install_xcat{
         }
     }
 
-    my $cmd = "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y xcat --allow-remove-essential --allow-unauthenticated";
+    my $cmd = "sudo timeout 1200 env DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y xcat --allow-remove-essential --allow-unauthenticated";
     @output = runcmd("$cmd");
     if($::RUNCMD_RC){
         my $lastline = $output[-1];
@@ -404,7 +404,7 @@ sub install_xcat{
                print "[install_xcat] $cmd....[Pass]\n";
             }
         }
-        $cmd = "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y xcat-probe --allow-remove-essential --allow-unauthenticated";
+        $cmd = "sudo timeout 1200 env DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y xcat-probe --allow-remove-essential --allow-unauthenticated";
         @output = runcmd("$cmd");
         if($::RUNCMD_RC){
             print RED "[install_xcat] $cmd ....[Failed]\n";
@@ -510,7 +510,7 @@ sub check_syntax{
 # Return code:
 #--------------------------------------------------------
 sub run_fast_regression_test{
-    my $cmd = "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y xcat-test --allow-remove-essential --allow-unauthenticated";
+    my $cmd = "sudo timeout 1200 env DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y xcat-test --allow-remove-essential --allow-unauthenticated";
     my @output = runcmd("$cmd");
     if($::RUNCMD_RC){
          print RED "[run_fast_regression_test] $cmd ....[Failed]\n";

--- a/xCAT-test/unit/github_action_noninteractive_install.t
+++ b/xCAT-test/unit/github_action_noninteractive_install.t
@@ -24,8 +24,8 @@ close($workflow_fh);
 for my $package (qw(xcat xcat-probe xcat-test)) {
     like(
         $contents,
-        qr{sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \Q$package\E\b},
-        "$package installation is noninteractive"
+        qr{sudo timeout \d+ env DEBIAN_FRONTEND=noninteractive apt-get (?:-o \S+ )*install -y \Q$package\E },
+        "$package installation is noninteractive and bounded"
     );
 }
 


### PR DESCRIPTION
The PR test job hung on `apt-get update` when the xcat.org repository stalled, and stayed silent until the 60 minute workflow limit canceled the run (see the run on #7730). The log ended without a reason.

Wrap the apt update and install steps in `timeout` and give apt a transfer timeout with retries. A stalled repository now fails the step in minutes and the driver prints its normal install error report, so a rerun is possible at once.