### PR TITLE
feat: add `genpdu` pdutype for generic SNMP PDUs (PDU2-MIB)

### DIFF
--- a/docs/source/advanced/pdu/genpdu.rst
+++ b/docs/source/advanced/pdu/genpdu.rst
@@ -120,7 +120,7 @@ The following commands are supported against a PDU:
          mypdu: inlet 1 Power Factor: 0.99
          mypdu: inlet 1 Frequency: 60.0 Hz
          mypdu: inlet 1 Unbalanced Current: 11 %
-         mypdu: inlet 1 Reactive Power: 0 var
+         mypdu: inlet 1 Reactive Power: -1360 var
          mypdu: inlet 1 Active Energy: 145702407 Wh
          mypdu: inlet 1 Apparent Energy: 147093631 VAh
          mypdu: outlet 1 RMS Current: 0.000 A
@@ -137,6 +137,12 @@ The following commands are supported against a PDU:
      appears as ``13.959 A`` on a PX4 and ``18.1 A`` on a PX2, because the two
      devices declare a different number of decimal digits for it.
 
+     Sensors that can read negative, such as reactive power, are taken from the
+     signed value column of the MIB, which the device selects through the
+     sensor's signed minimum. The unsigned column is used for every other
+     sensor, including wide-range ones such as active energy, where the signed
+     column does not apply.
+
      Sensors that the device does not report are omitted, so the exact set of
      lines varies by model. Per-outlet sensors are skipped entirely on models
      that do not meter individual outlets. The reported sensor types are a
@@ -151,7 +157,7 @@ The following commands are supported against a PDU:
 Limitations
 -----------
 
-   * PDU linking (cascading multiple PDUs behind one management interface) is not supported. The MIB indexes outlets by link ID, and xCAT assumes the value used by unlinked units. BCM2 and PMC power meters are also out of scope for the same reason.
+   * PDU linking (cascading multiple PDUs behind one management interface) is not supported. The MIB indexes outlets by link ID, and xCAT assumes the value used by unlinked units, so only the primary unit is managed. BCM2 and PMC power meters are out of scope for the same reason. A PDU reporting more than one unit is not refused, but every command against it warns that only the primary unit is being driven.
 
    * ``authtype``, ``privtype`` and the other SNMP attributes are per-PDU attributes in the ``pdu`` table, so PDUs using different SNMP protocols need their values set individually.
 

--- a/docs/source/advanced/pdu/genpdu.rst
+++ b/docs/source/advanced/pdu/genpdu.rst
@@ -1,0 +1,164 @@
+Generic SNMP PDU
+================
+
+The generic SNMP PDU support (``pdutype=genpdu``) drives any PDU that implements the Raritan **PDU2-MIB**. A single MIB covers the Raritan PX2, PX3, PX4, PXC, SRC, PXO and BCM series, the Server Technology PRO3X and PRO4X series, and the Legrand intelligent PDUs, so the same code path applies to all of them without per-model configuration.
+
+xCAT communicates with these PDUs over SNMP v1, v2c or v3, using the credentials in the ``pdu`` table. Unlike the other PDU types, the sensor scaling factors and units are read from the device rather than hardcoded, so readings are correct on any model regardless of the precision it reports.
+
+
+Defining a PDU
+--------------
+
+Create the PDU node definition and set the SNMP credentials in the ``pdu`` table.
+
+For SNMP v2c: ::
+
+    mkdef mypdu groups=pdu nodetype=pdu mgt=pdu pdutype=genpdu
+    chdef mypdu snmpversion=2 community=<community>
+
+For SNMP v3: ::
+
+    mkdef mypdu groups=pdu nodetype=pdu mgt=pdu pdutype=genpdu
+    chdef mypdu snmpversion=3 snmpuser=<user> \
+                authtype=SHA authkey=<passphrase> \
+                privtype=AES privkey=<passphrase> seclevel=authPriv
+
+The ``seclevel`` attribute is optional. When it is not set, ``authPriv`` is used if ``privtype`` is set and ``authNoPriv`` otherwise. When ``privkey`` is not set it falls back to ``authkey``. If ``authtype`` or ``privtype`` are not set they default to ``SHA`` and ``DES``.
+
+The ``outlet`` attribute is discovered automatically from the MIB on first use and cached in the ``pdu`` table. It can also be set explicitly to skip the discovery query.
+
+
+Switched and metered PDUs
+-------------------------
+
+PDU2-MIB covers both switched models and metered-only models. xCAT detects which it is talking to at connection time, so no configuration is needed to distinguish them.
+
+On a metered-only PDU, ``rinv`` and ``rvitals`` work normally, and the power control commands report that switching is unavailable rather than failing per outlet: ::
+
+    # rpower mypdu stat
+      mypdu: this PDU does not support outlet switching
+
+Writing to a switched PDU requires credentials with write access. SNMP agents on these devices commonly grant read-only access by default, in which case xCAT reports ``noAccess`` on power commands while read commands continue to work. Configure a read-write community, or an SNMP v3 user with write permission, on the PDU itself.
+
+
+PDU Commands
+------------
+
+Administrators will need to know the exact mapping of the outlets to each server in the frame.  xCAT cannot validate the physical cable is connected to the correct server.
+
+Add a ``pdu`` attribute to the compute node definition in the form "PDU_Name:outlet": ::
+
+    #
+    # Compute server cn01 has two power supplies
+    # connected to outlet 6 and 7 on pdu=mypdu
+    #
+    chdef cn01 pdu=mypdu:6,mypdu:7
+
+The following commands are supported against a compute node:
+
+   * Check the pdu status for a compute node: ::
+
+       # rpower cn01 pdustat
+         cn01: mypdu operational state for outlet 6 is on
+         cn01: mypdu operational state for outlet 7 is on
+
+   * Power off the PDU outlets for a compute node: ::
+
+       # rpower cn01 pduoff
+         cn01: mypdu operational state for outlet 6 is off
+         cn01: mypdu operational state for outlet 7 is off
+
+   * Power on the PDU outlets for a compute node: ::
+
+       # rpower cn01 pduon
+         cn01: mypdu operational state for outlet 6 is on
+         cn01: mypdu operational state for outlet 7 is on
+
+   * Power cycling the PDU outlets for a compute node: ::
+
+       # rpower cn01 pdureset
+         cn01: mypdu operational state for outlet 6 is reset
+         cn01: mypdu operational state for outlet 7 is reset
+
+The following commands are supported against a PDU:
+
+   * Check the status of the full PDU: ::
+
+       # rpower mypdu stat
+         mypdu: operational state for the outlet 1 is on
+         mypdu: operational state for the outlet 2 is on
+         mypdu: operational state for the outlet 3 is on
+
+   * Power off, on or reset the full PDU: ::
+
+       # rpower mypdu off
+       # rpower mypdu on
+       # rpower mypdu reset
+
+   * PDU inventory information: ::
+
+       # rinv mypdu
+         mypdu: PDU Manufacturer: Raritan
+         mypdu: PDU Model: PX4-5851-E7V2
+         mypdu: PDU Serial Number: XXXXXXXXXX
+         mypdu: PDU Rated Voltage: 360-415V
+         mypdu: PDU Rated Current: 24A
+         mypdu: PDU Rated Frequency: 50/60Hz
+         mypdu: PDU Rated VA: 15.0-17.3kVA
+         mypdu: PDU Inlet Count: 1
+         mypdu: PDU Overcurrent Protector Count: 6
+         mypdu: PDU Outlet Count: 36
+         mypdu: PDU Description: Raritan PDU, MD:PX4-5851-E7V2 HW:0x1D FW:4.2.10.5-50400
+
+   * PDU and outlet power information: ::
+
+       # rvitals mypdu
+         mypdu: inlet 1 RMS Voltage: 412 V
+         mypdu: inlet 1 RMS Current: 13.959 A
+         mypdu: inlet 1 Active Power: 8879 W
+         mypdu: inlet 1 Apparent Power: 8950 VA
+         mypdu: inlet 1 Power Factor: 0.99
+         mypdu: inlet 1 Frequency: 60.0 Hz
+         mypdu: inlet 1 Unbalanced Current: 11 %
+         mypdu: inlet 1 Reactive Power: 0 var
+         mypdu: inlet 1 Active Energy: 145702407 Wh
+         mypdu: inlet 1 Apparent Energy: 147093631 VAh
+         mypdu: outlet 1 RMS Current: 0.000 A
+         mypdu: outlet 1 Active Power: 0 W
+         mypdu: outlet 1 Active Energy: 0 Wh
+         mypdu: outlet 2 RMS Current: 2.793 A
+         mypdu: outlet 2 Active Power: 660 W
+         mypdu: outlet 2 Active Energy: 9794434 Wh
+
+     Units and decimal precision are read from the MIB for each sensor rather
+     than being hardcoded, so readings are correct on any model without
+     per-model configuration. The same sensor can therefore be reported at
+     different precision on different models: for example inlet RMS current
+     appears as ``13.959 A`` on a PX4 and ``18.1 A`` on a PX2, because the two
+     devices declare a different number of decimal digits for it.
+
+     Sensors that the device does not report are omitted, so the exact set of
+     lines varies by model. Per-outlet sensors are skipped entirely on models
+     that do not meter individual outlets. The reported sensor types are a
+     fixed list in the plugin and can be extended by adding entries to it;
+     types with no name defined are reported as ``sensor <N>``.
+
+**Note:** ``rspconfig`` is not supported for ``pdutype=genpdu``. Network and hostname configuration should be done on the PDU itself.
+
+**Note:** For BMC based compute nodes, turning the PDU outlet power on does not automatically power on the compute side.  Users will need to issue ``rpower <node> on`` to power on the compute side after the BMC boots.
+
+
+Limitations
+-----------
+
+   * PDU linking (cascading multiple PDUs behind one management interface) is not supported. The MIB indexes outlets by link ID, and xCAT assumes the value used by unlinked units. BCM2 and PMC power meters are also out of scope for the same reason.
+
+   * ``authtype``, ``privtype`` and the other SNMP attributes are per-PDU attributes in the ``pdu`` table, so PDUs using different SNMP protocols need their values set individually.
+
+
+Tested hardware
+---------------
+
+   * Raritan PX4-5851-E7V2, firmware 4.2.10.5-50400 (switched, 36 outlets)
+   * Raritan PX3-1901U-N1 and PX3-1901U-N1A6, firmware 4.0.20.5-49038 (metered, 48 outlets)
+   * Raritan PX2-1901U-N1A6, firmware 4.0.20.5-49038 (metered, 48 outlets)

--- a/docs/source/advanced/pdu/index.rst
+++ b/docs/source/advanced/pdu/index.rst
@@ -1,9 +1,9 @@
 PDUs
 ====
 
-Power Distribution Units (PDUs) are devices that distribute power to servers in a frame.  They have the capability of monitoring the amount of power that is being used by devices plugged into it and cycle power to individual receptacles.  xCAT can support two kinds of PDUs, infrastructure PDU (irpdu) and collaborative PDU (crpdu).
+Power Distribution Units (PDUs) are devices that distribute power to servers in a frame.  They have the capability of monitoring the amount of power that is being used by devices plugged into it and cycle power to individual receptacles.  xCAT can support three kinds of PDUs, infrastructure PDU (irpdu), collaborative PDU (crpdu) and generic SNMP PDU (genpdu).
 
-The Infrastructure rack PDUs are switched and monitored 1U PDU products which can connect up to nine C19 devices or up to 12 C13 devices and an additional three C13 peripheral devices to a single dedicated power source.  The Collaborative PDU is on the compute rack and has the 6x IEC 320-C13 receptacles that feed the rack switches. These two types of PDU have different design and implementation.  xCAT has different code path to maintains PDU commands via **pdutype**.
+The Infrastructure rack PDUs are switched and monitored 1U PDU products which can connect up to nine C19 devices or up to 12 C13 devices and an additional three C13 peripheral devices to a single dedicated power source.  The Collaborative PDU is on the compute rack and has the 6x IEC 320-C13 receptacles that feed the rack switches. The generic SNMP PDU is any PDU driven by the Raritan PDU2-MIB, which covers the Raritan PX2/PX3/PX4/PXC/SRC/PXO/BCM series, the Server Technology PRO3X/PRO4X series and the Legrand intelligent PDUs.  These types of PDU have different design and implementation.  xCAT has different code path to maintains PDU commands via **pdutype**.
 
 
 .. toctree::
@@ -12,3 +12,4 @@ The Infrastructure rack PDUs are switched and monitored 1U PDU products which ca
    pdu.rst
    irpdu.rst
    crpdu.rst
