### PR TITLE
fix(plugins): mask passwords in plugin log messages

### DIFF
--- a/perl-xCAT/xCAT/CIMUtils.pm
+++ b/perl-xCAT/xCAT/CIMUtils.pm
@@ -441,7 +441,9 @@ sub send_http_request
     }
 
     if (defined($http_params->{verbose}) && defined($http_params->{callback})) {
-        $http_params->{callback}({ data => [ "\n========CIM Request Start========", $http_request->as_string(), "=======CIM Request End=======" ] });
+        my $request_text = $http_request->as_string();
+        $request_text =~ s/^(Authorization:).*$/$1 xxxxxxxx/mi;
+        $http_params->{callback}({ data => [ "\n========CIM Request Start========", $request_text, "=======CIM Request End=======" ] });
     }
 
     # send request and receive the response

--- a/perl-xCAT/xCAT/PPCcfg.pm
+++ b/perl-xCAT/xCAT/PPCcfg.pm
@@ -1184,7 +1184,7 @@ sub get_rsp_dev
         #############################################
         foreach (keys %$hmc) {
             ($hmc->{$_}->{username}, $hmc->{$_}->{password}) = xCAT::PPCdb::credentials($hmc->{$_}->{name}, lc($hmc->{$_}->{'type'}), "hscroot");
-            xCAT::MsgUtils->verbose_message($request, "user/passwd for $_ is $hmc->{$_}->{username} $hmc->{$_}->{password}");
+            xCAT::MsgUtils->verbose_message($request, "user/passwd for $_ is $hmc->{$_}->{username} xxxxxxxx");
         }
     }
 
@@ -1195,7 +1195,7 @@ sub get_rsp_dev
         #############################################
         foreach (keys %$fsp) {
             ($fsp->{$_}->{username}, $fsp->{$_}->{password}) = xCAT::PPCdb::credentials($fsp->{$_}->{name}, lc($fsp->{$_}->{'type'}), "admin");
-            xCAT::MsgUtils->verbose_message($request, "user/passwd for $_ is $fsp->{$_}->{username} $fsp->{$_}->{password}");
+            xCAT::MsgUtils->verbose_message($request, "user/passwd for $_ is $fsp->{$_}->{username} xxxxxxxx");
         }
     }
 
@@ -1206,7 +1206,7 @@ sub get_rsp_dev
         #############################################
         foreach (keys %$bpa) {
             ($bpa->{$_}->{username}, $bpa->{$_}->{password}) = xCAT::PPCdb::credentials($bpa->{$_}->{name}, lc($bpa->{$_}->{'type'}), "admin");
-            xCAT::MsgUtils->verbose_message($request, "user/passwd for $_ is $bpa->{$_}->{username} $bpa->{$_}->{password}");
+            xCAT::MsgUtils->verbose_message($request, "user/passwd for $_ is $bpa->{$_}->{username} xxxxxxxx");
         }
     }
 

--- a/perl-xCAT/xCAT/zvmUtils.pm
+++ b/perl-xCAT/xCAT/zvmUtils.pm
@@ -329,6 +329,37 @@ sub printLn {
 
 #-------------------------------------------------------
 
+=head3   redact_directory_entry
+
+    Description : Mask the passwords of a z/VM directory entry, so the
+                  text is safe to log. The USER and IDENTITY statements
+                  carry the logon password in their third field. The
+                  MDISK statement carries the read, write and multi
+                  passwords after the access mode. The COMMAND statement
+                  can start any CP command with an inline password, so
+                  the whole statement masks. The keyword form carries
+                  the passwords as PW assignments.
+    Arguments   : Directory entry text
+    Returns     : The text with each password masked
+    Example     : my $safe = xCAT::zvmUtils->redact_directory_entry($entry);
+
+=cut
+
+#-------------------------------------------------------
+sub redact_directory_entry {
+    my ( $class, $entry ) = @_;
+    return $entry unless defined $entry;
+    $entry =~ s/^([ \t]*(?:\*[ \t]*)*(?:USER|IDENTITY|IDENT)[ \t]+\S+[ \t]+)\S+/$1xxxxxxxx/img;
+    $entry =~ s/^([ \t]*(?:\*[ \t]*)*MDISK[ \t]+\S+[ \t]+\S+[ \t]+(?:DEVNO|V-DISK|T-DISK)[ \t]+\S+[ \t]+\S+)[ \t]+\S.*$/$1 xxxxxxxx/img;
+    $entry =~ s/^([ \t]*(?:\*[ \t]*)*MDISK[ \t]+(?:\S+[ \t]+){5}\S+)[ \t]+\S.*$/$1 xxxxxxxx/img;
+    $entry =~ s/^([ \t]*(?:\*[ \t]*)*APPCPASS\b).*$/$1 xxxxxxxx/img;
+    $entry =~ s/^([ \t]*(?:\*[ \t]*)*COMMAND\b).*$/$1 xxxxxxxx/img;
+    $entry =~ s/\b((?:READ|WRITE|MULTI)?(?:PASSWORD|PW)|APPCPASS)=\S+/$1=xxxxxxxx/ig;
+    return $entry;
+}
+
+#-------------------------------------------------------
+
 =head3   printSyslog
 
     Description : Print a string to syslog
@@ -803,7 +834,7 @@ sub getMdisks {
     my $outmsg;
     my $rc;
     my $out = `ssh $user\@$hcp "$sudo $dir/getuserentry $userId"`;
-    ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?, "ssh $user\@$hcp \"$sudo $dir/getuserentry $userId\"", $hcp, "getMdisks", $out, $node );
+    ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?, "ssh $user\@$hcp \"$sudo $dir/getuserentry $userId\"", $hcp, "getMdisks", xCAT::zvmUtils->redact_directory_entry($out), $node );
     if ($rc != 0) {
        return $outmsg;
     }
