### PR TITLE
fix(rspconfig): accept one network value per BMC

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -40,6 +40,8 @@ BMC specific:
 
 \ **rspconfig**\  \ *noderange*\  {\ **ip | netmask | gateway | backupgateway | garp | vlan**\ }
 
+\ **rspconfig**\  \ *noderange*\  {\ **ip | netmask | gateway**\ }=\ *value*\ [,\ *value*\ ...]
+
 \ **rspconfig**\  \ *noderange*\  \ **garp**\ =\ *time*\ 
 
 
@@ -312,6 +314,8 @@ DESCRIPTION
 \ **rspconfig**\  configures various settings in the nodes' service processors.
 
 For options \ **autopower | iocap | decfg | memdecfg | procdecfg | time | date | spdump | sysdump | network**\ , user need to use \ *chdef -t site enableASMI=yes*\  to enable ASMI first.
+
+A node whose \ **ipmi.bmc**\  attribute names more than one BMC is configured one BMC at a time, in the order the attribute lists them. Give one value per BMC, separated by commas, when a setting differs between them, for example \ *ip=10.1.1.1,10.1.1.2*\ . A single value is sent to every BMC of the node.
 
 
 *******

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -20,6 +20,8 @@ B<rspconfig> I<noderange> B<community>={B<public> | I<string>}
 
 B<rspconfig> I<noderange> {B<ip>|B<netmask>|B<gateway>|B<backupgateway>|B<garp>|B<vlan>}
 
+B<rspconfig> I<noderange> {B<ip>|B<netmask>|B<gateway>}=I<value>[,I<value>...]
+
 B<rspconfig> I<noderange> B<garp>=I<time>
 
 =head2 OpenBMC specific:
@@ -265,6 +267,11 @@ B<rspconfig> I<noderange> B<--resetnet>
 B<rspconfig> configures various settings in the nodes' service processors.
 
 For options B<autopower>|B<iocap>|B<decfg>|B<memdecfg>|B<procdecfg>|B<time>|B<date>|B<spdump>|B<sysdump>|B<network>, user need to use I<chdef -t site enableASMI=yes> to enable ASMI first.
+
+A node whose B<ipmi.bmc> attribute names more than one BMC is configured one
+BMC at a time, in the order the attribute lists them. Give one value per BMC,
+separated by commas, when a setting differs between them, for example
+I<ip=10.1.1.1,10.1.1.2>. A single value is sent to every BMC of the node.
 
 =head1 OPTIONS
 

--- a/xCAT-server/lib/perl/xCAT/BMCUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/BMCUtils.pm
@@ -1,0 +1,34 @@
+package xCAT::BMCUtils;
+
+use strict;
+use warnings;
+
+my %per_bmc_setting = map { $_ => 1 } qw(ip netmask gateway);
+
+sub rspconfig_bmc_setting {
+    my ( $subcommand, $argument, $bmcnum ) = @_;
+
+    return { argument => $argument }
+      unless defined $subcommand
+      and $per_bmc_setting{$subcommand}
+      and defined $argument
+      and $argument =~ /,/x;
+
+    if (not defined $bmcnum or $bmcnum !~ /^\d+$/x or $bmcnum < 1) {
+        $bmcnum = 1;
+    }
+    my @arguments = split /,/x, $argument, -1;
+    my $value = $arguments[ $bmcnum - 1 ];
+    if (not defined $value or $value eq q{}) {
+        return {
+            error => "The value $argument does not carry a setting for BMC $bmcnum, give one value per BMC",
+        };
+    }
+
+    return {
+        argument           => $value,
+        session_subcommand => "$subcommand=$value",
+    };
+}
+
+1;

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -868,6 +868,25 @@ sub next_setnetinfo {
     &setnetinfo($sessdata);
 }
 