+   genpdu.rst

--- a/docs/source/guides/admin-guides/references/man5/pdu.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/pdu.5.rst
@@ -50,7 +50,7 @@ pdu Attributes:
 
 \ **pdutype**\ 
  
- The type of pdu
+ The type of pdu: irpdu (infrastructure PDU, SNMP), crpdu (collaborative PDU, ssh) or genpdu (generic SNMP PDU, PDU2-MIB)
  
 
 

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -707,7 +707,7 @@ passed as argument rather than by table value',
         descriptions => {
             node => 'The hostname/address of the pdu to which the settings apply',
             nodetype => 'The node type should be pdu ',
-            pdutype => 'The type of pdu ',
+            pdutype => 'The type of pdu: irpdu (infrastructure PDU, SNMP), crpdu (collaborative PDU, ssh) or genpdu (generic SNMP PDU, PDU2-MIB)',
             outlet => 'The pdu outlet count',
             username => 'The remote login user name',
             password => 'The remote login password',

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -57,8 +57,8 @@ my $pduhash;
 # pduId is the PDU's link ID and is 1 when linking is not used; BCM2/PMC use 0
 # for the main controller. Linked and BCM2/PMC deployments are out of scope for
 # genpdu, because pduoutlet.pdu is parsed as PDU:outlet and has no field for a
-# link ID. pduCount reports how many units are behind one agent and is 1 on a
-# standalone PDU.
+# link ID. pduCount reports how many units sit behind one agent, 1 when
+# standalone.
 #-------------------------------------------------------
 my $PDU2_PDUCOUNT    = ".1.3.6.1.4.1.13742.6.3.1.0";      #pduCount,             ro, scalar
 my $PDU2_SWITCHOP    = ".1.3.6.1.4.1.13742.6.4.1.2.1.2";  #switchingOperation,  rw, off(0) on(1) cycle(2)
@@ -66,15 +66,15 @@ my $PDU2_OUTLETSTATE = ".1.3.6.1.4.1.13742.6.4.1.2.1.3";  #outletSwitchingState,
 my $PDU2_OUTLETCOUNT = ".1.3.6.1.4.1.13742.6.3.2.2.1.4";  #outletCount,          ro, INDEX { pduId }
 my $PDU2_PDUID       = 1;
 
+#PDUs whose linked-unit warning has already been printed.
+my %genpdu_linked;
+
 #rinv / rvitals sources. The nameplate and unitConfiguration entries are
 #INDEX { pduId }; the measurement and sensor-configuration entries are
 #INDEX { pduId, <inlet|outlet>Id, sensorType }.
-#A sensor whose SensorSignedMinimum is below zero can read negative and must be
-#taken from the signed value column, per the SensorSignedMinimum DESCRIPTION.
-#The two columns are not interchangeable in either direction: the unsigned
-#column is undefined for such a sensor (a PX4 answers 0 for inlet reactive
-#power), and the signed column is undefined for sensors whose range exceeds
-#Integer32 (the same PX4 answers 0 for active and apparent energy).
+#SensorSignedMinimum selects the value column. On a PX4 the unsigned column
+#returns 0 for reactive power, and the signed column returns 0 for active
+#energy, whose range exceeds Integer32.
 my $PDU2_NAMEPLATE       = ".1.3.6.1.4.1.13742.6.3.2.1.1";    #nameplateEntry
 my $PDU2_UNITCONF        = ".1.3.6.1.4.1.13742.6.3.2.2.1";    #unitConfigurationEntry
 my $PDU2_INLETVAL        = ".1.3.6.1.4.1.13742.6.5.2.3.1.4";  #measurementsInletSensorValue
@@ -841,11 +841,34 @@ sub pdu2_session_args {
 
 #-------------------------------------------------------
 
+=head3  pdu2_get
+
+   Read one object. Returns its value and one of 'ok', 'absent' or 'failed'.
+   A missing object is exception text under v2c/v3 and an error under v1, so
+   both count as absent rather than as a failure.
+
+=cut
+
+#-------------------------------------------------------
+sub pdu2_get {
+    my ($session, $oid) = @_;
+
+    #Cleared first so the error below belongs to this GET.
+    $session->{ErrorStr} = '';
+    my $val = $session->get($oid);
+    my $err = $session->{ErrorStr} || '';
+
+    return ($val, 'ok') if (defined $val and $val ne '' and $val !~ /^No Such/i);
+    return (undef, 'failed') if ($err ne '' and $err !~ /no such/i);
+    return (undef, 'absent');
+}
+
+#-------------------------------------------------------
+
 =head3  pdu2_session_probe
 
-   First exchange with a generic SNMP PDU. Returns false when the PDU does not
-   answer at all, so callers report a connection failure, and records whether
-   its outlets can be switched.
+   Returns false when the PDU does not answer, so callers report a connection
+   failure, and records whether its outlets can be switched.
 
 =cut
 
@@ -853,40 +876,32 @@ sub pdu2_session_args {
 sub pdu2_session_probe {
     my ($session, $pdu, $callback) = @_;
 
-    #SNMP::Session->new does not contact the device, so this GET is where an
-    #unreachable PDU or a wrong credential first shows up. pduCount is a
-    #mandatory PDU2-MIB scalar, which makes it a reliable liveness check: the
-    #switching probe below cannot serve that purpose, because a PDU that never
-    #answers looks exactly like a PDU that has no switched outlets.
-    my $pducount = $session->get("$PDU2_PDUCOUNT");
-    unless (defined $pducount and $pducount =~ /^\d+$/) {
-        #Every PDU2 device tested answers pduCount, but genpdu is meant for any
-        #implementation of the MIB, so fall back to sysDescr before calling the
-        #PDU unreachable: it is mandatory in SNMPv2-MIB, and rinv reads it
-        #already. The unit count is then unknown rather than assumed to differ,
-        #so no linking warning is issued.
-        my $descr = $session->get("$SYSDESCR");
-        unless (defined $descr and $descr ne '' and $descr !~ /No Such/i) {
-            return 0;
-        }
+    #SNMP::Session->new does not contact the device, so pduCount is the first
+    #exchange and the liveness check: a silent PDU otherwise looks like one
+    #with no switched outlets.
+    my ($pducount, $state) = pdu2_get($session, "$PDU2_PDUCOUNT");
+    return 0 if ($state eq 'failed');
+
+    unless (defined $pducount and $pducount =~ /^\d+$/ and $pducount >= 1) {
+        #Some MIB implementations may not provide pduCount. Fall back to a
+        #nameplate object, so credentials without PDU2 access are rejected.
+        my ($model) = pdu2_get($session, "$PDU2_NAMEPLATE.3.$PDU2_PDUID");
+        return 0 unless (defined $model);
         $pducount = 1;
     }
 
-    #pduCount is the number of link units including the primary, or for BCM2 and
-    #PMC the number of power meters plus the main controller. genpdu only drives
-    #pduId 1, which is the primary on a linked unit but a power meter on
-    #BCM2/PMC. Warn rather than refuse: driving the primary alone stays correct,
-    #and pduoutlet.pdu has no field for a link id in any case.
-    if ($pducount != 1) {
+    #pduCount includes the primary and its link units (for BCM2 and PMC, the
+    #meters and the controller). genpdu drives pduId 1, still the primary when
+    #linked, so warn rather than refuse. Once per PDU: node ranges connect per
+    #node.
+    if ($pducount != 1 and !$genpdu_linked{$pdu}) {
+        $genpdu_linked{$pdu} = 1;
         xCAT::SvrUtils::sendmsg("pduCount is $pducount, only the primary unit (pduId $PDU2_PDUID) is managed", $callback, $pdu);
     }
 
-    #Metered-only PDU2 models (for example PX2-1901U) answer the nameplate and
-    #measurement tables normally but have no outletSwitchControlTable instances.
-    #Probe once here, the same way the irpdu path above probes a version OID,
-    #so callers can refuse switching with one clear message instead of leaking
-    #the agent's "No Such Instance" text from every outlet read.
-    my $probe = $session->get("$PDU2_OUTLETSTATE.$PDU2_PDUID.1");
+    #Metered-only models such as PX2-1901U answer the measurement tables but
+    #have no outletSwitchControlTable instances.
+    my ($probe) = pdu2_get($session, "$PDU2_OUTLETSTATE.$PDU2_PDUID.1");
     $session->{genpdu_switchable} =
         ((defined $probe) and ($probe =~ /^\d+$/ or $probe =~ /^(on|off)$/i)) ? 1 : 0;
 
@@ -903,11 +918,12 @@ sub pdu2_session_probe {
    $oids is one of the PDU2_*_SENSOR column sets and $idx is the full instance
    suffix (pduId.entityId.sensorType). The value column, scaling factor and unit
    all come from the matching sensor-configuration table, so no unit, precision
-   or column choice is hardcoded. They are formally per-entity but are uniform
-   across entities on PDU2 devices, so they are cached per sensorType to keep
-   this to one GET per entity per sensor rather than four. The cache is filled
-   only once a sensor is known to exist, so an entity that lacks a sensor cannot
-   seed it with fallbacks for the entities behind it.
+   or column choice is hardcoded.
+
+   Unit and decimal digits are cached per sensorType, and only once a sensor is
+   known to exist, so an entity that lacks one cannot seed the cache for those
+   behind it. The signed minimum is read per entity instead: it decides which
+   column is read, and a stale one reports a wrong number, not no number.
 
 =cut
 
@@ -915,28 +931,29 @@ sub pdu2_session_probe {
 sub pdu2_sensor_fmt {
     my ($session, $oids, $idx, $cache) = @_;
 
-    my $st = (split /\./, $idx)[-1];
-    my $meta = $cache->{$st};
-
-    #SensorSignedMinimum below zero means the sensor can read negative and the
-    #signed value column has to be used. Treat an unreadable minimum as zero:
-    #firmware that does not implement the column keeps the unsigned reading it
-    #has always returned.
-    my $min = (defined $meta) ? $meta->[2] : $session->get("$oids->{min}.$idx");
+    #Use the signed column when the minimum is below zero. An absent minimum
+    #means firmware without the column, so keep the unsigned reading; a failed
+    #GET means neither column can be trusted.
+    my ($min, $state) = pdu2_get($session, "$oids->{min}.$idx");
+    return undef if ($state eq 'failed');
     $min = 0 unless (defined $min and $min =~ /^-?\d+$/);
 
     my $valoid = ($min < 0) ? $oids->{signed} : $oids->{val};
-    my $raw = $session->get("$valoid.$idx");
+    my ($raw) = pdu2_get($session, "$valoid.$idx");
     return undef unless (defined $raw and $raw =~ /^-?\d+$/);
 
-    unless (defined $meta) {
-        my $u = $session->get("$oids->{units}.$idx");
-        my $d = $session->get("$oids->{dec}.$idx");
+    my $st = (split /\./, $idx)[-1];
+    unless (exists $cache->{$st}) {
+        #A failed read here would cache the wrong scaling for every entity
+        #behind this one.
+        my ($u, $ustate) = pdu2_get($session, "$oids->{units}.$idx");
+        my ($d, $dstate) = pdu2_get($session, "$oids->{dec}.$idx");
+        return undef if ($ustate eq 'failed' or $dstate eq 'failed');
         $u = -1 unless (defined $u and $u =~ /^-?\d+$/);
         $d = 0  unless (defined $d and $d =~ /^\d+$/);
-        $meta = $cache->{$st} = [ $u, $d, $min ];
+        $cache->{$st} = [ $u, $d ];
     }
-    my ($units, $digits) = @$meta;
+    my ($units, $digits) = @{ $cache->{$st} };
 
     my $val = sprintf("%.*f", $digits, $raw / (10 ** $digits));
     my $sfx = (defined $PDU2_SENSOR_UNIT{$units}) ? $PDU2_SENSOR_UNIT{$units} : "";
@@ -974,16 +991,17 @@ sub rinv_for_genpdu {
     );
 
     foreach my $f (@fields) {
-        my $output = $session->get("$f->[0].$f->[1].$PDU2_PDUID");
-        next unless (defined $output and $output ne '');
+        #Not every model populates every nameplate field.
+        my ($output) = pdu2_get($session, "$f->[0].$f->[1].$PDU2_PDUID");
+        next unless (defined $output);
         #UseSprintValue returns DisplayStrings quoted; strip for readability.
         $output =~ s/^"(.*)"$/$1/;
         next if ($output eq '');
         xCAT::SvrUtils::sendmsg("$f->[2]: $output", $callback, $pdu);
     }
 
-    my $output = $session->get("$SYSDESCR");
-    if (defined $output and $output ne '') {
+    my ($output) = pdu2_get($session, "$SYSDESCR");
+    if (defined $output) {
         $output =~ s/^"(.*)"$/$1/;
         xCAT::SvrUtils::sendmsg("PDU Description: $output", $callback, $pdu);
     }
@@ -1021,13 +1039,10 @@ sub rvitals_for_genpdu {
 
     my %outlet_cache;
 
-    #Metered-only models (PX2-1901U, PX3-1901U) populate the inlet tables but
-    #have no per-outlet sensors. Probe one before looping: a 48-outlet unit
-    #otherwise costs 192 GETs that all return No Such Instance and print
-    #nothing, which matters when rvitals is run against a group. The unsigned
-    #column is the right one to probe because the first outlet sensor is
-    #rmsCurrent, which cannot read negative.
-    my $probe = $session->get("$PDU2_OUTLETVAL.$PDU2_PDUID.1.$PDU2_OUTLET_SENSORS[0]");
+    #PX2-1901U and PX3-1901U have no per-outlet sensors: probing avoids 192
+    #failed GETs on a 48-outlet unit. rmsCurrent, the first outlet sensor, is
+    #unsigned.
+    my ($probe) = pdu2_get($session, "$PDU2_OUTLETVAL.$PDU2_PDUID.1.$PDU2_OUTLET_SENSORS[0]");
     return unless (defined $probe and $probe =~ /^-?\d+$/);
 
     for (my $outlet = 1; $outlet <= $count; $outlet++) {

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -57,9 +57,10 @@ my $pduhash;
 # pduId is the PDU's link ID and is 1 when linking is not used; BCM2/PMC use 0
 # for the main controller. Linked and BCM2/PMC deployments are out of scope for
 # genpdu, because pduoutlet.pdu is parsed as PDU:outlet and has no field for a
-# link ID. Read pduCount (.1.3.6.1.4.1.13742.6.3.1.0) to confirm a unit is
-# unlinked; it returns 1 when it is.
+# link ID. pduCount reports how many units are behind one agent and is 1 on a
+# standalone PDU.
 #-------------------------------------------------------
+my $PDU2_PDUCOUNT    = ".1.3.6.1.4.1.13742.6.3.1.0";      #pduCount,             ro, scalar
 my $PDU2_SWITCHOP    = ".1.3.6.1.4.1.13742.6.4.1.2.1.2";  #switchingOperation,  rw, off(0) on(1) cycle(2)
 my $PDU2_OUTLETSTATE = ".1.3.6.1.4.1.13742.6.4.1.2.1.3";  #outletSwitchingState, ro, on(7) off(8)
 my $PDU2_OUTLETCOUNT = ".1.3.6.1.4.1.13742.6.3.2.2.1.4";  #outletCount,          ro, INDEX { pduId }
@@ -68,14 +69,40 @@ my $PDU2_PDUID       = 1;
 #rinv / rvitals sources. The nameplate and unitConfiguration entries are
 #INDEX { pduId }; the measurement and sensor-configuration entries are
 #INDEX { pduId, <inlet|outlet>Id, sensorType }.
-my $PDU2_NAMEPLATE   = ".1.3.6.1.4.1.13742.6.3.2.1.1";    #nameplateEntry
-my $PDU2_UNITCONF    = ".1.3.6.1.4.1.13742.6.3.2.2.1";    #unitConfigurationEntry
-my $PDU2_INLETVAL    = ".1.3.6.1.4.1.13742.6.5.2.3.1.4";  #measurementsInletSensorValue
-my $PDU2_INLETUNITS  = ".1.3.6.1.4.1.13742.6.3.3.4.1.6";  #inletSensorUnits
-my $PDU2_INLETDEC    = ".1.3.6.1.4.1.13742.6.3.3.4.1.7";  #inletSensorDecimalDigits
-my $PDU2_OUTLETVAL   = ".1.3.6.1.4.1.13742.6.5.4.3.1.4";  #measurementsOutletSensorValue
-my $PDU2_OUTLETUNITS = ".1.3.6.1.4.1.13742.6.3.5.4.1.6";  #outletSensorUnits
-my $PDU2_OUTLETDEC   = ".1.3.6.1.4.1.13742.6.3.5.4.1.7";  #outletSensorDecimalDigits
+#A sensor whose SensorSignedMinimum is below zero can read negative and must be
+#taken from the signed value column, per the SensorSignedMinimum DESCRIPTION.
+#The two columns are not interchangeable in either direction: the unsigned
+#column is undefined for such a sensor (a PX4 answers 0 for inlet reactive
+#power), and the signed column is undefined for sensors whose range exceeds
+#Integer32 (the same PX4 answers 0 for active and apparent energy).
+my $PDU2_NAMEPLATE       = ".1.3.6.1.4.1.13742.6.3.2.1.1";    #nameplateEntry
+my $PDU2_UNITCONF        = ".1.3.6.1.4.1.13742.6.3.2.2.1";    #unitConfigurationEntry
+my $PDU2_INLETVAL        = ".1.3.6.1.4.1.13742.6.5.2.3.1.4";  #measurementsInletSensorValue
+my $PDU2_INLETSIGNEDVAL  = ".1.3.6.1.4.1.13742.6.5.2.3.1.6";  #measurementsInletSensorSignedValue
+my $PDU2_INLETSIGNEDMIN  = ".1.3.6.1.4.1.13742.6.3.3.4.1.27"; #inletSensorSignedMinimum
+my $PDU2_INLETUNITS      = ".1.3.6.1.4.1.13742.6.3.3.4.1.6";  #inletSensorUnits
+my $PDU2_INLETDEC        = ".1.3.6.1.4.1.13742.6.3.3.4.1.7";  #inletSensorDecimalDigits
+my $PDU2_OUTLETVAL       = ".1.3.6.1.4.1.13742.6.5.4.3.1.4";  #measurementsOutletSensorValue
+my $PDU2_OUTLETSIGNEDVAL = ".1.3.6.1.4.1.13742.6.5.4.3.1.6";  #measurementsOutletSensorSignedValue
+my $PDU2_OUTLETSIGNEDMIN = ".1.3.6.1.4.1.13742.6.3.5.4.1.27"; #outletSensorSignedMinimum
+my $PDU2_OUTLETUNITS     = ".1.3.6.1.4.1.13742.6.3.5.4.1.6";  #outletSensorUnits
+my $PDU2_OUTLETDEC       = ".1.3.6.1.4.1.13742.6.3.5.4.1.7";  #outletSensorDecimalDigits
+
+#The five columns pdu2_sensor_fmt reads, grouped per entity type.
+my $PDU2_INLET_SENSOR = {
+    val    => $PDU2_INLETVAL,
+    signed => $PDU2_INLETSIGNEDVAL,
+    min    => $PDU2_INLETSIGNEDMIN,
+    units  => $PDU2_INLETUNITS,
+    dec    => $PDU2_INLETDEC,
+};
+my $PDU2_OUTLET_SENSOR = {
+    val    => $PDU2_OUTLETVAL,
+    signed => $PDU2_OUTLETSIGNEDVAL,
+    min    => $PDU2_OUTLETSIGNEDMIN,
+    units  => $PDU2_OUTLETUNITS,
+    dec    => $PDU2_OUTLETDEC,
+};
 
 #PDU2-MIB has no pollable PDU-level firmware version (boardFirmwareVersion is
 #per-controller under unit 3, imageVersion is trap payload only), so the
@@ -749,49 +776,110 @@ sub connectTopdu_gen {
     my $pdu = shift;
     my $callback = shift;
 
-    my $ent = $pduhash->{$pdu}->[0];
+    my $session = new SNMP::Session(pdu2_session_args($pdu, $pduhash->{$pdu}->[0]));
+    unless ($session) {
+        return;
+    }
+    $session->{genpdu} = 1;
+
+    unless (pdu2_session_probe($session, $pdu, $callback)) {
+        return;
+    }
+
+    return $session;
+}
+
+#-------------------------------------------------------
+
+=head3  pdu2_session_args
+
+   Map a 'pdu' table row onto the SNMP::Session arguments for that PDU.
+
+=cut
+
+#-------------------------------------------------------
+sub pdu2_session_args {
+    my ($pdu, $ent) = @_;
+
     my $snmpver = $ent->{snmpversion};
     if    (!defined $snmpver) { $snmpver = "1"; }
     elsif ($snmpver =~ /3/)   { $snmpver = "3"; }
     elsif ($snmpver =~ /2/)   { $snmpver = "2"; }
     else                      { $snmpver = "1"; }
 
-    my $session;
     if ($snmpver ne "3") {
-        my $community = $ent->{community} || "public";
-        $session = new SNMP::Session(
+        return (
             DestHost       => $pdu,
             Version        => $snmpver,
-            Community      => $community,
+            Community      => $ent->{community} || "public",
             UseSprintValue => 1,
         );
-    } else {
-        my $authpass = $ent->{authkey};
-        my $privpass = (defined $ent->{privkey}) ? $ent->{privkey} : $authpass;
-        my $seclevel = $ent->{seclevel};
-        unless ($seclevel) {
-            $seclevel = ($ent->{privtype}) ? "authPriv" : "authNoPriv";
-        }
-        my %args = (
-            DestHost       => $pdu,
-            Version        => 3,
-            SecName        => $ent->{snmpuser},
-            SecLevel       => $seclevel,
-            AuthProto      => uc($ent->{authtype} || "SHA"),
-            AuthPass       => $authpass,
-            UseSprintValue => 1,
-        );
-        if ($seclevel eq "authPriv") {
-            $args{PrivProto} = uc($ent->{privtype} || "DES");
-            $args{PrivPass}  = $privpass;
-        }
-        $session = new SNMP::Session(%args);
     }
 
-    unless ($session) {
-        return;
+    my $authpass = $ent->{authkey};
+    my $privpass = (defined $ent->{privkey}) ? $ent->{privkey} : $authpass;
+    my $seclevel = $ent->{seclevel};
+    unless ($seclevel) {
+        $seclevel = ($ent->{privtype}) ? "authPriv" : "authNoPriv";
     }
-    $session->{genpdu} = 1;
+    my %args = (
+        DestHost       => $pdu,
+        Version        => 3,
+        SecName        => $ent->{snmpuser},
+        SecLevel       => $seclevel,
+        AuthProto      => uc($ent->{authtype} || "SHA"),
+        AuthPass       => $authpass,
+        UseSprintValue => 1,
+    );
+    if ($seclevel eq "authPriv") {
+        $args{PrivProto} = uc($ent->{privtype} || "DES");
+        $args{PrivPass}  = $privpass;
+    }
+
+    return %args;
+}
+
+#-------------------------------------------------------
+
+=head3  pdu2_session_probe
+
+   First exchange with a generic SNMP PDU. Returns false when the PDU does not
+   answer at all, so callers report a connection failure, and records whether
+   its outlets can be switched.
+
+=cut
+
+#-------------------------------------------------------
+sub pdu2_session_probe {
+    my ($session, $pdu, $callback) = @_;
+
+    #SNMP::Session->new does not contact the device, so this GET is where an
+    #unreachable PDU or a wrong credential first shows up. pduCount is a
+    #mandatory PDU2-MIB scalar, which makes it a reliable liveness check: the
+    #switching probe below cannot serve that purpose, because a PDU that never
+    #answers looks exactly like a PDU that has no switched outlets.
+    my $pducount = $session->get("$PDU2_PDUCOUNT");
+    unless (defined $pducount and $pducount =~ /^\d+$/) {
+        #Every PDU2 device tested answers pduCount, but genpdu is meant for any
+        #implementation of the MIB, so fall back to sysDescr before calling the
+        #PDU unreachable: it is mandatory in SNMPv2-MIB, and rinv reads it
+        #already. The unit count is then unknown rather than assumed to differ,
+        #so no linking warning is issued.
+        my $descr = $session->get("$SYSDESCR");
+        unless (defined $descr and $descr ne '' and $descr !~ /No Such/i) {
+            return 0;
+        }
+        $pducount = 1;
+    }
+
+    #pduCount is the number of link units including the primary, or for BCM2 and
+    #PMC the number of power meters plus the main controller. genpdu only drives
+    #pduId 1, which is the primary on a linked unit but a power meter on
+    #BCM2/PMC. Warn rather than refuse: driving the primary alone stays correct,
+    #and pduoutlet.pdu has no field for a link id in any case.
+    if ($pducount != 1) {
+        xCAT::SvrUtils::sendmsg("pduCount is $pducount, only the primary unit (pduId $PDU2_PDUID) is managed", $callback, $pdu);
+    }
 
     #Metered-only PDU2 models (for example PX2-1901U) answer the nameplate and
     #measurement tables normally but have no outletSwitchControlTable instances.
@@ -802,7 +890,7 @@ sub connectTopdu_gen {
     $session->{genpdu_switchable} =
         ((defined $probe) and ($probe =~ /^\d+$/ or $probe =~ /^(on|off)$/i)) ? 1 : 0;
 
-    return $session;
+    return 1;
 }
 
 #-------------------------------------------------------
@@ -812,30 +900,43 @@ sub connectTopdu_gen {
    Read one PDU2-MIB sensor and return it formatted with its unit, or undef if
    the sensor is not present on this device.
 
-   $idx is the full instance suffix (pduId.entityId.sensorType). The scaling
-   factor and unit come from the matching sensor-configuration table, so no
-   unit or precision is hardcoded. They are formally per-entity but are uniform
+   $oids is one of the PDU2_*_SENSOR column sets and $idx is the full instance
+   suffix (pduId.entityId.sensorType). The value column, scaling factor and unit
+   all come from the matching sensor-configuration table, so no unit, precision
+   or column choice is hardcoded. They are formally per-entity but are uniform
    across entities on PDU2 devices, so they are cached per sensorType to keep
-   this to one GET per entity per sensor rather than three.
+   this to one GET per entity per sensor rather than four. The cache is filled
+   only once a sensor is known to exist, so an entity that lacks a sensor cannot
+   seed it with fallbacks for the entities behind it.
 
 =cut
 
 #-------------------------------------------------------
 sub pdu2_sensor_fmt {
-    my ($session, $valoid, $unitoid, $decoid, $idx, $cache) = @_;
+    my ($session, $oids, $idx, $cache) = @_;
 
+    my $st = (split /\./, $idx)[-1];
+    my $meta = $cache->{$st};
+
+    #SensorSignedMinimum below zero means the sensor can read negative and the
+    #signed value column has to be used. Treat an unreadable minimum as zero:
+    #firmware that does not implement the column keeps the unsigned reading it
+    #has always returned.
+    my $min = (defined $meta) ? $meta->[2] : $session->get("$oids->{min}.$idx");
+    $min = 0 unless (defined $min and $min =~ /^-?\d+$/);
+
+    my $valoid = ($min < 0) ? $oids->{signed} : $oids->{val};
     my $raw = $session->get("$valoid.$idx");
     return undef unless (defined $raw and $raw =~ /^-?\d+$/);
 
-    my $st = (split /\./, $idx)[-1];
-    unless (exists $cache->{$st}) {
-        my $u = $session->get("$unitoid.$idx");
-        my $d = $session->get("$decoid.$idx");
+    unless (defined $meta) {
+        my $u = $session->get("$oids->{units}.$idx");
+        my $d = $session->get("$oids->{dec}.$idx");
         $u = -1 unless (defined $u and $u =~ /^-?\d+$/);
         $d = 0  unless (defined $d and $d =~ /^\d+$/);
-        $cache->{$st} = [ $u, $d ];
+        $meta = $cache->{$st} = [ $u, $d, $min ];
     }
-    my ($units, $digits) = @{ $cache->{$st} };
+    my ($units, $digits) = @$meta;
 
     my $val = sprintf("%.*f", $digits, $raw / (10 ** $digits));
     my $sfx = (defined $PDU2_SENSOR_UNIT{$units}) ? $PDU2_SENSOR_UNIT{$units} : "";
@@ -910,8 +1011,8 @@ sub rvitals_for_genpdu {
     my %inlet_cache;
     for (my $inlet = 1; $inlet <= $inlets; $inlet++) {
         foreach my $st (@PDU2_INLET_SENSORS) {
-            my $fmt = pdu2_sensor_fmt($session, $PDU2_INLETVAL, $PDU2_INLETUNITS,
-                        $PDU2_INLETDEC, "$PDU2_PDUID.$inlet.$st", \%inlet_cache);
+            my $fmt = pdu2_sensor_fmt($session, $PDU2_INLET_SENSOR,
+                        "$PDU2_PDUID.$inlet.$st", \%inlet_cache);
             next unless (defined $fmt);
             my $name = $PDU2_SENSOR_NAME{$st} || "sensor $st";
             xCAT::SvrUtils::sendmsg("inlet $inlet $name: $fmt", $callback, $pdu);
@@ -922,15 +1023,17 @@ sub rvitals_for_genpdu {
 
     #Metered-only models (PX2-1901U, PX3-1901U) populate the inlet tables but
     #have no per-outlet sensors. Probe one before looping: a 48-outlet unit
-    #otherwise costs 144 GETs that all return No Such Instance and print
-    #nothing, which matters when rvitals is run against a group.
+    #otherwise costs 192 GETs that all return No Such Instance and print
+    #nothing, which matters when rvitals is run against a group. The unsigned
+    #column is the right one to probe because the first outlet sensor is
+    #rmsCurrent, which cannot read negative.
     my $probe = $session->get("$PDU2_OUTLETVAL.$PDU2_PDUID.1.$PDU2_OUTLET_SENSORS[0]");
     return unless (defined $probe and $probe =~ /^-?\d+$/);
 
     for (my $outlet = 1; $outlet <= $count; $outlet++) {
         foreach my $st (@PDU2_OUTLET_SENSORS) {
-            my $fmt = pdu2_sensor_fmt($session, $PDU2_OUTLETVAL, $PDU2_OUTLETUNITS,
-                        $PDU2_OUTLETDEC, "$PDU2_PDUID.$outlet.$st", \%outlet_cache);
+            my $fmt = pdu2_sensor_fmt($session, $PDU2_OUTLET_SENSOR,
+                        "$PDU2_PDUID.$outlet.$st", \%outlet_cache);
             next unless (defined $fmt);
             my $name = $PDU2_SENSOR_NAME{$st} || "sensor $st";
             xCAT::SvrUtils::sendmsg("outlet $outlet $name: $fmt", $callback, $pdu);

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -46,6 +46,63 @@ my $callback;
 my $pdutab;
 my $pduhash;
 
+#-------------------------------------------------------
+# PDU2-MIB OIDs, used for pdutype=genpdu (generic SNMP PDU).
+#
+# A single MIB covers the Raritan PX2/PX3/PX4/PXC/SRC/PXO/BCM/BCM2 series, the
+# Server Technology PRO3X/PRO4X series and the Legrand intelligent PDUs, so
+# these OIDs are model-independent (PDU2-MIB rev 4.3.0, 202410070000Z).
+#
+# Both outlet tables are INDEX { pduId, outletId }. Per the pduId DESCRIPTION,
+# pduId is the PDU's link ID and is 1 when linking is not used; BCM2/PMC use 0
+# for the main controller. Linked and BCM2/PMC deployments are out of scope for
+# genpdu, because pduoutlet.pdu is parsed as PDU:outlet and has no field for a
+# link ID. Read pduCount (.1.3.6.1.4.1.13742.6.3.1.0) to confirm a unit is
+# unlinked; it returns 1 when it is.
+#-------------------------------------------------------
+my $PDU2_SWITCHOP    = ".1.3.6.1.4.1.13742.6.4.1.2.1.2";  #switchingOperation,  rw, off(0) on(1) cycle(2)
+my $PDU2_OUTLETSTATE = ".1.3.6.1.4.1.13742.6.4.1.2.1.3";  #outletSwitchingState, ro, on(7) off(8)
+my $PDU2_OUTLETCOUNT = ".1.3.6.1.4.1.13742.6.3.2.2.1.4";  #outletCount,          ro, INDEX { pduId }
+my $PDU2_PDUID       = 1;
+
+#rinv / rvitals sources. The nameplate and unitConfiguration entries are
+#INDEX { pduId }; the measurement and sensor-configuration entries are
+#INDEX { pduId, <inlet|outlet>Id, sensorType }.
+my $PDU2_NAMEPLATE   = ".1.3.6.1.4.1.13742.6.3.2.1.1";    #nameplateEntry
+my $PDU2_UNITCONF    = ".1.3.6.1.4.1.13742.6.3.2.2.1";    #unitConfigurationEntry
+my $PDU2_INLETVAL    = ".1.3.6.1.4.1.13742.6.5.2.3.1.4";  #measurementsInletSensorValue
+my $PDU2_INLETUNITS  = ".1.3.6.1.4.1.13742.6.3.3.4.1.6";  #inletSensorUnits
+my $PDU2_INLETDEC    = ".1.3.6.1.4.1.13742.6.3.3.4.1.7";  #inletSensorDecimalDigits
+my $PDU2_OUTLETVAL   = ".1.3.6.1.4.1.13742.6.5.4.3.1.4";  #measurementsOutletSensorValue
+my $PDU2_OUTLETUNITS = ".1.3.6.1.4.1.13742.6.3.5.4.1.6";  #outletSensorUnits
+my $PDU2_OUTLETDEC   = ".1.3.6.1.4.1.13742.6.3.5.4.1.7";  #outletSensorDecimalDigits
+
+#PDU2-MIB has no pollable PDU-level firmware version (boardFirmwareVersion is
+#per-controller under unit 3, imageVersion is trap payload only), so the
+#firmware string is taken from sysDescr in SNMPv2-MIB.
+my $SYSDESCR         = ".1.3.6.1.2.1.1.1.0";
+
+#SensorTypeEnumeration subset reported for inlets and outlets, and the
+#SensorUnitsEnumeration values those sensors use. Readings are scaled by the
+#matching ...SensorDecimalDigits and labelled from ...SensorUnits, so this
+#works unchanged on any PDU2 model regardless of which sensors it populates.
+my %PDU2_SENSOR_NAME = (
+    1  => "RMS Current",       2  => "Peak Current",
+    3  => "Unbalanced Current", 4 => "RMS Voltage",
+    5  => "Active Power",      6  => "Apparent Power",
+    7  => "Power Factor",      8  => "Active Energy",
+    9  => "Apparent Energy",   10 => "Temperature",
+    23 => "Frequency",         29 => "Reactive Power",
+);
+my %PDU2_SENSOR_UNIT = (
+    -1 => "",   0 => "",    1 => "V",  2 => "A",   3 => "W",
+     4 => "VA", 5 => "Wh",  6 => "VAh", 7 => "C",  8 => "Hz",
+     9 => "%", 20 => "deg", 23 => "var",
+);
+#Ordered for readability rather than by enum value.
+my @PDU2_INLET_SENSORS  = (4, 1, 5, 6, 7, 23, 3, 29, 8, 9, 10);
+my @PDU2_OUTLET_SENSORS = (1, 5, 8);
+
 
 #-------------------------------------------------------
 
@@ -83,6 +140,13 @@ sub pdu_usage
      The following commands support IR PDU with pdutype=irpdu :
         rpower computenodes [pduoff|pduon|pdustat|pdustatus|pdureset]
         rspconfig irpdunode [hostname=<NAME>|ip=<IP>|gateway=<GATEWAY>|mask=<MASK>]
+
+     The following commands support Generic SNMP PDU with pdutype=genpdu :
+        rpower    pdunodes [off|on|stat|reset]
+        rpower    computenodes [pduoff|pduon|pdustat|pdureset]
+        rinv      pdunodes
+        rvitals   pdunodes
+        (rspconfig is not supported for pdutype=genpdu)
 
      The following commands support CR PDU with pdutype=crpdu :
         rpower    pdunodes relay=[1|2|3] [on|off]
@@ -257,6 +321,21 @@ sub fill_outletCount {
     my $session = shift;
     my $pdu = shift;
     my $callback = shift;
+
+    #genpdu: outletCount is the authoritative count; the outletSwitchControlTable
+    #DESCRIPTION states its entry count is given by outletCount. If the 'outlet'
+    #attribute is set on the pdu node, callers use it first and this never runs.
+    if ($session->{genpdu}) {
+        my $count = $session->get("$PDU2_OUTLETCOUNT.$PDU2_PDUID");
+        if ($count) {
+            my $pdutab = xCAT::Table->new('pdu');
+            $pdutab->setNodeAttribs($pdu, { outlet => $count });
+        } else {
+            xCAT::SvrUtils::sendmsg("Could not read outletCount, set the 'outlet' attribute on $pdu", $callback, $pdu);
+        }
+        return $count;
+    }
+
     my $outletoid = ".1.3.6.1.4.1.2.6.223.8.2.1.0";
     my $pdutab = xCAT::Table->new('pdu');
 
@@ -299,6 +378,10 @@ sub powerpdu {
         my $session = connectTopdu($node,$callback);
         if (!$session) {
             $callback->({ errorcode => [1],error => "Couldn't connect to $node"});
+            next;
+        }
+        if (defined $session->{genpdu_switchable} and !$session->{genpdu_switchable}) {
+            xCAT::SvrUtils::sendmsg("this PDU does not support outlet switching", $callback, $node);
             next;
         }
         my $count = $pduhash->{$node}->[0]->{outlet};
@@ -374,6 +457,10 @@ sub powerpduoutlet {
                 $callback->({ errorcode => [1],error => "$node: Couldn't connect to $pdu"});
                 next;
             }
+            if (defined $session->{genpdu_switchable} and !$session->{genpdu_switchable}) {
+                $callback->({ errorcode => [1],error => "$node: $pdu does not support outlet switching"});
+                next;
+            }
             my $count = $pduhash->{$pdu}->[0]->{outlet};
             unless ($count) {
                 $count = fill_outletCount($session, $pdu, $callback);
@@ -424,6 +511,14 @@ sub outletpower {
     my $session = shift;
     my $outlet = shift;
     my $value = shift;
+
+    #genpdu: PDU2-MIB switchingOperation is off(0) on(1) cycle(2), and the
+    #callers (powerpdu / powerpduoutlet) already pass 0=off, 1=on, 2=reset, so
+    #the value maps directly onto the MIB enum with no translation.
+    if ($session->{genpdu}) {
+        my $varbind = new SNMP::Varbind([ $PDU2_SWITCHOP, "$PDU2_PDUID.$outlet", $value, "INTEGER" ]);
+        return $session->set($varbind);
+    }
 
     my $oid = ".1.3.6.1.4.1.2.6.223.8.2.2.1.11";
     my $type = "INTEGER";
@@ -501,6 +596,10 @@ sub powerstat {
             $callback->({ errorcode => [1],error => "Couldn't connect to $pdu"});
             next;
         }
+        if (defined $session->{genpdu_switchable} and !$session->{genpdu_switchable}) {
+            xCAT::SvrUtils::sendmsg("this PDU does not support outlet switching", $callback, $pdu);
+            next;
+        }
         my $count = $pduhash->{$pdu}->[0]->{outlet};
         unless ($count) {
             $count = fill_outletCount($session, $pdu, $callback);
@@ -533,6 +632,18 @@ sub powerstat {
 sub outletstat {
     my $session = shift;
     my $outlet = shift;
+
+    #genpdu: PDU2-MIB outletSwitchingState uses SensorStateEnumeration, of which
+    #on(7) and off(8) are the switching states. The value may come back as the
+    #integer or as the MIB label depending on which MIBs the Net-SNMP perl
+    #module has loaded, so both forms are accepted.
+    if ($session->{genpdu}) {
+        my $val = $session->get("$PDU2_OUTLETSTATE.$PDU2_PDUID.$outlet");
+        return "unknown state" unless (defined $val);
+        if    ($val eq "7" or $val eq "on")  { return "on"; }
+        elsif ($val eq "8" or $val eq "off") { return "off"; }
+        else                                 { return "$val(unknown state)"; }
+    }
 
     my $oid = ".1.3.6.1.4.1.2.6.223.8.2.2.1.11";
     my $output;
@@ -573,6 +684,12 @@ sub connectTopdu {
     my $pdu = shift;
     my $callback = shift;
 
+    #genpdu uses its own v1/v2c/v3 session builder and the PDU2-MIB OIDs; skip
+    #the IBM-specific version probe below, which a non-IBM agent will not answer.
+    if (($pduhash->{$pdu}->[0]->{pdutype} || '') eq 'genpdu') {
+        return connectTopdu_gen($pdu, $callback);
+    }
+
     #get community string from pdu table if defined,
     #otherwise, use default
     my $community;
@@ -610,6 +727,215 @@ sub connectTopdu {
 
     return $session;
 
+}
+
+#-------------------------------------------------------
+
+=head3  connectTopdu_gen
+
+   Build an SNMP v1/v2c/v3 session for a generic SNMP PDU (pdutype=genpdu),
+   driven by the PDU2-MIB.
+
+   SNMP parameters come from the 'pdu' table, following the same model xCAT
+   already uses for ethernet switches in xCAT::MacMap::getsnmpsession:
+     - one secret is reused (community for v1/v2c; the auth passphrase for v3),
+       and privkey falls back to authkey when only one is provided.
+     - SecLevel is derived: authNoPriv unless a privacy protocol is set.
+
+=cut
+
+#-------------------------------------------------------
+sub connectTopdu_gen {
+    my $pdu = shift;
+    my $callback = shift;
+
+    my $ent = $pduhash->{$pdu}->[0];
+    my $snmpver = $ent->{snmpversion};
+    if    (!defined $snmpver) { $snmpver = "1"; }
+    elsif ($snmpver =~ /3/)   { $snmpver = "3"; }
+    elsif ($snmpver =~ /2/)   { $snmpver = "2"; }
+    else                      { $snmpver = "1"; }
+
+    my $session;
+    if ($snmpver ne "3") {
+        my $community = $ent->{community} || "public";
+        $session = new SNMP::Session(
+            DestHost       => $pdu,
+            Version        => $snmpver,
+            Community      => $community,
+            UseSprintValue => 1,
+        );
+    } else {
+        my $authpass = $ent->{authkey};
+        my $privpass = (defined $ent->{privkey}) ? $ent->{privkey} : $authpass;
+        my $seclevel = $ent->{seclevel};
+        unless ($seclevel) {
+            $seclevel = ($ent->{privtype}) ? "authPriv" : "authNoPriv";
+        }
+        my %args = (
+            DestHost       => $pdu,
+            Version        => 3,
+            SecName        => $ent->{snmpuser},
+            SecLevel       => $seclevel,
+            AuthProto      => uc($ent->{authtype} || "SHA"),
+            AuthPass       => $authpass,
+            UseSprintValue => 1,
+        );
+        if ($seclevel eq "authPriv") {
+            $args{PrivProto} = uc($ent->{privtype} || "DES");
+            $args{PrivPass}  = $privpass;
+        }
+        $session = new SNMP::Session(%args);
+    }
+
+    unless ($session) {
+        return;
+    }
+    $session->{genpdu} = 1;
+
+    #Metered-only PDU2 models (for example PX2-1901U) answer the nameplate and
+    #measurement tables normally but have no outletSwitchControlTable instances.
+    #Probe once here, the same way the irpdu path above probes a version OID,
+    #so callers can refuse switching with one clear message instead of leaking
+    #the agent's "No Such Instance" text from every outlet read.
+    my $probe = $session->get("$PDU2_OUTLETSTATE.$PDU2_PDUID.1");
+    $session->{genpdu_switchable} =
+        ((defined $probe) and ($probe =~ /^\d+$/ or $probe =~ /^(on|off)$/i)) ? 1 : 0;
+
+    return $session;
+}
+
+#-------------------------------------------------------
+
+=head3  pdu2_sensor_fmt
+
+   Read one PDU2-MIB sensor and return it formatted with its unit, or undef if
+   the sensor is not present on this device.
+
+   $idx is the full instance suffix (pduId.entityId.sensorType). The scaling
+   factor and unit come from the matching sensor-configuration table, so no
+   unit or precision is hardcoded. They are formally per-entity but are uniform
+   across entities on PDU2 devices, so they are cached per sensorType to keep
+   this to one GET per entity per sensor rather than three.
+
+=cut
+
+#-------------------------------------------------------
+sub pdu2_sensor_fmt {
+    my ($session, $valoid, $unitoid, $decoid, $idx, $cache) = @_;
+
+    my $raw = $session->get("$valoid.$idx");
+    return undef unless (defined $raw and $raw =~ /^-?\d+$/);
+
+    my $st = (split /\./, $idx)[-1];
+    unless (exists $cache->{$st}) {
+        my $u = $session->get("$unitoid.$idx");
+        my $d = $session->get("$decoid.$idx");
+        $u = -1 unless (defined $u and $u =~ /^-?\d+$/);
+        $d = 0  unless (defined $d and $d =~ /^\d+$/);
+        $cache->{$st} = [ $u, $d ];
+    }
+    my ($units, $digits) = @{ $cache->{$st} };
+
+    my $val = sprintf("%.*f", $digits, $raw / (10 ** $digits));
+    my $sfx = (defined $PDU2_SENSOR_UNIT{$units}) ? $PDU2_SENSOR_UNIT{$units} : "";
+    return ($sfx ne "") ? "$val $sfx" : $val;
+}
+
+#-------------------------------------------------------
+
+=head3  rinv_for_genpdu
+
+   Inventory for a generic SNMP PDU, from the PDU2-MIB nameplate and
+   unitConfiguration entries plus sysDescr for the firmware string.
+
+=cut
+
+#-------------------------------------------------------
+sub rinv_for_genpdu {
+    my $pdu = shift;
+    my $session = shift;
+    my $callback = shift;
+
+    #The rated* nameplate objects are DisplayStrings with the unit already
+    #included (for example "24A", "15.0-17.3kVA"), so nothing is appended.
+    my @fields = (
+        [ $PDU2_NAMEPLATE, 2, "PDU Manufacturer" ],
+        [ $PDU2_NAMEPLATE, 3, "PDU Model" ],
+        [ $PDU2_NAMEPLATE, 4, "PDU Serial Number" ],
+        [ $PDU2_NAMEPLATE, 5, "PDU Rated Voltage" ],
+        [ $PDU2_NAMEPLATE, 6, "PDU Rated Current" ],
+        [ $PDU2_NAMEPLATE, 7, "PDU Rated Frequency" ],
+        [ $PDU2_NAMEPLATE, 8, "PDU Rated VA" ],
+        [ $PDU2_UNITCONF,  2, "PDU Inlet Count" ],
+        [ $PDU2_UNITCONF,  3, "PDU Overcurrent Protector Count" ],
+        [ $PDU2_UNITCONF,  4, "PDU Outlet Count" ],
+    );
+
+    foreach my $f (@fields) {
+        my $output = $session->get("$f->[0].$f->[1].$PDU2_PDUID");
+        next unless (defined $output and $output ne '');
+        #UseSprintValue returns DisplayStrings quoted; strip for readability.
+        $output =~ s/^"(.*)"$/$1/;
+        next if ($output eq '');
+        xCAT::SvrUtils::sendmsg("$f->[2]: $output", $callback, $pdu);
+    }
+
+    my $output = $session->get("$SYSDESCR");
+    if (defined $output and $output ne '') {
+        $output =~ s/^"(.*)"$/$1/;
+        xCAT::SvrUtils::sendmsg("PDU Description: $output", $callback, $pdu);
+    }
+}
+
+#-------------------------------------------------------
+
+=head3  rvitals_for_genpdu
+
+   Sensor readings for a generic SNMP PDU: every supported inlet sensor the
+   device reports, then current, active power and active energy per outlet.
+
+=cut
+
+#-------------------------------------------------------
+sub rvitals_for_genpdu {
+    my $pdu = shift;
+    my $count = shift;
+    my $session = shift;
+    my $callback = shift;
+
+    my $inlets = $session->get("$PDU2_UNITCONF.2.$PDU2_PDUID");
+    $inlets = 1 unless (defined $inlets and $inlets =~ /^\d+$/ and $inlets > 0);
+
+    my %inlet_cache;
+    for (my $inlet = 1; $inlet <= $inlets; $inlet++) {
+        foreach my $st (@PDU2_INLET_SENSORS) {
+            my $fmt = pdu2_sensor_fmt($session, $PDU2_INLETVAL, $PDU2_INLETUNITS,
+                        $PDU2_INLETDEC, "$PDU2_PDUID.$inlet.$st", \%inlet_cache);
+            next unless (defined $fmt);
+            my $name = $PDU2_SENSOR_NAME{$st} || "sensor $st";
+            xCAT::SvrUtils::sendmsg("inlet $inlet $name: $fmt", $callback, $pdu);
+        }
+    }
+
+    my %outlet_cache;
+
+    #Metered-only models (PX2-1901U, PX3-1901U) populate the inlet tables but
+    #have no per-outlet sensors. Probe one before looping: a 48-outlet unit
+    #otherwise costs 144 GETs that all return No Such Instance and print
+    #nothing, which matters when rvitals is run against a group.
+    my $probe = $session->get("$PDU2_OUTLETVAL.$PDU2_PDUID.1.$PDU2_OUTLET_SENSORS[0]");
+    return unless (defined $probe and $probe =~ /^-?\d+$/);
+
+    for (my $outlet = 1; $outlet <= $count; $outlet++) {
+        foreach my $st (@PDU2_OUTLET_SENSORS) {
+            my $fmt = pdu2_sensor_fmt($session, $PDU2_OUTLETVAL, $PDU2_OUTLETUNITS,
+                        $PDU2_OUTLETDEC, "$PDU2_PDUID.$outlet.$st", \%outlet_cache);
+            next unless (defined $fmt);
+            my $name = $PDU2_SENSOR_NAME{$st} || "sensor $st";
+            xCAT::SvrUtils::sendmsg("outlet $outlet $name: $fmt", $callback, $pdu);
+        }
+    }
 }
 
 #-------------------------------------------------------
@@ -661,6 +987,11 @@ sub process_netcfg {
     my $nodehash = $nodetab->getNodesAttribs($nodes,['ip','otherinterfaces']);
     my $static_ip = $nodehash->{$pdu}->[0]->{ip};
     my $discover_ip = $nodehash->{$pdu}->[0]->{otherinterfaces};
+
+    if (($pduhash->{$pdu}->[0]->{pdutype} || '') eq 'genpdu') {
+        xCAT::SvrUtils::sendmsg("rspconfig $subcmd is not supported for pdutype=genpdu", $callback, $pdu);
+        return;
+    }
 
     unless ($pduhash->{$pdu}->[0]->{pdutype} eq "crpdu") {
         netcfg_for_irpdu($pdu, $static_ip, $discover_ip, $request, $subreq, $callback);
@@ -944,6 +1275,15 @@ sub showMFR {
     my $nodehash = $nodetab->getNodesAttribs($noderange,['ip','otherinterfaces']);
 
     foreach my $pdu (@$noderange) {
+        if (($pduhash->{$pdu}->[0]->{pdutype} || '') eq 'genpdu') {
+            my $session = connectTopdu($pdu, $callback);
+            if (!$session) {
+                $callback->({ errorcode => [1], error => "Couldn't connect to $pdu" });
+                next;
+            }
+            rinv_for_genpdu($pdu, $session, $callback);
+            next;
+        }
         unless ($pduhash->{$pdu}->[0]->{pdutype} eq "crpdu") {
             rinv_for_irpdu($pdu, $callback);
             next;
@@ -1051,6 +1391,19 @@ sub showMonitorData {
     my $nodehash = $nodetab->getNodesAttribs($noderange,['ip','otherinterfaces']);
 
     foreach my $pdu (@$noderange) {
+        if (($pduhash->{$pdu}->[0]->{pdutype} || '') eq 'genpdu') {
+            my $session = connectTopdu($pdu, $callback);
+            if (!$session) {
+                $callback->({ errorcode => [1], error => "Couldn't connect to $pdu" });
+                next;
+            }
+            my $count = $pduhash->{$pdu}->[0]->{outlet};
+            unless ($count) {
+                $count = fill_outletCount($session, $pdu, $callback);
+            }
+            rvitals_for_genpdu($pdu, $count, $session, $callback);
+            next;
+        }
         unless ($pduhash->{$pdu}->[0]->{pdutype} eq "crpdu") {
             my $session = connectTopdu($pdu,$callback);
             if (!$session) {

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -126,6 +126,16 @@ my %PDU2_SENSOR_UNIT = (
      4 => "VA", 5 => "Wh",  6 => "VAh", 7 => "C",  8 => "Hz",
      9 => "%", 20 => "deg", 23 => "var",
 );
+
+#Net-SNMP returns an enumerated INTEGER as its MIB label once the MIB is loaded
+#(a PX4 answers "amp" rather than "2"), so both forms have to be accepted. Keys
+#are lower cased, since the MIB labels are not.
+my %PDU2_UNIT_CODE = (
+    none    => -1, other       => 0, volt    => 1,  amp     => 2, watt => 3,
+    voltamp => 4,  watthour    => 5, voltamphour => 6, degreec => 7,
+    hertz   => 8,  percent     => 9, degrees => 20, var     => 23,
+);
+my %PDU2_STATE_CODE = (on => 7, off => 8);
 #Ordered for readability rather than by enum value.
 my @PDU2_INLET_SENSORS  = (4, 1, 5, 6, 7, 23, 3, 29, 8, 9, 10);
 my @PDU2_OUTLET_SENSORS = (1, 5, 8);
@@ -660,16 +670,15 @@ sub outletstat {
     my $session = shift;
     my $outlet = shift;
 
-    #genpdu: PDU2-MIB outletSwitchingState uses SensorStateEnumeration, of which
-    #on(7) and off(8) are the switching states. The value may come back as the
-    #integer or as the MIB label depending on which MIBs the Net-SNMP perl
-    #module has loaded, so both forms are accepted.
+    #genpdu: outletSwitchingState uses SensorStateEnumeration, of which on(7)
+    #and off(8) are the switching states.
     if ($session->{genpdu}) {
         my $val = $session->get("$PDU2_OUTLETSTATE.$PDU2_PDUID.$outlet");
         return "unknown state" unless (defined $val);
-        if    ($val eq "7" or $val eq "on")  { return "on"; }
-        elsif ($val eq "8" or $val eq "off") { return "off"; }
-        else                                 { return "$val(unknown state)"; }
+        my $state = pdu2_enum($val, \%PDU2_STATE_CODE);
+        return "on"  if (defined $state and $state == 7);
+        return "off" if (defined $state and $state == 8);
+        return "$val(unknown state)";
     }
 
     my $oid = ".1.3.6.1.4.1.2.6.223.8.2.2.1.11";
@@ -841,6 +850,31 @@ sub pdu2_session_args {
 
 #-------------------------------------------------------
 
+=head3  pdu2_enum
+
+   Numeric value of an enumerated INTEGER. Net-SNMP returns those as the MIB
+   label once the MIB is loaded, as label(value) when quick printing is off, and
+   as the number when it is not. Returns undef for anything else.
+
+=cut
+
+#-------------------------------------------------------
+sub pdu2_enum {
+    my ($val, $codes) = @_;
+
+    return undef unless (defined $val);
+    $val =~ s/^\s+|\s+$//g;
+    return $val if ($val =~ /^-?\d+$/);
+
+    #Trust the label over the number in label(value), so a mislabelled agent
+    #cannot turn volts into amperes.
+    my ($label, $num) = ($val =~ /^(\w+)\((-?\d+)\)$/) ? ($1, $2) : ($val, undef);
+    return $codes->{ lc $label } if (defined $codes->{ lc $label });
+    return $num;
+}
+
+#-------------------------------------------------------
+
 =head3  pdu2_get
 
    Read one object. Returns its value and one of 'ok', 'absent' or 'failed'.
@@ -900,10 +934,11 @@ sub pdu2_session_probe {
     }
 
     #Metered-only models such as PX2-1901U answer the measurement tables but
-    #have no outletSwitchControlTable instances.
+    #have no outletSwitchControlTable instances. Any state proves the instance
+    #exists, and an outlet is not always on or off, so this only asks whether
+    #the read produced one: pdu2_get has already ruled out absent and failed.
     my ($probe) = pdu2_get($session, "$PDU2_OUTLETSTATE.$PDU2_PDUID.1");
-    $session->{genpdu_switchable} =
-        ((defined $probe) and ($probe =~ /^\d+$/ or $probe =~ /^(on|off)$/i)) ? 1 : 0;
+    $session->{genpdu_switchable} = (defined $probe) ? 1 : 0;
 
     return 1;
 }
@@ -949,7 +984,8 @@ sub pdu2_sensor_fmt {
         my ($u, $ustate) = pdu2_get($session, "$oids->{units}.$idx");
         my ($d, $dstate) = pdu2_get($session, "$oids->{dec}.$idx");
         return undef if ($ustate eq 'failed' or $dstate eq 'failed');
-        $u = -1 unless (defined $u and $u =~ /^-?\d+$/);
+        $u = pdu2_enum($u, \%PDU2_UNIT_CODE);
+        $u = -1 unless (defined $u);
         $d = 0  unless (defined $d and $d =~ /^\d+$/);
         $cache->{$st} = [ $u, $d ];
     }

--- a/xCAT-test/unit/pdu_genpdu.t
+++ b/xCAT-test/unit/pdu_genpdu.t
@@ -1,0 +1,337 @@
+use strict;
+use warnings;
+## no critic (Modules::RequireFilenameMatchesPackage, TestingAndDebugging::ProhibitNoWarnings, TestingAndDebugging::ProhibitNoStrict)
+no warnings 'once';
+
+use File::Spec;
+use FindBin;
+use Test::More;
+
+BEGIN {
+    #pdu.pm pulls in modules the genpdu code paths never touch and that are not
+    #installed everywhere (SNMP, Expect, XML::Simple), plus xCAT modules that
+    #would open the database. Stub them out. xCAT::SvrUtils::sendmsg is the one
+    #that has to behave, since it is how the plugin returns its output.
+    for my $mod (qw(xCAT::Table xCAT::Utils xCAT::FifoPipe xCAT::MsgUtils
+                    xCAT::State xCAT::Usage xCAT::NodeRange
+                    SNMP Expect XML::Simple)) {
+        (my $file = $mod) =~ s{::}{/}g;
+        $INC{"$file.pm"} = __FILE__;
+        no strict 'refs';
+        *{"${mod}::import"} = sub { };
+    }
+
+    #pdu.pm uses Expect's exp_continue constant in its crpdu code paths, so the
+    #stub has to keep exporting that name.
+    {
+        no strict 'refs';
+        no warnings 'redefine';
+        *{'Expect::import'} = sub {
+            my $caller = caller;
+            no strict 'refs';
+            *{"${caller}::exp_continue"} = sub { return; };
+            return;
+        };
+    }
+
+    package xCAT::SvrUtils;
+    our @messages;
+    sub import { }
+    sub sendmsg {
+        my ($msg, $cb, $node) = @_;
+        push @messages, defined($node) ? "$node|$msg" : $msg;
+        return;
+    }
+    $INC{'xCAT/SvrUtils.pm'} = __FILE__;
+}
+
+my $repo_root = File::Spec->catdir($FindBin::Bin, '..', '..');
+$ENV{XCATROOT} = File::Spec->catdir($repo_root, 'xCAT-server');
+my $plugin = File::Spec->catfile($repo_root, 'xCAT-server', 'lib', 'xcat',
+    'plugins', 'pdu.pm');
+do $plugin or die $@ || "Unable to load $plugin: $!";
+
+{
+    #A stand-in for SNMP::Session: answers GETs from a canned table and records
+    #which OIDs were asked for, so tests can assert on request counts too.
+    package FakeSession;
+    sub new {
+        my ($class, $resp) = @_;
+        return bless { resp => $resp || {}, gets => [] }, $class;
+    }
+    sub get {
+        my ($self, $oid) = @_;
+        push @{ $self->{gets} }, $oid;
+        return $self->{resp}->{$oid};
+    }
+}
+
+my $PDUCOUNT     = ".1.3.6.1.4.1.13742.6.3.1.0";
+my $OUTLETSTATE  = ".1.3.6.1.4.1.13742.6.4.1.2.1.3";
+my $NAMEPLATE    = ".1.3.6.1.4.1.13742.6.3.2.1.1";
+my $UNITCONF     = ".1.3.6.1.4.1.13742.6.3.2.2.1";
+my $INLET_VAL    = ".1.3.6.1.4.1.13742.6.5.2.3.1.4";
+my $INLET_SVAL   = ".1.3.6.1.4.1.13742.6.5.2.3.1.6";
+my $INLET_MIN    = ".1.3.6.1.4.1.13742.6.3.3.4.1.27";
+my $INLET_UNITS  = ".1.3.6.1.4.1.13742.6.3.3.4.1.6";
+my $INLET_DEC    = ".1.3.6.1.4.1.13742.6.3.3.4.1.7";
+my $OUTLET_VAL   = ".1.3.6.1.4.1.13742.6.5.4.3.1.4";
+my $OUTLET_SVAL  = ".1.3.6.1.4.1.13742.6.5.4.3.1.6";
+my $OUTLET_MIN   = ".1.3.6.1.4.1.13742.6.3.5.4.1.27";
+my $OUTLET_UNITS = ".1.3.6.1.4.1.13742.6.3.5.4.1.6";
+my $OUTLET_DEC   = ".1.3.6.1.4.1.13742.6.3.5.4.1.7";
+my $SYSDESCR     = ".1.3.6.1.2.1.1.1.0";
+
+#What a PDU2 agent answers for an instance that does not exist.
+my $NOSUCH = "No Such Instance currently exists at this OID";
+
+#Readings captured from a Raritan PX4-5851-E7V2 (fw 4.2.10.5-50400), inlet 1
+#and outlet 1, as [sensorType, signedMinimum, value, signedValue, units, digits].
+#Reactive power is the sensor with a negative signedMinimum: the unsigned column
+#answers 0 there, the signed column carries the reading. Active and apparent
+#energy are the reverse: the signed column answers 0 because their range
+#exceeds Integer32, so neither column can be used unconditionally.
+my @PX4_INLET = (
+    [ 1,  0,      9503,     9503,  2,  3 ],
+    [ 3,  0,      11,       11,    9,  0 ],
+    [ 4,  0,      412,      412,   1,  0 ],
+    [ 5,  0,      6002,     6002,  3,  0 ],
+    [ 6,  0,      6194,     6194,  4,  0 ],
+    [ 7,  0,      97,       97,    -1, 2 ],
+    [ 8,  0,      93653612, 0,     5,  0 ],
+    [ 9,  0,      97629274, 0,     6,  0 ],
+    [ 23, 0,      600,      600,   8,  1 ],
+    [ 29, -63000, 0,        -1360, 23, 0 ],
+);
+my @PX4_OUTLET = (
+    [ 1, 0, 1042,    1042, 2, 3 ],
+    [ 5, 0, 245,     245,  3, 0 ],
+    [ 8, 0, 4088376, 0,    5, 0 ],
+);
+
+sub inlet_sensor {
+    my ($resp, $inlet, $s) = @_;
+    my ($st, $min, $val, $sval, $units, $digits) = @$s;
+    $resp->{"$INLET_MIN.1.$inlet.$st"}   = $min;
+    $resp->{"$INLET_VAL.1.$inlet.$st"}   = $val;
+    $resp->{"$INLET_SVAL.1.$inlet.$st"}  = $sval;
+    $resp->{"$INLET_UNITS.1.$inlet.$st"} = $units;
+    $resp->{"$INLET_DEC.1.$inlet.$st"}   = $digits;
+    return;
+}
+
+sub px4_responses {
+    my %resp = (
+        "$UNITCONF.2.1" => 1,     #inletCount
+        "$UNITCONF.4.1" => 36,    #outletCount
+    );
+    inlet_sensor(\%resp, 1, $_) foreach (@PX4_INLET);
+    foreach my $s (@PX4_OUTLET) {
+        my ($st, $min, $val, $sval, $units, $digits) = @$s;
+        foreach my $outlet (1 .. 2) {
+            $resp{"$OUTLET_MIN.1.$outlet.$st"}   = $min;
+            $resp{"$OUTLET_VAL.1.$outlet.$st"}   = $val;
+            $resp{"$OUTLET_SVAL.1.$outlet.$st"}  = $sval;
+            $resp{"$OUTLET_UNITS.1.$outlet.$st"} = $units;
+            $resp{"$OUTLET_DEC.1.$outlet.$st"}   = $digits;
+        }
+    }
+    return \%resp;
+}
+
+sub vitals_messages {
+    my ($resp, $outlets) = @_;
+    local @xCAT::SvrUtils::messages = ();
+    my $session = FakeSession->new($resp);
+    $session->{genpdu} = 1;
+    xCAT_plugin::pdu::rvitals_for_genpdu('pdu1', $outlets, $session, undef);
+    return ([ @xCAT::SvrUtils::messages ], $session);
+}
+
+#-- rvitals: value column selection ------------------------------------------
+
+my ($msgs, $session) = vitals_messages(px4_responses(), 2);
+
+ok(
+    (grep { $_ eq 'pdu1|inlet 1 Reactive Power: -1360 var' } @$msgs),
+    'a sensor with a negative signedMinimum is read from the signed column'
+);
+ok(
+    (grep { $_ eq 'pdu1|inlet 1 Active Energy: 93653612 Wh' } @$msgs),
+    'a sensor with signedMinimum 0 stays on the unsigned column'
+);
+ok(
+    (grep { $_ eq 'pdu1|inlet 1 RMS Current: 9.503 A' } @$msgs),
+    'readings are scaled by decimalDigits and labelled from sensorUnits'
+);
+ok(
+    (grep { $_ eq 'pdu1|inlet 1 Power Factor: 0.97' } @$msgs),
+    'a sensor reporting units none(-1) gets no unit suffix'
+);
+ok(
+    (grep { $_ eq 'pdu1|outlet 2 RMS Current: 1.042 A' } @$msgs),
+    'outlet sensors are read for every outlet in the count'
+);
+
+#-- rvitals: metered-only PDUs ------------------------------------------------
+
+my %metered = ("$UNITCONF.2.1" => 1);
+inlet_sensor(\%metered, 1, $PX4_INLET[0]);
+foreach my $st (map { $_->[0] } @PX4_OUTLET) {
+    $metered{"$OUTLET_MIN.1.1.$st"}  = $NOSUCH;
+    $metered{"$OUTLET_VAL.1.1.$st"}  = $NOSUCH;
+    $metered{"$OUTLET_SVAL.1.1.$st"} = $NOSUCH;
+}
+
+($msgs, $session) = vitals_messages(\%metered, 48);
+is(
+    scalar(grep { /\|outlet / } @$msgs), 0,
+    'a PDU with no outlet sensors reports inlet readings only'
+);
+cmp_ok(
+    scalar(grep { /^\Q$OUTLET_VAL\E\./ } @{ $session->{gets} }), '<=', 2,
+    'the outlet sensor loop is skipped instead of walking every outlet'
+);
+
+#-- rvitals: sensor metadata cache -------------------------------------------
+
+my %two_inlets = ("$UNITCONF.2.1" => 2);
+foreach my $col ($INLET_MIN, $INLET_VAL, $INLET_SVAL, $INLET_UNITS, $INLET_DEC) {
+    $two_inlets{"$col.1.1.1"} = $NOSUCH;
+}
+inlet_sensor(\%two_inlets, 2, $PX4_INLET[0]);
+
+($msgs, $session) = vitals_messages(\%two_inlets, 0);
+ok(
+    (grep { $_ eq 'pdu1|inlet 2 RMS Current: 9.503 A' } @$msgs),
+    'an absent sensor on one inlet does not seed the metadata cache for the next'
+);
+
+#-- rvitals: firmware without the signedMinimum column -----------------------
+
+my %no_min = ("$UNITCONF.2.1" => 1);
+inlet_sensor(\%no_min, 1, $PX4_INLET[0]);
+$no_min{"$INLET_MIN.1.1.1"} = $NOSUCH;
+
+($msgs, $session) = vitals_messages(\%no_min, 0);
+ok(
+    (grep { $_ eq 'pdu1|inlet 1 RMS Current: 9.503 A' } @$msgs),
+    'a sensor with no signedMinimum column falls back to the unsigned column'
+);
+
+#-- session probe -------------------------------------------------------------
+
+sub probe {
+    my ($resp) = @_;
+    local @xCAT::SvrUtils::messages = ();
+    my $session = FakeSession->new($resp);
+    my $ok = xCAT_plugin::pdu::pdu2_session_probe($session, 'pdu1', undef);
+    return ($ok, $session, [ @xCAT::SvrUtils::messages ]);
+}
+
+my ($ok, $probed, $probe_msgs) = probe({});
+ok(!$ok, 'a PDU that answers nothing at all is reported as unreachable');
+
+($ok, $probed, $probe_msgs) = probe({
+    $SYSDESCR          => '"Raritan PDU, MD:PX4-5851-E7V2"',
+    "$OUTLETSTATE.1.1" => 7,
+});
+ok($ok, 'a PDU that answers sysDescr but not pduCount is still usable');
+is(scalar(@$probe_msgs), 0, 'a PDU with no pduCount is not warned about');
+
+($ok, $probed, $probe_msgs) = probe({
+    $PDUCOUNT             => 1,
+    "$OUTLETSTATE.1.1"    => 7,
+});
+ok($ok, 'a PDU that answers pduCount is usable');
+is($probed->{genpdu_switchable}, 1, 'an answered outlet state marks the PDU switchable');
+
+($ok, $probed, $probe_msgs) = probe({
+    $PDUCOUNT             => 1,
+    "$OUTLETSTATE.1.1"    => $NOSUCH,
+});
+ok($ok, 'a metered-only PDU is still usable for rinv and rvitals');
+is($probed->{genpdu_switchable}, 0, 'a missing outlet state marks the PDU not switchable');
+
+($ok, $probed, $probe_msgs) = probe({
+    $PDUCOUNT             => 3,
+    "$OUTLETSTATE.1.1"    => 7,
+});
+ok($ok, 'a linked PDU is not refused');
+ok(
+    (grep { /pduCount is 3/ } @$probe_msgs),
+    'a pduCount other than 1 warns that only the primary unit is managed'
+);
+
+#-- session arguments from the pdu table -------------------------------------
+
+my %v3 = xCAT_plugin::pdu::pdu2_session_args('pdu1', {
+    snmpversion => 'v3',
+    snmpuser    => 'admin',
+    authtype    => 'sha',
+    authkey     => 'authsecret',
+    privtype    => 'aes',
+});
+is($v3{Version},   3,            'snmpversion v3 selects SNMPv3');
+is($v3{SecName},   'admin',      'snmpuser becomes the v3 security name');
+is($v3{SecLevel},  'authPriv',   'a privacy protocol implies authPriv');
+is($v3{AuthProto}, 'SHA',        'the auth protocol is upper cased for net-snmp');
+is($v3{PrivProto}, 'AES',        'the privacy protocol is upper cased for net-snmp');
+is($v3{PrivPass},  'authsecret', 'privkey falls back to authkey when unset');
+
+my %noauth = xCAT_plugin::pdu::pdu2_session_args('pdu1', {
+    snmpversion => '3',
+    snmpuser    => 'admin',
+    authkey     => 'authsecret',
+});
+is($noauth{SecLevel}, 'authNoPriv', 'no privacy protocol implies authNoPriv');
+ok(!exists $noauth{PrivProto}, 'authNoPriv sends no privacy protocol');
+
+my %v2c = xCAT_plugin::pdu::pdu2_session_args('pdu1', {
+    snmpversion => 'v2c',
+    community   => 'private',
+});
+is($v2c{Version},   2,         'snmpversion v2c selects SNMPv2c');
+is($v2c{Community}, 'private', 'the community comes from the pdu table');
+
+my %v1 = xCAT_plugin::pdu::pdu2_session_args('pdu1', {});
+is($v1{Version},   1,        'an unset snmpversion falls back to SNMPv1');
+is($v1{Community}, 'public', 'an unset community falls back to public');
+
+#-- outlet state translation --------------------------------------------------
+
+sub outlet_state {
+    my ($val) = @_;
+    my $session = FakeSession->new({ "$OUTLETSTATE.1.4" => $val });
+    $session->{genpdu} = 1;
+    return xCAT_plugin::pdu::outletstat($session, 4);
+}
+
+is(outlet_state(7),        'on',            'outletSwitchingState on(7) reads as on');
+is(outlet_state(8),        'off',           'outletSwitchingState off(8) reads as off');
+is(outlet_state(undef),    'unknown state', 'an unanswered outlet state is unknown');
+
+#-- rinv ----------------------------------------------------------------------
+
+{
+    local @xCAT::SvrUtils::messages = ();
+    my $session = FakeSession->new({
+        "$NAMEPLATE.2.1" => '"Raritan"',
+        "$NAMEPLATE.3.1" => '"PX4-5851-E7V2"',
+        "$NAMEPLATE.4.1" => '"R2BP0123456"',
+        "$UNITCONF.4.1"  => 36,
+        $SYSDESCR        => '"Raritan PDU, MD:PX4-5851-E7V2 HW:0x1D FW:4.2.10.5-50400"',
+    });
+    $session->{genpdu} = 1;
+    xCAT_plugin::pdu::rinv_for_genpdu('pdu1', $session, undef);
+    my @m = @xCAT::SvrUtils::messages;
+
+    ok((grep { $_ eq 'pdu1|PDU Manufacturer: Raritan' } @m),
+        'nameplate strings are reported without their quotes');
+    ok((grep { $_ eq 'pdu1|PDU Outlet Count: 36' } @m),
+        'the outlet count is reported from unitConfiguration');
+    ok((grep { /^pdu1\|PDU Description: Raritan PDU, MD:PX4/ } @m),
+        'the firmware string is reported from sysDescr');
+}
+
+done_testing();

--- a/xCAT-test/unit/pdu_genpdu.t
+++ b/xCAT-test/unit/pdu_genpdu.t
@@ -59,10 +59,24 @@ do $plugin or die $@ || "Unable to load $plugin: $!";
         my ($class, $resp) = @_;
         return bless { resp => $resp || {}, gets => [] }, $class;
     }
+    #An OID the fixture does not mention models a device that does not answer:
+    #undef with ErrorStr set, which is what SNMP.pm does on a timeout. A fixture
+    #value of "No Such ..." models an answer that carries an exception, and a
+    #hashref models any other transport or protocol failure.
     sub get {
         my ($self, $oid) = @_;
         push @{ $self->{gets} }, $oid;
-        return $self->{resp}->{$oid};
+        my $val = $self->{resp}->{$oid};
+        if (ref $val eq 'HASH') {
+            $self->{ErrorStr} = $val->{err};
+            return undef;
+        }
+        unless (exists $self->{resp}->{$oid}) {
+            $self->{ErrorStr} = 'Timeout';
+            return undef;
+        }
+        $self->{ErrorStr} = '';
+        return $val;
     }
 }
 
@@ -207,6 +221,58 @@ ok(
     'an absent sensor on one inlet does not seed the metadata cache for the next'
 );
 
+#-- rvitals: the value column is decided per entity ---------------------------
+
+my %two_readings = ("$UNITCONF.2.1" => 2);
+inlet_sensor(\%two_readings, 1, [ 29, -63000, 0,   -1360, 23, 0 ]);
+inlet_sensor(\%two_readings, 2, [ 29, 0,      250, 999,   23, 0 ]);
+
+($msgs, $session) = vitals_messages(\%two_readings, 0);
+ok(
+    (grep { $_ eq 'pdu1|inlet 1 Reactive Power: -1360 var' } @$msgs),
+    'the entity with a negative signed minimum reads the signed column'
+);
+ok(
+    (grep { $_ eq 'pdu1|inlet 2 Reactive Power: 250 var' } @$msgs),
+    'an entity with signed minimum 0 is not forced onto the signed column by another entity'
+);
+
+#-- rvitals: a failed metadata read is not a missing column -------------------
+
+my %min_fails = ("$UNITCONF.2.1" => 1);
+inlet_sensor(\%min_fails, 1, $PX4_INLET[0]);
+$min_fails{"$INLET_MIN.1.1.1"} = { err => 'Timeout' };
+
+($msgs, $session) = vitals_messages(\%min_fails, 0);
+is(
+    scalar(grep { /RMS Current/ } @$msgs), 0,
+    'a sensor whose signed minimum read fails is skipped rather than guessed'
+);
+
+#-- rvitals: SNMPv1 reports an absent object as an error ----------------------
+
+my %v1_absent = ("$UNITCONF.2.1" => 1);
+inlet_sensor(\%v1_absent, 1, $PX4_INLET[0]);
+$v1_absent{"$INLET_MIN.1.1.1"} = { err => 'There is no such variable name in this MIB.' };
+
+($msgs, $session) = vitals_messages(\%v1_absent, 0);
+ok(
+    (grep { $_ eq 'pdu1|inlet 1 RMS Current: 9.503 A' } @$msgs),
+    'an absent signed minimum reported as a v1 error still falls back to the unsigned column'
+);
+
+#-- rvitals: a failed unit read is not a unitless sensor ----------------------
+
+my %units_fail = ("$UNITCONF.2.1" => 1);
+inlet_sensor(\%units_fail, 1, $PX4_INLET[0]);
+$units_fail{"$INLET_DEC.1.1.1"} = { err => 'Timeout' };
+
+($msgs, $session) = vitals_messages(\%units_fail, 0);
+is(
+    scalar(grep { /RMS Current/ } @$msgs), 0,
+    'a sensor whose precision read fails is skipped rather than reported unscaled'
+);
+
 #-- rvitals: firmware without the signedMinimum column -----------------------
 
 my %no_min = ("$UNITCONF.2.1" => 1);
@@ -222,22 +288,39 @@ ok(
 #-- session probe -------------------------------------------------------------
 
 sub probe {
-    my ($resp) = @_;
+    my ($resp, $name) = @_;
     local @xCAT::SvrUtils::messages = ();
     my $session = FakeSession->new($resp);
-    my $ok = xCAT_plugin::pdu::pdu2_session_probe($session, 'pdu1', undef);
+    my $ok = xCAT_plugin::pdu::pdu2_session_probe($session, $name || 'pdu1', undef);
     return ($ok, $session, [ @xCAT::SvrUtils::messages ]);
 }
 
 my ($ok, $probed, $probe_msgs) = probe({});
 ok(!$ok, 'a PDU that answers nothing at all is reported as unreachable');
+is(scalar(@{ $probed->{gets} }), 1, 'an unanswered PDU is not probed a second time');
 
 ($ok, $probed, $probe_msgs) = probe({
-    $SYSDESCR          => '"Raritan PDU, MD:PX4-5851-E7V2"',
+    $PDUCOUNT          => $NOSUCH,
+    "$NAMEPLATE.3.1"   => '"PX4-5851-E7V2"',
     "$OUTLETSTATE.1.1" => 7,
 });
-ok($ok, 'a PDU that answers sysDescr but not pduCount is still usable');
+ok($ok, 'a PDU that answers the nameplate but not pduCount is still usable');
 is(scalar(@$probe_msgs), 0, 'a PDU with no pduCount is not warned about');
+
+($ok, $probed, $probe_msgs) = probe({
+    $PDUCOUNT        => $NOSUCH,
+    "$NAMEPLATE.3.1" => $NOSUCH,
+    $SYSDESCR        => '"Raritan PDU, MD:PX4-5851-E7V2"',
+});
+ok(!$ok, 'a credential that cannot read the PDU2 tables is not a usable session');
+
+($ok, $probed, $probe_msgs) = probe({
+    $PDUCOUNT          => 0,
+    "$NAMEPLATE.3.1"   => '"PX4-5851-E7V2"',
+    "$OUTLETSTATE.1.1" => 7,
+});
+ok($ok, 'a pduCount of 0 falls back to the nameplate rather than being trusted');
+is(scalar(@$probe_msgs), 0, 'a pduCount of 0 does not warn about linked units');
 
 ($ok, $probed, $probe_msgs) = probe({
     $PDUCOUNT             => 1,
@@ -253,14 +336,21 @@ is($probed->{genpdu_switchable}, 1, 'an answered outlet state marks the PDU swit
 ok($ok, 'a metered-only PDU is still usable for rinv and rvitals');
 is($probed->{genpdu_switchable}, 0, 'a missing outlet state marks the PDU not switchable');
 
-($ok, $probed, $probe_msgs) = probe({
-    $PDUCOUNT             => 3,
-    "$OUTLETSTATE.1.1"    => 7,
-});
+my %linked = (
+    $PDUCOUNT          => 3,
+    "$OUTLETSTATE.1.1" => 7,
+);
+($ok, $probed, $probe_msgs) = probe(\%linked, 'linked1');
 ok($ok, 'a linked PDU is not refused');
 ok(
     (grep { /pduCount is 3/ } @$probe_msgs),
     'a pduCount other than 1 warns that only the primary unit is managed'
+);
+
+($ok, $probed, $probe_msgs) = probe(\%linked, 'linked1');
+is(
+    scalar(@$probe_msgs), 0,
+    'the linked unit warning is not repeated for the same PDU'
 );
 
 #-- session arguments from the pdu table -------------------------------------
@@ -332,6 +422,25 @@ is(outlet_state(undef),    'unknown state', 'an unanswered outlet state is unkno
         'the outlet count is reported from unitConfiguration');
     ok((grep { /^pdu1\|PDU Description: Raritan PDU, MD:PX4/ } @m),
         'the firmware string is reported from sysDescr');
+}
+
+{
+    local @xCAT::SvrUtils::messages = ();
+    my $session = FakeSession->new({
+        "$NAMEPLATE.2.1" => '"Raritan"',
+        "$NAMEPLATE.7.1" => $NOSUCH,
+    });
+    $session->{genpdu} = 1;
+    xCAT_plugin::pdu::rinv_for_genpdu('pdu1', $session, undef);
+
+    is(
+        scalar(grep { /Rated Frequency/ } @xCAT::SvrUtils::messages), 0,
+        'a nameplate field the device does not have is left out of rinv'
+    );
+    is(
+        scalar(grep { /No Such/ } @xCAT::SvrUtils::messages), 0,
+        'rinv never reports an SNMP exception string as inventory'
+    );
 }
 
 done_testing();

--- a/xCAT-test/unit/pdu_genpdu.t
+++ b/xCAT-test/unit/pdu_genpdu.t
@@ -187,6 +187,36 @@ ok(
     'outlet sensors are read for every outlet in the count'
 );
 
+#-- rvitals: units as MIB labels ----------------------------------------------
+
+#With PDU2-MIB loaded, Net-SNMP returns SensorUnitsEnumeration as its label:
+#a PX4 answers "amp" rather than "2", and "amp(2)" when quick printing is off.
+sub units_as {
+    my ($units) = @_;
+    my %resp = ("$UNITCONF.2.1" => 1);
+    inlet_sensor(\%resp, 1, $PX4_INLET[0]);
+    $resp{"$INLET_UNITS.1.1.1"} = $units;
+    my ($m) = vitals_messages(\%resp, 0);
+    return $m;
+}
+
+ok(
+    (grep { $_ eq 'pdu1|inlet 1 RMS Current: 9.503 A' } @{ units_as('amp') }),
+    'a unit returned as its MIB label still gets its suffix'
+);
+ok(
+    (grep { $_ eq 'pdu1|inlet 1 RMS Current: 9.503 A' } @{ units_as('amp(2)') }),
+    'a unit returned as label(value) still gets its suffix'
+);
+ok(
+    (grep { $_ eq 'pdu1|inlet 1 RMS Current: 9.503 Wh' } @{ units_as('wattHour') }),
+    'a mixed case MIB label is recognised'
+);
+ok(
+    (grep { $_ eq 'pdu1|inlet 1 RMS Current: 9.503' } @{ units_as('lux') }),
+    'a unit with no suffix defined is reported without one'
+);
+
 #-- rvitals: metered-only PDUs ------------------------------------------------
 
 my %metered = ("$UNITCONF.2.1" => 1);
@@ -330,6 +360,12 @@ ok($ok, 'a PDU that answers pduCount is usable');
 is($probed->{genpdu_switchable}, 1, 'an answered outlet state marks the PDU switchable');
 
 ($ok, $probed, $probe_msgs) = probe({
+    $PDUCOUNT          => 1,
+    "$OUTLETSTATE.1.1" => 'standby',
+});
+is($probed->{genpdu_switchable}, 1, 'an outlet in a state other than on or off is still switchable');
+
+($ok, $probed, $probe_msgs) = probe({
     $PDUCOUNT             => 1,
     "$OUTLETSTATE.1.1"    => $NOSUCH,
 });
@@ -399,6 +435,8 @@ sub outlet_state {
 
 is(outlet_state(7),        'on',            'outletSwitchingState on(7) reads as on');
 is(outlet_state(8),        'off',           'outletSwitchingState off(8) reads as off');
+is(outlet_state('on'),     'on',            'an outlet state returned as a MIB label reads as on');
+is(outlet_state('off(8)'), 'off',           'an outlet state returned as label(value) reads as off');
 is(outlet_state(undef),    'unknown state', 'an unanswered outlet state is unknown');
 
 #-- rinv ----------------------------------------------------------------------


### PR DESCRIPTION
Add a new pdutype (`genpdu`) for PDUs implementing the Raritan PDU2-MIB. A single MIB covers the Raritan PX2/PX3/PX4/PXC/SRC/PXO/BCM series, the Server Technology PRO3X/PRO4X series, the Legrand intelligent PDUs, and should work for all PDUs following the PDU2-MIB.

Supports rpower (whole-PDU and per-outlet), rinv and rvitals over SNMP v1, v2c or v3, with credentials read from the pdu table.

Unlike the existing types, sensor units and decimal precision are read from the MIB per sensor rather than hardcoded, so readings are correct across models that report differing precision for the same sensor. Outlet switching capability is probed at connect time, so metered-only models report a single "unsupported" message instead of a per-outlet error.

rspconfig is not supported for `genpdu`.

Tested on Raritan PX4-5851-E7V2 (fw 4.2.10.5-50400, switched), PX3-1901U-N1 and PX3-1901U-N1A6 (fw 4.0.20.5-49038, metered), and PX2-1901U-N1A6 (fw 4.0.20.5-49038, metered).