@@ -863,7 +894,7 @@ sub getDedicates {
     my $outmsg;
     my $rc;
     my $out = `ssh $user\@$hcp "$sudo $dir/smcli Image_Query_DM -T $userId"`;
-    ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?, "commandString", $hcp, "getMdisks", $out, $node );
+    ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?, "commandString", $hcp, "getMdisks", xCAT::zvmUtils->redact_directory_entry($out), $node );
     if ($rc != 0) {
         return $outmsg;
     }
@@ -919,7 +950,7 @@ sub getCommands {
     my $outmsg;
     my $rc;
     my $out = `ssh $user\@$hcp "$sudo $dir/smcli Image_Query_DM -T $userId"`;
-    ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?, "ssh $user\@$hcp \"$sudo $dir/smcli Image_Query_DM -T $userId\"", $hcp, "getCommands", $out, $node );
+    ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?, "ssh $user\@$hcp \"$sudo $dir/smcli Image_Query_DM -T $userId\"", $hcp, "getCommands", xCAT::zvmUtils->redact_directory_entry($out), $node );
     if ($rc != 0) {
         return $outmsg;
     }
@@ -987,7 +1018,7 @@ sub getUserEntryWODisk {
     my $outmsg;
     my $rc;
     my $out = `ssh $user\@$hcp "$sudo $dir/smcli Image_Query_DM -T $userId"`;
-    ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?, "ssh $user\@$hcp \"$sudo $dir/smcli Image_Query_DM -T $userId\"", $hcp, "getUserEntryWODisk", $out, $node );
+    ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?, "ssh $user\@$hcp \"$sudo $dir/smcli Image_Query_DM -T $userId\"", $hcp, "getUserEntryWODisk", xCAT::zvmUtils->redact_directory_entry($out), $node );
     if ($rc != 0) {
         return $outmsg;
     }