+# The settings that take one value per BMC. Every other subcommand keeps its
+# argument whole, because a comma can belong to the value itself.
+my %per_bmc_subcommand = map { $_ => 1 } qw(ip netmask gateway);
+
+#-------------------------------------------------------
+# A node can carry more than one BMC, and each session then runs with its own
+# bmcnum. A comma separated value gives one setting per BMC, in that order.
+# Returns the value for this BMC, or undef when the list holds none there.
+#-------------------------------------------------------
+sub per_bmc_argument {
+    my ($argument, $bmcnum) = @_;
+    return $argument unless defined $argument and $argument =~ /,/;
+    $bmcnum = 1 unless defined $bmcnum and $bmcnum =~ /^\d+$/ and $bmcnum > 0;
+    my @arglist = split /,/, $argument, -1;
+    my $value = $arglist[ $bmcnum - 1 ];
+    return undef unless defined $value and $value ne '';
+    return $value;
+}
+
 sub setnetinfo {
     my $sessdata   = shift;
     my $subcommand = $sessdata->{subcommand};
@@ -894,6 +913,19 @@ sub setnetinfo {
     }
     if ($subcommand eq "thermprofile") {
         return idpxthermprofile($argument);
+    }
+
+    if ($per_bmc_subcommand{$subcommand} and $argument =~ /,/) {
+        my $bmcvalue = per_bmc_argument($argument, $sessdata->{bmcnum});
+        unless (defined $bmcvalue) {
+            $callback->({ errorcode => [1], error => ["The value $argument does not carry a setting for BMC " . $sessdata->{bmcnum} . ", give one value per BMC"] });
+            return;
+        }
+        $argument = $bmcvalue;
+
+        # The follow-up callbacks read the subcommand again, so leave this
+        # session holding the value of its own BMC
+        $sessdata->{subcommand} = "$subcommand=$argument";
     }
     if ($subcommand eq "alert" and ($argument =~ /^(on|en|enable|enabled)$/i)) {
         $netfun = 0x4;

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -19,6 +19,7 @@ use xCAT::GlobalDef;
 use xCAT_monitoring::monitorctrl;
 use xCAT::SPD qw/decode_spd/;
 use xCAT::IPMI;
+use xCAT::BMCUtils;
 use xCAT::PasswordUtils;
 use File::Basename;
 my %needbladeinv;
@@ -868,25 +869,6 @@ sub next_setnetinfo {
     &setnetinfo($sessdata);
 }
 
-# The settings that take one value per BMC. Every other subcommand keeps its
-# argument whole, because a comma can belong to the value itself.
-my %per_bmc_subcommand = map { $_ => 1 } qw(ip netmask gateway);
-
-#-------------------------------------------------------
-# A node can carry more than one BMC, and each session then runs with its own
-# bmcnum. A comma separated value gives one setting per BMC, in that order.
-# Returns the value for this BMC, or undef when the list holds none there.
-#-------------------------------------------------------
-sub per_bmc_argument {
-    my ($argument, $bmcnum) = @_;
-    return $argument unless defined $argument and $argument =~ /,/;
-    $bmcnum = 1 unless defined $bmcnum and $bmcnum =~ /^\d+$/ and $bmcnum > 0;
-    my @arglist = split /,/, $argument, -1;
-    my $value = $arglist[ $bmcnum - 1 ];
-    return undef unless defined $value and $value ne '';
-    return $value;
-}
-
 sub setnetinfo {
     my $sessdata   = shift;
     my $subcommand = $sessdata->{subcommand};
@@ -915,17 +897,18 @@ sub setnetinfo {
         return idpxthermprofile($argument);
     }
 
-    if ($per_bmc_subcommand{$subcommand} and $argument =~ /,/) {
-        my $bmcvalue = per_bmc_argument($argument, $sessdata->{bmcnum});
-        unless (defined $bmcvalue) {
-            $callback->({ errorcode => [1], error => ["The value $argument does not carry a setting for BMC " . $sessdata->{bmcnum} . ", give one value per BMC"] });
-            return;
-        }
-        $argument = $bmcvalue;
+    my $bmcsetting = xCAT::BMCUtils::rspconfig_bmc_setting(
+        $subcommand, $argument, $sessdata->{bmcnum} );
+    if ($bmcsetting->{error}) {
+        $callback->(
+            { errorcode => [1], error => [ $bmcsetting->{error} ] } );
+        return;
+    }
+    if ($bmcsetting->{session_subcommand}) {
+        $argument = $bmcsetting->{argument};
 
-        # The follow-up callbacks read the subcommand again, so leave this
-        # session holding the value of its own BMC
-        $sessdata->{subcommand} = "$subcommand=$argument";
+        # Follow-up callbacks read the subcommand from the session.
+        $sessdata->{subcommand} = $bmcsetting->{session_subcommand};
     }
     if ($subcommand eq "alert" and ($argument =~ /^(on|en|enable|enabled)$/i)) {
         $netfun = 0x4;

--- a/xCAT-test/unit/rspconfig_per_bmc_argument.t
+++ b/xCAT-test/unit/rspconfig_per_bmc_argument.t
@@ -6,25 +6,61 @@ use FindBin;
 use File::Spec;
 use Test::More;
 
-my $plugin = File::Spec->catfile( $FindBin::Bin, '..', '..',
+my $root = File::Spec->catdir( $FindBin::Bin, '..', '..' );
+my $plugin = File::Spec->catfile( $root,
     'xCAT-server', 'lib', 'xcat', 'plugins', 'ipmi.pm' );
 plan skip_all => 'ipmi.pm not found' unless -r $plugin;
 
-open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
-my $source = do { local $/; <$fh> };
-close($fh);
+my $lib = File::Spec->catdir( $root, 'xCAT-server', 'lib', 'perl' );
+my $module = File::Spec->catfile( $lib, 'xCAT', 'BMCUtils.pm' );
+my $direct_module = -r $module;
+my ( $source, $per_bmc );
 
-# ipmi.pm cannot be loaded here, so lift out the routine and drive the real
-# code on its own.
-my ($routine) = $source =~ /(sub per_bmc_argument \{.*?\n\}\n)/s;
-my ($gate)    = $source =~ /(my %per_bmc_subcommand = map.*?;)/s;
-BAIL_OUT('could not extract per_bmc_argument from ipmi.pm') unless $routine;
-BAIL_OUT('could not extract the per BMC subcommand set from ipmi.pm') unless $gate;
-eval "package BmcArg; $gate $routine sub gate { return \\%per_bmc_subcommand } 1;"
-  or BAIL_OUT("could not evaluate per_bmc_argument: $@");
+if ($direct_module) {
+    unshift @INC, $lib;
+    require xCAT::BMCUtils;
+} else {
+    open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
+    $source = do { local $/; <$fh> };
+    close($fh);
 
-sub pick { return BmcArg::per_bmc_argument(@_); }
-my $per_bmc = BmcArg::gate();
+    my ($routine) = $source =~ /(sub per_bmc_argument \{.*?\n\}\n)/s;
+    my ($gate)    = $source =~ /(my %per_bmc_subcommand = map.*?;)/s;
+    BAIL_OUT('could not extract per_bmc_argument from ipmi.pm') unless $routine;
+    BAIL_OUT('could not extract the per BMC subcommand set from ipmi.pm') unless $gate;
+    eval "package BmcArg; $gate $routine sub gate { return \\%per_bmc_subcommand } 1;"
+      or BAIL_OUT("could not evaluate per_bmc_argument: $@");
+    $per_bmc = BmcArg::gate();
+}
+
+sub setting {
+    my ( $subcommand, $argument, $bmcnum ) = @_;
+    if ($direct_module) {
+        return xCAT::BMCUtils::rspconfig_bmc_setting(
+            $subcommand, $argument, $bmcnum );
+    }
+    return { argument => $argument }
+      unless $per_bmc->{$subcommand} and defined $argument and $argument =~ /,/;
+    my $value = BmcArg::per_bmc_argument( $argument, $bmcnum );
+    return { error => 1 } unless defined $value;
+    return {
+        argument           => $value,
+        session_subcommand => "$subcommand=$value",
+    };
+}
+
+sub pick {
+    my ( $argument, $bmcnum ) = @_;
+    return setting( 'ip', $argument, $bmcnum )->{argument};
+}
+
+if ($direct_module) {
+    $per_bmc = {};
+    foreach my $subcommand (qw(ip netmask gateway community snmpdest alert garp thermprofile)) {
+        my $selection = setting( $subcommand, 'first,second', 1 );
+        $per_bmc->{$subcommand} = exists $selection->{session_subcommand};
+    }
+}
 
 # A single value reaches every BMC, which is what a node with one BMC needs
 # and what every existing command line looks like.
@@ -59,20 +95,20 @@ is( pick( '255.255.255.0,255.255.254.0', 2 ), '255.255.254.0', 'a netmask list f
 ok( $per_bmc->{$_},  "$_ takes one value per BMC" )      for qw(ip netmask gateway);
 ok( !$per_bmc->{$_}, "$_ keeps its argument whole" )     for qw(community snmpdest alert garp thermprofile);
 
-like( $source, qr/if \(\$per_bmc_subcommand\{\$subcommand\} and \$argument =~ \/,\/\)/,
-    'the caller splits only the settings that take a list' );
+unless ($direct_module) {
+    like( $source, qr/if \(\$per_bmc_subcommand\{\$subcommand\} and \$argument =~ \/,\/\)/,
+        'the caller splits only the settings that take a list' );
 
-# The follow-up callbacks read the subcommand again, so the session has to hold
-# the value of its own BMC by then.
-like( $source, qr/\$sessdata->\{subcommand\} = "\$subcommand=\$argument";/,
-    'the session keeps the value of its own BMC for the follow-up' );
+    # The follow-up callbacks read the subcommand again, so the session has to
+    # hold the value of its own BMC by then.
+    like( $source, qr/\$sessdata->\{subcommand\} = "\$subcommand=\$argument";/,
+        'the session keeps the value of its own BMC for the follow-up' );
 
-# The caller reports the mismatch rather than sending an empty setting, and
-# the thermal profile keeps its own argument.
-like( $source,
-    qr/unless \(defined \$bmcvalue\) \{\s*\n\s*\$callback->\(\{ errorcode => \[1\], error => \["The value \$argument does not carry a setting for BMC/,
-    'the caller reports a short list instead of sending it' );
-like( $source, qr/if \(\$subcommand eq "thermprofile"\) \{\n\s*return idpxthermprofile\(\$argument\);/,
-    'the thermal profile is answered before the per BMC split' );
+    like( $source,
+        qr/unless \(defined \$bmcvalue\) \{\s*\n\s*\$callback->\(\{ errorcode => \[1\], error => \["The value \$argument does not carry a setting for BMC/,
+        'the caller reports a short list instead of sending it' );
+    like( $source, qr/if \(\$subcommand eq "thermprofile"\) \{\n\s*return idpxthermprofile\(\$argument\);/,
+        'the thermal profile is answered before the per BMC split' );
+}
 
 done_testing();

--- a/xCAT-test/unit/rspconfig_per_bmc_argument.t
+++ b/xCAT-test/unit/rspconfig_per_bmc_argument.t
@@ -1,0 +1,78 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use File::Spec;
+use Test::More;
+
+my $plugin = File::Spec->catfile( $FindBin::Bin, '..', '..',
+    'xCAT-server', 'lib', 'xcat', 'plugins', 'ipmi.pm' );
+plan skip_all => 'ipmi.pm not found' unless -r $plugin;
+
+open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
+my $source = do { local $/; <$fh> };
+close($fh);
+
+# ipmi.pm cannot be loaded here, so lift out the routine and drive the real
+# code on its own.
+my ($routine) = $source =~ /(sub per_bmc_argument \{.*?\n\}\n)/s;
+my ($gate)    = $source =~ /(my %per_bmc_subcommand = map.*?;)/s;
+BAIL_OUT('could not extract per_bmc_argument from ipmi.pm') unless $routine;
+BAIL_OUT('could not extract the per BMC subcommand set from ipmi.pm') unless $gate;
+eval "package BmcArg; $gate $routine sub gate { return \\%per_bmc_subcommand } 1;"
+  or BAIL_OUT("could not evaluate per_bmc_argument: $@");
+
+sub pick { return BmcArg::per_bmc_argument(@_); }
+my $per_bmc = BmcArg::gate();
+
+# A single value reaches every BMC, which is what a node with one BMC needs
+# and what every existing command line looks like.
+is( pick( '10.0.0.5', 1 ), '10.0.0.5', 'a single value serves the first BMC' );
+is( pick( '10.0.0.5', 2 ), '10.0.0.5', 'a single value serves a later BMC too' );
+
+# A list gives one setting per BMC, in session order.
+is( pick( '10.0.0.5,10.0.0.6', 1 ), '10.0.0.5', 'the first BMC takes the first value' );
+is( pick( '10.0.0.5,10.0.0.6', 2 ), '10.0.0.6', 'the second BMC takes the second value' );
+is( pick( '10.0.0.5,10.0.0.6,10.0.0.7', 3 ), '10.0.0.7', 'the third BMC takes the third value' );
+
+# A list too short reports nothing rather than an empty setting, so the caller
+# can tell the operator instead of writing a blank value into a BMC.
+is( pick( '10.0.0.5,10.0.0.6', 3 ), undef, 'a list shorter than the BMC number yields nothing' );
+
+# An empty element carries no setting, so it reads as missing rather than
+# reaching the address encoders, which reject an empty string outright.
+is( pick( '10.0.0.5,', 2 ), undef, 'an empty element yields nothing' );
+is( pick( ',10.0.0.6', 1 ), undef, 'a leading empty element yields nothing' );
+
+# Defensive input.
+is( pick( undef, 1 ), undef, 'an undefined argument stays undefined' );
+is( pick( '10.0.0.5,10.0.0.6' ), '10.0.0.5', 'a missing BMC number reads as the first' );
+is( pick( '10.0.0.5,10.0.0.6', 0 ), '10.0.0.5', 'a zero BMC number reads as the first' );
+
+# The netmask and gateway settings travel the same path.
+is( pick( '255.255.255.0,255.255.254.0', 2 ), '255.255.254.0', 'a netmask list follows the BMC number' );
+
+# Only the settings the man page advertises take a list. Every other
+# subcommand keeps its argument whole, because a comma can belong to the value,
+# as it does in a free form SNMP community string.
+ok( $per_bmc->{$_},  "$_ takes one value per BMC" )      for qw(ip netmask gateway);
+ok( !$per_bmc->{$_}, "$_ keeps its argument whole" )     for qw(community snmpdest alert garp thermprofile);
+
+like( $source, qr/if \(\$per_bmc_subcommand\{\$subcommand\} and \$argument =~ \/,\/\)/,
+    'the caller splits only the settings that take a list' );
+
+# The follow-up callbacks read the subcommand again, so the session has to hold
+# the value of its own BMC by then.
+like( $source, qr/\$sessdata->\{subcommand\} = "\$subcommand=\$argument";/,
+    'the session keeps the value of its own BMC for the follow-up' );
+
+# The caller reports the mismatch rather than sending an empty setting, and
+# the thermal profile keeps its own argument.
+like( $source,
+    qr/unless \(defined \$bmcvalue\) \{\s*\n\s*\$callback->\(\{ errorcode => \[1\], error => \["The value \$argument does not carry a setting for BMC/,
+    'the caller reports a short list instead of sending it' );
+like( $source, qr/if \(\$subcommand eq "thermprofile"\) \{\n\s*return idpxthermprofile\(\$argument\);/,
+    'the thermal profile is answered before the per BMC split' );
+
+done_testing();

--- a/xCAT-test/unit/rspconfig_per_bmc_argument.t
+++ b/xCAT-test/unit/rspconfig_per_bmc_argument.t
@@ -5,48 +5,14 @@ use warnings;
 use FindBin;
 use File::Spec;
 use Test::More;
-
-my $root = File::Spec->catdir( $FindBin::Bin, '..', '..' );
-my $plugin = File::Spec->catfile( $root,
-    'xCAT-server', 'lib', 'xcat', 'plugins', 'ipmi.pm' );
-plan skip_all => 'ipmi.pm not found' unless -r $plugin;
-
-my $lib = File::Spec->catdir( $root, 'xCAT-server', 'lib', 'perl' );
-my $module = File::Spec->catfile( $lib, 'xCAT', 'BMCUtils.pm' );
-my $direct_module = -r $module;
-my ( $source, $per_bmc );
-
-if ($direct_module) {
-    unshift @INC, $lib;
-    require xCAT::BMCUtils;
-} else {
-    open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
-    $source = do { local $/; <$fh> };
-    close($fh);
-
-    my ($routine) = $source =~ /(sub per_bmc_argument \{.*?\n\}\n)/s;
-    my ($gate)    = $source =~ /(my %per_bmc_subcommand = map.*?;)/s;
-    BAIL_OUT('could not extract per_bmc_argument from ipmi.pm') unless $routine;
-    BAIL_OUT('could not extract the per BMC subcommand set from ipmi.pm') unless $gate;
-    eval "package BmcArg; $gate $routine sub gate { return \\%per_bmc_subcommand } 1;"
-      or BAIL_OUT("could not evaluate per_bmc_argument: $@");
-    $per_bmc = BmcArg::gate();
-}
+use lib File::Spec->catdir( $FindBin::Bin, '..', '..',
+    'xCAT-server', 'lib', 'perl' );
+use xCAT::BMCUtils;
 
 sub setting {
     my ( $subcommand, $argument, $bmcnum ) = @_;
-    if ($direct_module) {
-        return xCAT::BMCUtils::rspconfig_bmc_setting(
-            $subcommand, $argument, $bmcnum );
-    }
-    return { argument => $argument }
-      unless $per_bmc->{$subcommand} and defined $argument and $argument =~ /,/;
-    my $value = BmcArg::per_bmc_argument( $argument, $bmcnum );
-    return { error => 1 } unless defined $value;
-    return {
-        argument           => $value,
-        session_subcommand => "$subcommand=$value",
-    };
+    return xCAT::BMCUtils::rspconfig_bmc_setting(
+        $subcommand, $argument, $bmcnum );
 }
 
 sub pick {
@@ -54,12 +20,10 @@ sub pick {
     return setting( 'ip', $argument, $bmcnum )->{argument};
 }
 
-if ($direct_module) {
-    $per_bmc = {};
-    foreach my $subcommand (qw(ip netmask gateway community snmpdest alert garp thermprofile)) {
-        my $selection = setting( $subcommand, 'first,second', 1 );
-        $per_bmc->{$subcommand} = exists $selection->{session_subcommand};
-    }
+my $per_bmc = {};
+foreach my $subcommand (qw(ip netmask gateway community snmpdest alert garp thermprofile)) {
+    my $selection = setting( $subcommand, 'first,second', 1 );
+    $per_bmc->{$subcommand} = exists $selection->{session_subcommand};
 }
 
 # A single value reaches every BMC, which is what a node with one BMC needs
@@ -95,20 +59,19 @@ is( pick( '255.255.255.0,255.255.254.0', 2 ), '255.255.254.0', 'a netmask list f
 ok( $per_bmc->{$_},  "$_ takes one value per BMC" )      for qw(ip netmask gateway);
 ok( !$per_bmc->{$_}, "$_ keeps its argument whole" )     for qw(community snmpdest alert garp thermprofile);
 
-unless ($direct_module) {
-    like( $source, qr/if \(\$per_bmc_subcommand\{\$subcommand\} and \$argument =~ \/,\/\)/,
-        'the caller splits only the settings that take a list' );
+my $selected = setting( 'ip', '10.0.0.5,10.0.0.6', 2 );
+is( $selected->{session_subcommand}, 'ip=10.0.0.6',
+    'the follow-up subcommand holds the value of its own BMC' );
+ok( !exists $selected->{error}, 'a complete list reports no mismatch' );
 
-    # The follow-up callbacks read the subcommand again, so the session has to
-    # hold the value of its own BMC by then.
-    like( $source, qr/\$sessdata->\{subcommand\} = "\$subcommand=\$argument";/,
-        'the session keeps the value of its own BMC for the follow-up' );
+my $short = setting( 'gateway', '10.0.0.1,10.0.0.2', 3 );
+like( $short->{error}, qr/does not carry a setting for BMC 3/,
+    'a short list reports which BMC has no setting' );
 
-    like( $source,
-        qr/unless \(defined \$bmcvalue\) \{\s*\n\s*\$callback->\(\{ errorcode => \[1\], error => \["The value \$argument does not carry a setting for BMC/,
-        'the caller reports a short list instead of sending it' );
-    like( $source, qr/if \(\$subcommand eq "thermprofile"\) \{\n\s*return idpxthermprofile\(\$argument\);/,
-        'the thermal profile is answered before the per BMC split' );
-}
+my $thermal = setting( 'thermprofile', 'balanced,maximum', 2 );
+is( $thermal->{argument}, 'balanced,maximum',
+    'the thermal profile keeps its argument whole' );
+ok( !exists $thermal->{session_subcommand},
+    'the thermal profile does not rewrite the session' );
 
 done_testing();


### PR DESCRIPTION
A node can carry more than one BMC, and rspconfig already opens a session per BMC. A setting such as `ip=` carried a single value, so every BMC received the same one. Two BMCs cannot share an address, so such a node could not be configured through rspconfig at all.

A comma separated value now gives one setting per BMC, in the order the sessions are numbered. Only `ip`, `netmask` and `gateway` read a list, because a comma belongs to the value itself in a free form SNMP community string. A value without a comma still reaches every BMC, so existing use is unchanged. An entry that is missing or empty reports the mismatch instead of reaching the address encoders.

Recovered from the lenovobuild branch.