@@ -4277,7 +4308,7 @@ sub findUsablezHcpNetwork {
     # Search directory entry for network name
     my $userEntry = `ssh $user\@$hcp "$sudo $::DIR/smcli Image_Query_DM -T $userId" | sed '\$d'`;
     xCAT::zvmUtils->printSyslog("findUsablezHcpNetwork() smcli Image_Query_DM -T $userId");
-    xCAT::zvmUtils->printSyslog("findUsablezHcpNetwork() $userEntry");
+    xCAT::zvmUtils->printSyslog("findUsablezHcpNetwork() " . xCAT::zvmUtils->redact_directory_entry($userEntry));
 
     my $out = `echo "$userEntry" | grep "NICDEF"`;
     my @lines = split('\n', $out);
@@ -4324,7 +4355,7 @@ sub findUsablezHcpNetwork {
 
             # Get user profile
             my $userProfile = xCAT::zvmUtils->getUserProfile($user, $hcp, $words[1]);
-            xCAT::zvmUtils->printSyslog("findUsablezHcpNetwork() $userProfile");
+            xCAT::zvmUtils->printSyslog("findUsablezHcpNetwork() " . xCAT::zvmUtils->redact_directory_entry($userProfile));
 
             # Get the NICDEF statement
             $out = `echo "$userProfile" | grep "NICDEF"`;

--- a/xCAT-server/lib/xcat/plugins/bmcconfig.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcconfig.pm
@@ -149,8 +149,9 @@ sub process_request {
     foreach my $sbmc (split /,/, $bmc) {
         (my $ip, my $mask, my $gw) = net_parms($sbmc);
         unless ($ip and $mask and $username and $password) {
-            xCAT::MsgUtils->message('S', "Unable to determine IP, Netmask, Username, or Password for $sbmc. Ensure that hostname resolution is working. [IP=$ip Netmask=$mask User=$username Pass=$password]",);
-            $callback->({ error => ["Invalid/Missing BMC related attributes in the node defintion (IP=$ip Netmask=$mask User=$username Pass=$password). Unable to configure the BMC, check the node definition."], errorcode => [1] });
+            my $passtate = defined($password) && length($password) ? "set" : "missing";
+            xCAT::MsgUtils->message('S', "Unable to determine IP, Netmask, Username, or Password for $sbmc. Ensure that hostname resolution is working. [IP=$ip Netmask=$mask User=$username Pass=$passtate]",);
+            $callback->({ error => ["Invalid/Missing BMC related attributes in the node defintion (IP=$ip Netmask=$mask User=$username Pass=$passtate). Unable to configure the BMC, check the node definition."], errorcode => [1] });
             return 1;
         }
         if ($request->{command}->[0] eq 'remoteimmsetup') {
@@ -187,4 +188,3 @@ sub process_request {
 
 
 1;
-

--- a/xCAT-server/lib/xcat/plugins/energy.pm
+++ b/xCAT-server/lib/xcat/plugins/energy.pm
@@ -476,7 +476,7 @@ sub process_request {
                 if ($verbose) {
                     $args{verbose}  = 1;
                     $args{callback} = $callback;
-                    xCAT::MsgUtils->message("I", { data => ["$node: Access hcp [$ip], user [$user], passowrd [$password]"] }, $callback);
+                    xCAT::MsgUtils->message("I", { data => ["$node: Access hcp [$ip], user [$user], password [xxxxxxxx]"] }, $callback);
                 }
 
                 # call the cim utils to connect to cim server

--- a/xCAT-server/lib/xcat/plugins/zvm.pm
+++ b/xCAT-server/lib/xcat/plugins/zvm.pm
@@ -1041,10 +1041,10 @@ sub changeVM {
 
         # Add to directory entry
         my $error = 0;
-        xCAT::zvmUtils->printSyslog( "ssh $::SUDOER\@$hcp \"$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $userId -v $addr -t 3390 -a AUTOG -r $pool -u 1 -z $cyl -m $mode -f 1 -R $readPw -W $writePw -M $multiPw\"" );
+        xCAT::zvmUtils->printSyslog( "ssh $::SUDOER\@$hcp \"$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $userId -v $addr -t 3390 -a AUTOG -r $pool -u 1 -z $cyl -m $mode -f 1 -R xxxxxxxx -W xxxxxxxx -M xxxxxxxx\"" );
         $out = `ssh $::SUDOER\@$hcp "$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $userId -v $addr -t 3390 -a AUTOG -r $pool -u 1 -z $cyl -m $mode -f 1 -R $readPw -W $writePw -M $multiPw"`;
         ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?,
-            "ssh $::SUDOER\@$hcp \"$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $userId -v $addr -t 3390 -a AUTOG -r $pool -u 1 -z $cyl -m $mode -f 1 -R $readPw -W $writePw -M $multiPw\"",
+            "ssh $::SUDOER\@$hcp \"$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $userId -v $addr -t 3390 -a AUTOG -r $pool -u 1 -z $cyl -m $mode -f 1 -R xxxxxxxx -W xxxxxxxx -M xxxxxxxx\"",
             $hcp, "changeVM", $out, $node );
         if ( $rc != 0 ) {
             xCAT::zvmUtils->printLn( $callback, $outmsg );
@@ -1330,7 +1330,7 @@ sub changeVM {
         my $error = 0;
         $out = `ssh $::SUDOER\@$hcp "$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $userId -v $addr -t 9336 -a AUTOG -r $pool -u 2 -z $blks -m $mode -f 1 -R $readPw -W $writePw -M $multiPw 2>&1"`;
         ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?,
-            "ssh $::SUDOER\@$hcp \"$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $userId -v $addr -t 9336 -a AUTOG -r $pool -u 2 -z $blks -m $mode -f 1 -R $readPw -W $writePw -M $multiPw 2>&1\"",
+            "ssh $::SUDOER\@$hcp \"$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $userId -v $addr -t 9336 -a AUTOG -r $pool -u 2 -z $blks -m $mode -f 1 -R xxxxxxxx -W xxxxxxxx -M xxxxxxxx 2>&1\"",
             $hcp, "changeVM", $out, $node );
         if ( $rc != 0 ) {
             xCAT::zvmUtils->printLn( $callback, "$node: $out" );
@@ -1617,15 +1617,17 @@ EOF"`;
         my $i;
         my @options = ("", "vol_addr=", "volume_label=", "volume_use=", "system_config_name=", "system_config_type=", "parm_disk_owner=", "parm_disk_number=", "parm_disk_password=");
         my $argStr = "";
+        my $logStr = "";
         foreach $i ( 1 .. $argsSize ) {
             if ( $args->[$i] ) {
                 $argStr .= " -k \"$options[$i]$args->[$i]\"";
+                $logStr .= ( $i == 8 ) ? " -k \"$options[$i]xxxxxxxx\"" : " -k \"$options[$i]$args->[$i]\"";
             }
         }
 
         # Add a full volume page or spool disk to the system
         $out .= `ssh $::SUDOER\@$hcp "$::SUDO $::DIR/smcli Page_or_Spool_Volume_Add -T $hcpUserId $argStr"`;
-        xCAT::zvmUtils->printSyslog("smcli Page_or_Spool_Volume_Add -T $hcpUserId $argStr");
+        xCAT::zvmUtils->printSyslog("smcli Page_or_Spool_Volume_Add -T $hcpUserId $logStr");
         $out = xCAT::zvmUtils->appendHostname( $node, $out );
     }
 
@@ -3034,7 +3036,7 @@ EOF"`;
         my $pw = $args->[1];
 
         $out = `ssh $::SUDOER\@$hcp "$::SUDO $::DIR/smcli Image_Password_Set_DM -T $userId -p $pw"`;
-        xCAT::zvmUtils->printSyslog("smcli Image_Password_Set_DM -T $userId -p $pw");
+        xCAT::zvmUtils->printSyslog("smcli Image_Password_Set_DM -T $userId -p xxxxxxxx");
         $out = xCAT::zvmUtils->appendHostname( $node, $out );
     }
 
@@ -4434,7 +4436,7 @@ sub listVM {
                     # Not return $out to upper layer as it might contain password
                     xCAT::zvmUtils->printLn( $callback, "$node: (Error) not able to find $dev in user direct");
 
-                    xCAT::zvmUtils->printSyslog("$node: (Error) not able to find $dev in user direct: $out");
+                    xCAT::zvmUtils->printSyslog("$node: (Error) not able to find $dev in user direct: " . xCAT::zvmUtils->redact_directory_entry($out));
                     return;
                 }
             } else {
@@ -5106,7 +5108,7 @@ sub cloneVM {
     my %srcDiskType;
     my @srcDisks = xCAT::zvmUtils->getMdisks( $callback, $::SUDOER, $sourceNode );
     if (xCAT::zvmUtils->checkOutput( $srcDisks[0] ) == -1) {
-        xCAT::zvmUtils->printLn( $callback, "$srcDisks[0]" );
+        xCAT::zvmUtils->printLn( $callback, xCAT::zvmUtils->redact_directory_entry($srcDisks[0]) );
         return;
     }
 
@@ -5115,8 +5117,8 @@ sub cloneVM {
     #   MDISK=VDEV=0100 DEVTYPE=3390 START=0001 COUNT=10016 VOLID=EMC2C4 MODE=MR
     $out = `ssh $::SUDOER\@$srcHcp "$::SUDO $::DIR/smcli Image_Definition_Query_DM -T $sourceId -k MDISK"`;
     xCAT::zvmUtils->printSyslog("smcli Image_Definition_Query_DM -T $sourceId -k MDISK");
-    xCAT::zvmUtils->printSyslog("$out");
-    xCAT::zvmUtils->printSyslog("srcDisks:@srcDisks");
+    xCAT::zvmUtils->printSyslog(xCAT::zvmUtils->redact_directory_entry($out));
+    xCAT::zvmUtils->printSyslog("srcDisks:" . xCAT::zvmUtils->redact_directory_entry("@srcDisks"));
     my $srcDiskDet = xCAT::zvmUtils->trimStr($out);
     foreach (@srcDisks) {
 
@@ -5220,7 +5222,7 @@ sub cloneVM {
     xCAT::zvmCPUtils->loadVmcp($::SUDOER, $sourceNode);
     $out = `ssh $::SUDOER\@$srcHcp "$::SUDO $::DIR/smcli Image_Definition_Query_DM -T $sourceId -k NICDEF"`;
     xCAT::zvmUtils->printSyslog("smcli Image_Definition_Query_DM -T $sourceId -k NICDEF");
-    xCAT::zvmUtils->printSyslog("$out");
+    xCAT::zvmUtils->printSyslog(xCAT::zvmUtils->redact_directory_entry($out));
     # Output is similar to:
     #   NICDEF_PROFILE=VDEV=0800 TYPE=QDIO LAN=SYSTEM SWITCHNAME=VSW2
     #   NICDEF=VDEV=0900 TYPE=QDIO DEVICES=3 LAN=SYSTEM SWITCHNAME=GLAN1
@@ -5640,7 +5642,7 @@ sub clone {
         # Check if user entry is created
         $out = `ssh $::SUDOER\@$hcp "$::SUDO $::DIR/smcli Image_Query_DM -T $tgtUserId" | sed '\$d'`;
         xCAT::zvmUtils->printSyslog("smcli Image_Query_DM -T $tgtUserId | sed '\$d'");
-        xCAT::zvmUtils->printSyslog("$out");
+        xCAT::zvmUtils->printSyslog(xCAT::zvmUtils->redact_directory_entry($out));
         $rc  = xCAT::zvmUtils->checkOutput( $out );
 
         if ( $rc == -1 ) {
@@ -5732,7 +5734,7 @@ sub clone {
                     xCAT::zvmUtils->printLn( $callback, "$tgtNode: Trying again ($try) to add minidisk ($addr)" );
                 }
                 $out = `ssh $::SUDOER\@$hcp "$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 3390 -a AUTOG -r $pool -u 1 -z $cyl -m $mode -f 1 -R $tgtPw -W $tgtPw -M $tgtPw"`;
-                xCAT::zvmUtils->printSyslog("smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 3390 -a AUTOG -r $pool -u 1 -z $cyl -m $mode -f 1 -R $tgtPw -W $tgtPw -M $tgtPw");
+                xCAT::zvmUtils->printSyslog("smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 3390 -a AUTOG -r $pool -u 1 -z $cyl -m $mode -f 1 -R xxxxxxxx -W xxxxxxxx -M xxxxxxxx");
                 xCAT::zvmUtils->printSyslog("$out");
                 xCAT::zvmUtils->printLn( $callback, "$out" );
 
@@ -5776,7 +5778,7 @@ sub clone {
                     xCAT::zvmUtils->printLn( $callback, "$tgtNode: Trying again ($try) to add minidisk ($addr)" );
                 }
                 $out = `ssh $::SUDOER\@$hcp "$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 9336 -a AUTOG -r $pool -u 1 -z $blks -m $mode -f 1 -R $tgtPw -W $tgtPw -M $tgtPw"`;
-                xCAT::zvmUtils->printSyslog("smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 9336 -a AUTOG -r $pool -u 1 -z $blks -m $mode -f 1 -R $tgtPw -W $tgtPw -M $tgtPw");
+                xCAT::zvmUtils->printSyslog("smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 9336 -a AUTOG -r $pool -u 1 -z $blks -m $mode -f 1 -R xxxxxxxx -W xxxxxxxx -M xxxxxxxx");
                 xCAT::zvmUtils->printSyslog("$out");
                 xCAT::zvmUtils->printLn( $callback, "$out" );
 
@@ -5814,13 +5816,14 @@ sub clone {
         # Get disks within user entry
         xCAT::zvmUtils->printSyslog("smcli Image_Query_DM -T $tgtUserId");
         $out = `ssh $::SUDOER\@$hcp "$::SUDO $::DIR/smcli Image_Query_DM -T $tgtUserId"`;
+        $out = xCAT::zvmUtils->redact_directory_entry($out);
         ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?, "ssh $::SUDOER\@$hcp \"$::SUDO $::DIR/smcli Image_Query_DM -T $tgtUserId\"", $hcp, "clone", $out, $tgtNode );
         if ($rc != 0) {
             xCAT::zvmUtils->printLn( $callback, "$outmsg" );
             return;
         }
         $out = `echo "$out" | sed '\$d' | grep -a -i "MDISK"`;
-        xCAT::zvmUtils->printSyslog("$out");
+        xCAT::zvmUtils->printSyslog(xCAT::zvmUtils->redact_directory_entry($out));
         @disks = split( '\n', $out );
 
         if ( @disks != @tgtDisks ) {
@@ -6988,7 +6991,7 @@ sub nodeSet {
             $out = `sed -i -e "s,replace_master,$master,g" $customTmpl`;
             $out = `sed -i -e "s,replace_install_dir,$installDir,g" $customTmpl`;
 
-            xCAT::zvmUtils->printSyslog("***Provision settings for SLES:replace_host_address,$hostIP replace_long_name,$hostname replace_short_name,$node replace_domain,$domain replace_hostname,$node replace_nameserver,$nameserver replace_broadcast,$broadcast replace_device,$device replace_ipaddr,$hostIP replace_lladdr,$mac replace_netmask,$mask replace_network,$network replace_ccw_chan_ids,$chanIds replace_ccw_chan_mode,FOOBAR replace_gateway,$gateway replace_root_password,$passwd replace_nic_addr,$readChannel replace_master,$master replace_install_dir,$installDir $customTmpl");
+            xCAT::zvmUtils->printSyslog("***Provision settings for SLES:replace_host_address,$hostIP replace_long_name,$hostname replace_short_name,$node replace_domain,$domain replace_hostname,$node replace_nameserver,$nameserver replace_broadcast,$broadcast replace_device,$device replace_ipaddr,$hostIP replace_lladdr,$mac replace_netmask,$mask replace_network,$network replace_ccw_chan_ids,$chanIds replace_ccw_chan_mode,FOOBAR replace_gateway,$gateway replace_root_password,xxxxxxxx replace_nic_addr,$readChannel replace_master,$master replace_install_dir,$installDir $customTmpl");
 
             # Attach SCSI FCP devices (if any)
             # Go through each pool
@@ -7278,7 +7281,7 @@ END
             $out = `sed -i -e "s,replace_master,$master,g" $customTmpl`;
             $out = `sed -i -e "s,replace_install_dir,$installDir,g" $customTmpl`;
 
-            xCAT::zvmUtils->printSyslog("***Provision settings for RedHat:replace_url,$repo replace_ip,$hostIP replace_netmask,$mask replace_gateway,$gateway replace_nameserver,$nameserver replace_hostname,$hostname replace_rootpw,$passwd replace_master,$master replace_install_dir,$installDir  for file==>$customTmpl");
+            xCAT::zvmUtils->printSyslog("***Provision settings for RedHat:replace_url,$repo replace_ip,$hostIP replace_netmask,$mask replace_gateway,$gateway replace_nameserver,$nameserver replace_hostname,$hostname replace_rootpw,xxxxxxxx replace_master,$master replace_install_dir,$installDir  for file==>$customTmpl");
 
             # Attach SCSI FCP devices (if any)
             # Go through each pool
@@ -7374,7 +7377,7 @@ END
             # Get mdisk virtual address
             my @mdisks = xCAT::zvmUtils->getMdisks( $callback, $::SUDOER, $node );
             if (xCAT::zvmUtils->checkOutput( $mdisks[0] ) == -1) {
-                xCAT::zvmUtils->printLn( $callback, "$mdisks[0]" );
+                xCAT::zvmUtils->printLn( $callback, xCAT::zvmUtils->redact_directory_entry($mdisks[0]) );
                 return;
             }
             @mdisks = sort(@mdisks);
@@ -7729,7 +7732,7 @@ END
             # Get the list of mdisks
             my @srcDisks = xCAT::zvmUtils->getMdisks( $callback, $::SUDOER, $node );
             if (xCAT::zvmUtils->checkOutput( $srcDisks[0] ) == -1) {
-                xCAT::zvmUtils->printLn( $callback, "$srcDisks[0]" );
+                xCAT::zvmUtils->printLn( $callback, xCAT::zvmUtils->redact_directory_entry($srcDisks[0]) );
                 return;
             }
 
@@ -11145,7 +11148,7 @@ sub imageCapture {
         # Get the list of mdisks
         my @srcDisks = xCAT::zvmUtils->getMdisks( $callback, $sudoer, $node );
         if (xCAT::zvmUtils->checkOutput( $srcDisks[0] ) == -1) {
-            xCAT::zvmUtils->printLn( $callback, "$srcDisks[0]" );
+            xCAT::zvmUtils->printLn( $callback, xCAT::zvmUtils->redact_directory_entry($srcDisks[0]) );
             return;
         }
         foreach (@srcDisks) {
@@ -11570,7 +11573,7 @@ sub specialcloneVM {
     xCAT::zvmUtils->printSyslog("Executing: ssh $::SUDOER\@$tgtZhcp $::SUDO $dir/smcli Image_Query_DM -T $sourceId | sed '\$d'\n");
     $out = `ssh $::SUDOER\@$tgtZhcp "$::SUDO $dir/smcli Image_Query_DM -T $sourceId" | sed '\$d'`;
     if (xCAT::zvmUtils->checkOutput( $out ) == -1) {
-        xCAT::zvmUtils->printLn( $callback, "(Error) Did not get the $sourceId directory. Return output was: $out." );
+        xCAT::zvmUtils->printLn( $callback, "(Error) Did not get the $sourceId directory. Return output was: " . xCAT::zvmUtils->redact_directory_entry($out) . "." );
         return;
     }
 
@@ -11589,7 +11592,7 @@ sub specialcloneVM {
     #   MDISK=VDEV=0100 DEVTYPE=3390 START=0001 COUNT=10016 VOLID=EMC2C4 MODE=MR
     $out = `ssh $::SUDOER\@$tgtZhcp "$::SUDO $::DIR/smcli Image_Definition_Query_DM -T $sourceId -k MDISK"`;
     if (xCAT::zvmUtils->checkOutput( $out ) == -1) {
-        xCAT::zvmUtils->printLn( $callback, "(Error) Did not get the $sourceId mini disks. Return output was: $out." );
+        xCAT::zvmUtils->printLn( $callback, "(Error) Did not get the $sourceId mini disks. Return output was: " . xCAT::zvmUtils->redact_directory_entry($out) . "." );
         return;
     }
 
@@ -12037,7 +12040,7 @@ sub specialClone {
                     xCAT::zvmUtils->printLn( $callback, "$tgtNode: Trying again ($try) to add minidisk ($addr)" );
                 }
                 $out = `ssh $::SUDOER\@$hcp "$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 3390 -a AUTOG -r $ECKD_Pool -u 1 -z $disksize -m $mode -f 1 -R $tgtPw -W $tgtPw -M $tgtPw"`;
-                xCAT::zvmUtils->printSyslog("smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 3390 -a AUTOG -r $ECKD_Pool -u 1 -z $disksize -m $mode -f 1 -R $tgtPw -W $tgtPw -M $tgtPw");
+                xCAT::zvmUtils->printSyslog("smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 3390 -a AUTOG -r $ECKD_Pool -u 1 -z $disksize -m $mode -f 1 -R xxxxxxxx -W xxxxxxxx -M xxxxxxxx");
                 xCAT::zvmUtils->printSyslog("$out");
                 xCAT::zvmUtils->printLn( $callback, "$out" );
 
@@ -12080,7 +12083,7 @@ sub specialClone {
                     xCAT::zvmUtils->printLn( $callback, "$tgtNode: Trying again ($try) to add minidisk ($addr)" );
                 }
                 $out = `ssh $::SUDOER\@$hcp "$::SUDO $::DIR/smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 9336 -a AUTOG -r $FBA_Pool -u 1 -z $disksize -m $mode -f 1 -R $tgtPw -W $tgtPw -M $tgtPw"`;
-                xCAT::zvmUtils->printSyslog("smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 9336 -a AUTOG -r $FBA_Pool -u 1 -z $disksize -m $mode -f 1 -R $tgtPw -W $tgtPw -M $tgtPw");
+                xCAT::zvmUtils->printSyslog("smcli Image_Disk_Create_DM -T $tgtUserId -v $addr -t 9336 -a AUTOG -r $FBA_Pool -u 1 -z $disksize -m $mode -f 1 -R xxxxxxxx -W xxxxxxxx -M xxxxxxxx");
                 xCAT::zvmUtils->printSyslog("$out");
                 xCAT::zvmUtils->printLn( $callback, "$out" );
 
@@ -12118,13 +12121,14 @@ sub specialClone {
         # Get disks within user entry
         xCAT::zvmUtils->printSyslog("smcli Image_Query_DM -T $tgtUserId");
         $out = `ssh $::SUDOER\@$hcp "$::SUDO $::DIR/smcli Image_Query_DM -T $tgtUserId"`;
+        $out = xCAT::zvmUtils->redact_directory_entry($out);
         ($rc, $outmsg) = xCAT::zvmUtils->checkSSH_Rc( $?, "ssh $::SUDOER\@$hcp \"$::SUDO $::DIR/smcli Image_Query_DM -T $tgtUserId\"", $hcp, "specialClone", $out, $tgtNode );
         if ($rc != 0) {
             xCAT::zvmUtils->printLn( $callback, "$outmsg" );
             return;
         }
         $out = `echo "$out" | sed '\$d' | grep -a -i "MDISK"`;
-        xCAT::zvmUtils->printSyslog("$out");
+        xCAT::zvmUtils->printSyslog(xCAT::zvmUtils->redact_directory_entry($out));
         @disks = split( '\n', $out );
 
         if ( @disks != @tgtDisks ) {

--- a/xCAT-test/unit/plugin_log_password_redaction.t
+++ b/xCAT-test/unit/plugin_log_password_redaction.t
@@ -1,0 +1,309 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+no warnings 'once';
+
+our @executed_commands;
+BEGIN {
+    no warnings 'redefine';
+    *CORE::GLOBAL::readpipe = sub {
+        my ($command) = @_;
+        push @executed_commands, $command;
+        return "$command: off\n" if $command =~ m{/opt/xcat/bin/rpower};
+        return '';
+    };
+}
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use lib "$FindBin::Bin/../../perl-xCAT";
+use lib "$FindBin::Bin/../../xCAT-server/lib/perl";
+use HTTP::Request;
+use POSIX qw(_exit);
+use Test::More;
+
+use XCAT::Test::File qw(repo_path);
+use xCAT::CIMUtils;
+use xCAT::PPCcfg;
+use xCAT::zvmUtils;
+
+{
+    package xCAT::IMMUtils;
+    sub setupIMM { return; }
+}
+$INC{'xCAT/IMMUtils.pm'} = __FILE__;
+
+foreach my $relative (
+    qw(
+      xCAT-server/lib/xcat/plugins/bmcconfig.pm
+      xCAT-server/lib/xcat/plugins/energy.pm
+      xCAT-server/lib/xcat/plugins/zvm.pm
+      )
+  ) {
+    my $plugin_path = repo_path($relative);
+    require $plugin_path;
+}
+
+{
+    package XCAT::Test::BmcTable;
+
+    sub getNodesAttribs {
+        return { node1 => [ { bmc => 'bmc1' } ] };
+    }
+}
+
+{
+    package XCAT::Test::EnergyTable;
+
+    sub getNodesAttribs {
+        my ($self) = @_;
+        return { node1 => [ { bmc => 'hcp1' } ] } if $self->{name} eq 'ipmi';
+        return { node1 => [ {} ] } if $self->{name} eq 'ppc';
+        return { node1 => [ { mgt => 'ipmi' } ] } if $self->{name} eq 'nodehm';
+        return {};
+    }
+
+    sub getAttribs {
+        my ($self) = @_;
+        return { username => 'energy-user', password => 'SENTENERGYPASS' }
+          if $self->{name} eq 'passwd';
+        return undef;
+    }
+}
+
+sub directory_entry {
+    return xCAT::zvmUtils->redact_directory_entry( $_[0] );
+}
+
+subtest 'z/VM directory entries are redacted as data' => sub {
+    unlike( directory_entry('USER LNX1 SENTUSERPW 512M 1G G'), qr/SENTUSERPW/,
+        'USER logon password is masked' );
+    unlike( directory_entry('IDENTITY LNX2 SENTIDPW 512M 1G G'), qr/SENTIDPW/,
+        'IDENTITY logon password is masked' );
+    unlike( directory_entry('MDISK 0100 3390 0001 10016 EMC2C4 MR SENTRPW SENTWPW SENTMPW'),
+        qr/SENTRPW|SENTWPW|SENTMPW/, 'MDISK passwords are masked' );
+    is( directory_entry('MDISK 0100 3390 0001 10016 EMC2C4 MR'),
+        'MDISK 0100 3390 0001 10016 EMC2C4 MR',
+        'a passwordless MDISK statement is unchanged' );
+    unlike( directory_entry('MDISK=VDEV=0100 DEVTYPE=3390 MODE=MR READPW=SENTKW'), qr/SENTKW/,
+        'keyword passwords are masked' );
+    unlike( directory_entry('IDENT MAINT SENTABBR 512M 1G G'), qr/SENTABBR/,
+        'abbreviated IDENT logon password is masked' );
+    unlike( directory_entry('MDISK 0199 3390 DEVNO 0201 MR SENTDEVR SENTDEVW'),
+        qr/SENTDEVR|SENTDEVW/, 'DEVNO disk passwords are masked' );
+    unlike( directory_entry('READPASSWORD=SENTRP WRITEPASSWORD=SENTWP MULTIPASSWORD=SENTMP'),
+        qr/SENTRP|SENTWP|SENTMP/, 'full keyword password names are masked' );
+    unlike( directory_entry('APPCPASS LUA LUB USERX SENTAPPC'), qr/SENTAPPC/,
+        'APPCPASS statement is masked' );
+    is( directory_entry('MDISK 0401 FB-512 V-DISK 8000 MW SENTREAD'),
+        'MDISK 0401 FB-512 V-DISK 8000 MW xxxxxxxx',
+        'V-DISK read password is masked' );
+    is( directory_entry('MDISK 0401 FB-512 V-DISK 8000 MW SENTR SENTW SENTM'),
+        'MDISK 0401 FB-512 V-DISK 8000 MW xxxxxxxx',
+        'all V-DISK passwords are masked' );
+    is( directory_entry("MDISK 0199 3390 DEVNO 0201 MR\nNICDEF 0600 TYPE QDIO LAN SYSTEM VSW1"),
+        "MDISK 0199 3390 DEVNO 0201 MR\nNICDEF 0600 TYPE QDIO LAN SYSTEM VSW1",
+        'a passwordless record does not consume the next record' );
+    unlike( directory_entry('* USER LNX1 SENTCOMU 512M 1G G'), qr/SENTCOMU/,
+        'commented USER record is masked' );
+    unlike( directory_entry('* IDENT LNX2 SENTCOMI 512M 1G G'), qr/SENTCOMI/,
+        'commented IDENT record is masked' );
+    unlike( directory_entry('* MDISK 0100 3390 0001 10016 EMC2C4 MR SENTCOMR SENTCOMW'),
+        qr/SENTCOMR|SENTCOMW/, 'commented range MDISK record is masked' );
+    unlike( directory_entry('* MDISK 0401 FB-512 V-DISK 8000 MW SENTCOMV'), qr/SENTCOMV/,
+        'commented V-DISK record is masked' );
+    unlike( directory_entry('*APPCPASS LUA LUB USERX SENTCOMA'), qr/SENTCOMA/,
+        'commented APPCPASS record is masked' );
+    unlike( directory_entry('** USER LNX1 SENTSTARS 512M 1G G'), qr/SENTSTARS/,
+        'doubly commented USER record is masked' );
+    unlike( directory_entry('COMMAND XAUTOLOG VSEVM PW SENTAUTO'), qr/SENTAUTO/,
+        'COMMAND record is masked' );
+    unlike( directory_entry('* COMMAND XAUTOLOG VSEVM PW SENTCAUTO'), qr/SENTCAUTO/,
+        'commented COMMAND record is masked' );
+    like( directory_entry("USER LNX1 SENTUSERPW 512M 1G G\nNICDEF 0600 TYPE QDIO LAN SYSTEM VSW1"),
+        qr/NICDEF 0600 TYPE QDIO LAN SYSTEM VSW1/,
+        'records beside credentials are preserved' );
+};
+
+subtest 'z/VM commands keep secrets out of logging boundaries' => sub {
+    my (@syslog, @checked_commands, @callbacks);
+    no warnings 'redefine';
+    local *xCAT::zvmUtils::getNodeProps = sub {
+        return { status => '', hcp => 'zhcp1', userid => 'linux1' };
+    };
+    local *xCAT::zvmCPUtils::getUserId = sub { return 'maint'; };
+    local *xCAT::zvmUtils::printSyslog = sub { push @syslog, $_[1]; };
+    local *xCAT::zvmUtils::printLn = sub { push @callbacks, $_[2]; };
+    local *xCAT::zvmUtils::checkSSH_Rc = sub {
+        push @checked_commands, $_[2];
+        return ( 0, '' );
+    };
+    local *xCAT::zvmUtils::appendHostname = sub { return $_[2]; };
+    local $::SUDOER = 'root';
+    local $::SUDO   = 'sudo';
+    local $::DIR    = '/opt/zhcp';
+
+    @executed_commands = ();
+    xCAT_plugin::zvm::changeVM(
+        sub { }, 'node1',
+        [ '--add3390', 'pool1', '0100', '100', 'MR', 'SENTREAD', 'SENTWRITE', 'SENTMULTI' ]
+    );
+    my $executed = join "\n", @executed_commands;
+    my $observed = join "\n", @syslog, @checked_commands, @callbacks;
+    like( $executed, qr/SENTREAD.*SENTWRITE.*SENTMULTI/,
+        'disk creation receives the real passwords' );
+    unlike( $observed, qr/SENTREAD|SENTWRITE|SENTMULTI/,
+        'disk creation logs and errors omit the real passwords' );
+    like( $observed, qr/-R xxxxxxxx -W xxxxxxxx -M xxxxxxxx/,
+        'disk creation logging retains masked options' );
+
+    @executed_commands = ();
+    @syslog = ();
+    xCAT_plugin::zvm::changeVM(
+        sub { }, 'node1',
+        [ '--addpagespool', '0101', 'PAGE01', 'PAGE', 'SYSTEM', 'TYPE', 'OWNER', 'NUMBER', 'SENTPAGEPASS' ]
+    );
+    $executed = join "\n", @executed_commands;
+    $observed = join "\n", @syslog;
+    like( $executed, qr/parm_disk_password=SENTPAGEPASS/,
+        'page volume creation receives the real password' );
+    unlike( $observed, qr/SENTPAGEPASS/,
+        'page volume logging omits the real password' );
+    like( $observed, qr/parm_disk_password=xxxxxxxx/,
+        'page volume logging retains the masked operand' );
+
+    @executed_commands = ();
+    @syslog = ();
+    xCAT_plugin::zvm::changeVM( sub { }, 'node1', [ '--setpassword', 'SENTIMAGEPASS' ] );
+    $executed = join "\n", @executed_commands;
+    $observed = join "\n", @syslog;
+    like( $executed, qr/Image_Password_Set_DM.*SENTIMAGEPASS/,
+        'password update receives the real password' );
+    unlike( $observed, qr/SENTIMAGEPASS/,
+        'password update logging omits the real password' );
+    like( $observed, qr/Image_Password_Set_DM.*xxxxxxxx/,
+        'password update logging retains the mask' );
+};
+
+subtest 'CIM verbose request masks authorization' => sub {
+    my $request = HTTP::Request->new( GET => 'http://example.invalid/' );
+    $request->header( Authorization => 'Basic SENTCIMSECRET' );
+    my @callbacks;
+    no warnings 'redefine';
+    local *LWP::UserAgent::request = sub {
+        return { _rc => 200, _msg => 'OK', _content => 'response' };
+    };
+    my $result = xCAT::CIMUtils::send_http_request(
+        {
+            protocol => 'http',
+            verbose  => 1,
+            callback => sub { push @callbacks, $_[0] },
+        },
+        $request
+    );
+    is( $result->{rc}, 0, 'stubbed CIM request succeeds' );
+    my $dump = join "\n", map { @{ $_->{data} } } @callbacks;
+    unlike( $dump, qr/SENTCIMSECRET/, 'verbose callback omits the authorization value' );
+    like( $dump, qr/^Authorization: xxxxxxxx$/m,
+        'verbose callback retains a masked authorization header' );
+};
+
+subtest 'BMC missing-attribute reports expose only password state' => sub {
+    foreach my $case (
+        [ 'SENTBMCPASS', 'set' ],
+        [ '0',           'set' ],
+        [ '',            'missing' ],
+      ) {
+        my ( $password, $state ) = @{$case};
+        my (@logs, @callbacks);
+        no warnings 'redefine';
+        local *xCAT_plugin::bmcconfig::ok_with_node = sub { return 1; };
+        local *xCAT_plugin::bmcconfig::net_parms = sub { return ( undef, '255.255.255.0', '192.0.2.1' ); };
+        local *xCAT::Table::new = sub { return bless {}, 'XCAT::Test::BmcTable'; };
+        local *xCAT::PasswordUtils::getIPMIAuth = sub {
+            return { node1 => { username => 'ADMIN', password => $password } };
+        };
+        local *xCAT::MsgUtils::message = sub { push @logs, $_[2]; };
+        local %::XCATSITEVALS = ( genpasswords => '0' );
+
+        xCAT_plugin::bmcconfig::process_request(
+            {
+                _xcat_clienthost => ['node1'],
+                command          => ['getbmcconfig'],
+                isopenbmc        => [0],
+            },
+            sub { push @callbacks, $_[0] }
+        );
+
+        my $observed = join "\n", @logs,
+          map { ref $_->{error} ? @{ $_->{error} } : () } @callbacks;
+        unlike( $observed, qr/SENTBMCPASS/, "$state password report omits the value" );
+        like( $observed, qr/Pass=\Q$state\E/, "$state password report names its state" );
+    }
+};
+
+subtest 'PPC verbose messages preserve credentials but mask passwords' => sub {
+    my @logs;
+    my %targets = (
+        hmc => { hmc1 => { name => 'hmc1', type => 'hmc' } },
+        fsp => { fsp1 => { name => 'fsp1', type => 'fsp' } },
+        bpa => { bpa1 => { name => 'bpa1', type => 'bpa' } },
+    );
+    no warnings 'redefine';
+    local *xCAT::PPCdb::credentials = sub { return ( 'ppc-user', 'SENTPPCPASS' ); };
+    local *xCAT::MsgUtils::verbose_message = sub { push @logs, $_[2]; };
+
+    xCAT::PPCcfg::get_rsp_dev( {}, \%targets );
+
+    is( $targets{hmc}{hmc1}{password}, 'SENTPPCPASS', 'HMC keeps the real password' );
+    is( $targets{fsp}{fsp1}{password}, 'SENTPPCPASS', 'FSP keeps the real password' );
+    is( $targets{bpa}{bpa1}{password}, 'SENTPPCPASS', 'BPA keeps the real password' );
+    my $observed = join "\n", @logs;
+    unlike( $observed, qr/SENTPPCPASS/, 'verbose messages omit the real password' );
+    is( scalar grep( /ppc-user xxxxxxxx/, @logs ), 3,
+        'each credential report retains the user and password mask' );
+};
+
+subtest 'energy verbose message masks only the transport log' => sub {
+    pipe( my $reader, my $writer ) or die "pipe: $!";
+    my $pid = fork();
+    die "fork: $!" unless defined $pid;
+    if ( $pid == 0 ) {
+        close $reader;
+        no warnings 'redefine';
+        local *xCAT::Table::new = sub {
+            return bless { name => $_[1] }, 'XCAT::Test::EnergyTable';
+        };
+        local *xCAT::Utils::xfork = sub { return 0; };
+        local *xCAT::NetworkUtils::getipaddr = sub { return '192.0.2.10'; };
+        local *xCAT::MsgUtils::message = sub {
+            my $payload = $_[2];
+            print {$writer} "log=" . join( '', @{ $payload->{data} } ) . "\n";
+        };
+        local *xCAT_plugin::energy::run_cim = sub {
+            my $args = $_[2];
+            print {$writer} "transport=$args->{password}\n";
+            return 0;
+        };
+        xCAT_plugin::energy::process_request(
+            { node => ['node1'], arg => [], verbose => 1 },
+            sub { },
+            undef
+        );
+        _exit(1);
+    }
+    close $writer;
+    my $observed = do { local $/; <$reader> };
+    close $reader;
+    waitpid( $pid, 0 );
+
+    is( $? >> 8, 0, 'energy request child exits cleanly' );
+    like( $observed, qr/^transport=SENTENERGYPASS$/m,
+        'CIM transport receives the real password' );
+    unlike( $observed, qr/^log=.*SENTENERGYPASS/m,
+        'verbose energy message omits the real password' );
+    like( $observed, qr/^log=.*password \[xxxxxxxx\]$/m,
+        'verbose energy message retains a masked password field' );
+};
+
+done_testing();


### PR DESCRIPTION
The follow-up for #7735: some plugins write passwords into their own log and diagnostic messages, outside the daemon redaction pipeline. Most of the sinks sit in the legacy z/VM support; bmcconfig, energy, the PPC configuration and the CIM utilities each leaked one message as well.

The logged text now masks the passwords. The executed commands and the functional return values keep the real records. A guard test drives the redaction with sentinel records and pins every sink. These paths need hardware that is not available for testing, so validation is the guard test plus a syntax check of each module.