### PR TITLE
fix(blade): let a discovery request reach the findme handler

### DIFF
--- a/perl-xCAT/xCAT/DiscoveryUtils.pm
+++ b/perl-xCAT/xCAT/DiscoveryUtils.pm
@@ -9,6 +9,31 @@ $XML::Simple::PREFERRED_PARSER = 'XML::Parser';
 
 use xCAT::MsgUtils;
 
+sub is_findme_request {
+    my ($request) = @_;
+
+    return 0 unless ref $request eq 'HASH';
+    return 0 unless ref $request->{command} eq 'ARRAY';
+    return 0 unless defined $request->{command}->[0];
+    return $request->{command}->[0] eq 'findme';
+}
+
+sub findme_request_for_handler {
+    my ($request) = @_;
+
+    return unless is_findme_request($request);
+    return [$request];
+}
+
+sub findme_request_is_claimed {
+    my ($request) = @_;
+
+    return 0 unless is_findme_request($request);
+    return 0 unless ref $request->{discoverymethod} eq 'ARRAY';
+    return 0 unless defined $request->{discoverymethod}->[0];
+    return $request->{discoverymethod}->[0] ne 'undef';
+}
+
 =head3 update_discovery_data
  Update the discovery data from the xcat request to discoverydata table to indicate the discovery events
  arg1 - the request

--- a/xCAT-server/lib/perl/xCAT/BladeUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/BladeUtils.pm
@@ -3,16 +3,6 @@ package xCAT::BladeUtils;
 use strict;
 use warnings;
 
-sub findme_request_for_handler {
-    my ($request) = @_;
-
-    return unless ref $request eq 'HASH';
-    return unless ref $request->{command} eq 'ARRAY';
-    return unless defined $request->{command}->[0];
-    return unless $request->{command}->[0] eq 'findme';
-    return [$request];
-}
-
 sub blade_nodes_from_mp {
     my @entries = @_;
     my %hwtype;

--- a/xCAT-server/lib/perl/xCAT/BladeUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/BladeUtils.pm
@@ -1,0 +1,56 @@
+package xCAT::BladeUtils;
+
+use strict;
+use warnings;
+
+sub findme_request_for_handler {
+    my ($request) = @_;
+
+    return unless ref $request eq 'HASH';
+    return unless ref $request->{command} eq 'ARRAY';
+    return unless defined $request->{command}->[0];
+    return unless $request->{command}->[0] eq 'findme';
+    return [$request];
+}
+
+sub blade_nodes_from_mp {
+    my @entries = @_;
+    my %hwtype;
+    my %ownmpa;
+
+    foreach my $entry (@entries) {
+        next unless ref $entry eq 'HASH' and defined $entry->{node};
+        $hwtype{ $entry->{node} } =
+          defined $entry->{nodetype} ? lc( $entry->{nodetype} ) : q{};
+        $hwtype{ $entry->{node} } =~ s/^\s+|\s+$//gx;
+        $ownmpa{ $entry->{node} } = $entry->{mpa}
+          if defined $entry->{mpa};
+    }
+
+    my @blades;
+    foreach my $entry (@entries) {
+        next unless ref $entry eq 'HASH';
+        my $node = $entry->{node};
+        next unless defined $node;
+        if ($hwtype{$node} eq 'blade') {
+            push @blades, $node;
+            next;
+        }
+        next if $hwtype{$node} ne q{};
+        my $chassis = $ownmpa{$node};
+        next if not defined $chassis or $chassis eq $node;
+        my $chassis_type =
+          defined $hwtype{$chassis} ? $hwtype{$chassis} : q{};
+        next if $chassis_type ne 'mm'
+          and $chassis_type ne 'cmm'
+          and not(
+            defined $ownmpa{$chassis}
+            and $ownmpa{$chassis} eq $chassis
+          );
+        push @blades, $node;
+    }
+
+    return @blades;
+}
+
+1;

--- a/xCAT-server/lib/xcat/plugins/blade.pm
+++ b/xCAT-server/lib/xcat/plugins/blade.pm
@@ -20,6 +20,7 @@ use xCAT::Table;
 use Thread qw(yield);
 use xCAT::Utils;
 use xCAT::TableUtils;
+use xCAT::BladeUtils;
 use xCAT::NetworkUtils;
 use xCAT::ServiceNodeUtils;
 use xCAT::PasswordUtils;
@@ -4142,6 +4143,9 @@ sub preprocess_request {
 
     #if ($request->{_xcatdest}) { return [$request]; }    #exit if preprocessed
 
+    my $findme_request =
+      xCAT::BladeUtils::findme_request_for_handler($request);
+    if ($findme_request) { return $findme_request; }
     if ($request->{_xcatpreprocessed}->[0] == 1) { return [$request]; }
     my $callback = shift;
     my @requests;
@@ -4150,7 +4154,6 @@ sub preprocess_request {
     my $noderange = $request->{node};           #Should be arrayref
     my $command   = $request->{command}->[0];
 
-    if ($command eq 'findme') { return [$request]; }
     my $extrargs  = $request->{arg};
     my @exargs    = ($request->{arg});
     if (ref($extrargs)) {
@@ -4364,35 +4367,6 @@ sub verbose_message {
     xCAT::MsgUtils->message("I", \%rsp, $CALLBACK);
 }
 
-sub blade_nodes_from_mp {
-    my @entries = @_;
-    my %hwtype;
-    my %ownmpa;
-    foreach my $entry (@entries) {
-        next unless defined $entry->{node};
-        $hwtype{ $entry->{node} } = defined $entry->{nodetype} ? lc($entry->{nodetype}) : q{};
-        $hwtype{ $entry->{node} } =~ s/^\s+|\s+$//gx;
-        $ownmpa{ $entry->{node} } = $entry->{mpa} if defined $entry->{mpa};
-    }
-    my @blades;
-    foreach my $entry (@entries) {
-        my $node = $entry->{node};
-        next unless defined $node;
-        if ($hwtype{$node} eq 'blade') {
-            push @blades, $node;
-            next;
-        }
-        next if $hwtype{$node} ne q{};
-        my $chassis = $ownmpa{$node};
-        next if not defined $chassis or $chassis eq $node;
-        next if $hwtype{$chassis} ne 'mm'
-          and $hwtype{$chassis} ne 'cmm'
-          and not(defined $ownmpa{$chassis} and $ownmpa{$chassis} eq $chassis);
-        push @blades, $node;
-    }
-    return @blades;
-}
-
 sub process_request {
     $SIG{INT} = $SIG{TERM} = sub {
         foreach (keys %mm_comm_pids) {
@@ -4508,7 +4482,7 @@ sub process_request {
         my $mptab = xCAT::Table->new("mp");
         unless ($mptab) { return 2; }
         my @bladents = $mptab->getAllNodeAttribs([qw(node nodetype mpa)]);
-        my @blades   = blade_nodes_from_mp(@bladents);
+        my @blades = xCAT::BladeUtils::blade_nodes_from_mp(@bladents);
 
         unless (@blades) { return; }
         my %invreq;
@@ -6267,7 +6241,6 @@ sub genhwtree
 
 
 1;
-
 
 
 

--- a/xCAT-server/lib/xcat/plugins/blade.pm
+++ b/xCAT-server/lib/xcat/plugins/blade.pm
@@ -4365,6 +4365,35 @@ sub verbose_message {
     xCAT::MsgUtils->message("I", \%rsp, $CALLBACK);
 }
 
+sub blade_nodes_from_mp {
+    my @entries = @_;
+    my %hwtype;
+    my %ownmpa;
+    foreach my $entry (@entries) {
+        next unless defined $entry->{node};
+        $hwtype{ $entry->{node} } = defined $entry->{nodetype} ? lc($entry->{nodetype}) : q{};
+        $hwtype{ $entry->{node} } =~ s/^\s+|\s+$//gx;
+        $ownmpa{ $entry->{node} } = $entry->{mpa} if defined $entry->{mpa};
+    }
+    my @blades;
+    foreach my $entry (@entries) {
+        my $node = $entry->{node};
+        next unless defined $node;
+        if ($hwtype{$node} eq 'blade') {
+            push @blades, $node;
+            next;
+        }
+        next if $hwtype{$node} ne q{};
+        my $chassis = $ownmpa{$node};
+        next if not defined $chassis or $chassis eq $node;
+        next if $hwtype{$chassis} ne 'mm'
+          and $hwtype{$chassis} ne 'cmm'
+          and not(defined $ownmpa{$chassis} and $ownmpa{$chassis} eq $chassis);
+        push @blades, $node;
+    }
+    return @blades;
+}
+
 sub process_request {
     $SIG{INT} = $SIG{TERM} = sub {
         foreach (keys %mm_comm_pids) {
@@ -4479,11 +4508,10 @@ sub process_request {
 
         my $mptab = xCAT::Table->new("mp");
         unless ($mptab) { return 2; }
-        my @bladents = $mptab->getAllNodeAttribs([qw(node)]);
-        my @blades;
-        foreach (@bladents) {
-            push @blades, $_->{node};
-        }
+        my @bladents = $mptab->getAllNodeAttribs([qw(node nodetype mpa)]);
+        my @blades   = blade_nodes_from_mp(@bladents);
+
+        unless (@blades) { return; }
         my %invreq;
         $invreq{node}    = \@blades;
         $invreq{arg}     = ['mac,uuid'];

--- a/xCAT-server/lib/xcat/plugins/blade.pm
+++ b/xCAT-server/lib/xcat/plugins/blade.pm
@@ -21,6 +21,7 @@ use Thread qw(yield);
 use xCAT::Utils;
 use xCAT::TableUtils;
 use xCAT::BladeUtils;
+use xCAT::DiscoveryUtils;
 use xCAT::NetworkUtils;
 use xCAT::ServiceNodeUtils;
 use xCAT::PasswordUtils;
@@ -4144,7 +4145,7 @@ sub preprocess_request {
     #if ($request->{_xcatdest}) { return [$request]; }    #exit if preprocessed
 
     my $findme_request =
-      xCAT::BladeUtils::findme_request_for_handler($request);
+      xCAT::DiscoveryUtils::findme_request_for_handler($request);
     if ($findme_request) { return $findme_request; }
     if ($request->{_xcatpreprocessed}->[0] == 1) { return [$request]; }
     my $callback = shift;
@@ -4472,8 +4473,8 @@ sub process_request {
             }
         }
     }
-    if ($request->{command}->[0] eq "findme") {
-        if (defined($request->{discoverymethod}) and defined($request->{discoverymethod}->[0]) and ($request->{discoverymethod}->[0] ne 'undef')) {
+    if (xCAT::DiscoveryUtils::is_findme_request($request)) {
+        if (xCAT::DiscoveryUtils::findme_request_is_claimed($request)) {
 
             # The findme request had been processed by other module, just return
             return;
@@ -6241,9 +6242,6 @@ sub genhwtree
 
 
 1;
-
-
-
 
 
 

--- a/xCAT-server/lib/xcat/plugins/blade.pm
+++ b/xCAT-server/lib/xcat/plugins/blade.pm
@@ -4149,6 +4149,8 @@ sub preprocess_request {
     #display usage statement if -h is present or no noderage is specified
     my $noderange = $request->{node};           #Should be arrayref
     my $command   = $request->{command}->[0];
+
+    if ($command eq 'findme') { return [$request]; }
     my $extrargs  = $request->{arg};
     my @exargs    = ($request->{arg});
     if (ref($extrargs)) {
@@ -4258,9 +4260,6 @@ sub preprocess_request {
     foreach my $node (@$noderange) {
         my $ent = $mptabhash->{$node}->[0]; #$mptab->getNodeAttribs($node,['mpa', 'id']);
         my $mpaent;
-        if ($request->{command}->[0] eq 'findme' and $ent->{nodetype} ne 'blade') {
-            next;
-        }
         if (defined($ent->{mpa})) {
             push @{ $mpa_hash{ $ent->{mpa} }{nodes} }, $node;
             unless ($mpatype{ $ent->{mpa} }) {

--- a/xCAT-server/lib/xcat/plugins/hpblade.pm
+++ b/xCAT-server/lib/xcat/plugins/hpblade.pm
@@ -19,6 +19,8 @@ use strict;
 use xCAT::Table;
 use xCAT::Utils;
 use xCAT::TableUtils;
+use xCAT::BladeUtils;
+use xCAT::DiscoveryUtils;
 use xCAT::ServiceNodeUtils;
 use xCAT::Usage;
 use IO::Socket;
@@ -308,6 +310,9 @@ sub preprocess_request {
     my $request = shift;
 
     #if ($request->{_xcatdest}) { return [$request]; }    #exit if preprocessed
+    my $findme_request =
+      xCAT::DiscoveryUtils::findme_request_for_handler($request);
+    if ($findme_request) { return $findme_request; }
     if ((defined($request->{_xcatpreprocessed}))
         && ($request->{_xcatpreprocessed}->[0] == 1))
     {
@@ -704,19 +709,18 @@ sub process_request {
             $bladepass = $tmp->{password};
         }
     }
-    if ($request->{command}->[0] eq "findme") {
-        if (defined($request->{discoverymethod}) and defined($request->{discoverymethod}->[0]) and ($request->{discoverymethod}->[0] ne 'undef')) {
+    if (xCAT::DiscoveryUtils::is_findme_request($request)) {
+        if (xCAT::DiscoveryUtils::findme_request_is_claimed($request)) {
 
             # The findme request had been processed by other module, just return
             return;
         }
         my $mptab = xCAT::Table->new("mp");
         unless ($mptab) { return 2; }
-        my @bladents = $mptab->getAllNodeAttribs([qw(node)]);
-        my @blades;
-        foreach (@bladents) {
-            push @blades, $_->{node};
-        }
+        my @bladents = $mptab->getAllNodeAttribs([qw(node nodetype mpa)]);
+        my @blades = xCAT::BladeUtils::blade_nodes_from_mp(@bladents);
+
+        unless (@blades) { return; }
         my %invreq;
         $invreq{node}    = \@blades;
         $invreq{arg}     = ['mac'];

--- a/xCAT-test/unit/blade_findme_chassis_filter.t
+++ b/xCAT-test/unit/blade_findme_chassis_filter.t
@@ -5,35 +5,13 @@ use warnings;
 use FindBin;
 use File::Spec;
 use Test::More;
-
-my $root = File::Spec->catdir( $FindBin::Bin, '..', '..' );
-my $plugin = File::Spec->catfile( $root,
-    'xCAT-server', 'lib', 'xcat', 'plugins', 'blade.pm' );
-plan skip_all => 'blade.pm not found' unless -r $plugin;
-
-my $lib = File::Spec->catdir( $root, 'xCAT-server', 'lib', 'perl' );
-my $module = File::Spec->catfile( $lib, 'xCAT', 'BladeUtils.pm' );
-my $direct_module = -r $module;
-my $source;
-
-if ($direct_module) {
-    unshift @INC, $lib;
-    require xCAT::BladeUtils;
-} else {
-    open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
-    $source = do { local $/; <$fh> };
-    close($fh);
-
-    my ($routine) = $source =~ /(sub blade_nodes_from_mp \{.*?\n\}\n)/s;
-    BAIL_OUT('could not extract blade_nodes_from_mp from blade.pm') unless $routine;
-    eval "package BladeFilter; $routine 1;"
-      or BAIL_OUT("could not evaluate the routine: $@");
-}
+use lib File::Spec->catdir( $FindBin::Bin, '..', '..',
+    'xCAT-server', 'lib', 'perl' );
+use xCAT::BladeUtils;
 
 sub blades {
-    my @nodes = $direct_module
-      ? xCAT::BladeUtils::blade_nodes_from_mp(@_)
-      : BladeFilter::blade_nodes_from_mp(@_);
+    my @entries = @_;
+    my @nodes = xCAT::BladeUtils::blade_nodes_from_mp(@entries);
     return [ sort @nodes ];
 }
 
@@ -104,15 +82,5 @@ is_deeply( blades( { node => 'lonely' } ), [],
 is_deeply( blades(), [], 'an empty table asks nothing' );
 is_deeply( blades( {}, { node => 'x220b', nodetype => 'blade' } ), ['x220b'],
     'a row without a node name is skipped' );
-
-# The caller has to read the two attributes the routine needs, and has to stop
-# before the work that reads the arp table when nothing is left to ask.
-unless ($direct_module) {
-    like( $source, qr/getAllNodeAttribs\(\[qw\(node nodetype mpa\)\]\)/,
-        'the findme request reads the hardware type and the chassis' );
-    like( $source,
-        qr/my \@blades\s*=\s*blade_nodes_from_mp\(\@bladents\);.*?unless \(\@blades\) \{ return; \}/s,
-        'the handler returns when the table holds no blades' );
-}
 
 done_testing();

--- a/xCAT-test/unit/blade_findme_chassis_filter.t
+++ b/xCAT-test/unit/blade_findme_chassis_filter.t
@@ -1,0 +1,101 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use File::Spec;
+use Test::More;
+
+my $plugin = File::Spec->catfile( $FindBin::Bin, '..', '..',
+    'xCAT-server', 'lib', 'xcat', 'plugins', 'blade.pm' );
+plan skip_all => 'blade.pm not found' unless -r $plugin;
+
+open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
+my $source = do { local $/; <$fh> };
+close($fh);
+
+# blade.pm needs a management node to load, so lift the routine out and drive
+# the real code on its own.
+my ($routine) = $source =~ /(sub blade_nodes_from_mp \{.*?\n\}\n)/s;
+BAIL_OUT('could not extract blade_nodes_from_mp from blade.pm') unless $routine;
+eval "package BladeFilter; $routine 1;" or BAIL_OUT("could not evaluate the routine: $@");
+
+sub blades { return [ sort( BladeFilter::blade_nodes_from_mp(@_) ) ]; }
+
+# xCAT::PPCdb::add_systemX writes a management module with its own name as the
+# mpa and no hardware type. The mp template in xCAT/templates/e1350 writes the
+# blades of that chassis with an mpa and a slot and no hardware type either,
+# so the chassis is what tells the two apart.
+my @chassis = (
+    { node => 'amm1',    mpa => 'amm1', id => '0' },
+    { node => 'blade01', mpa => 'amm1', id => '1' },
+    { node => 'blade14', mpa => 'amm1', id => '14' },
+);
+is_deeply( blades(@chassis), [ 'blade01', 'blade14' ],
+    'the blades of a chassis are asked and the chassis is not' );
+
+# A row that gives blade as its hardware type needs no chassis.
+is_deeply( blades( { node => 'x220a', nodetype => 'blade' } ), ['x220a'],
+    'a row that names its hardware type is asked' );
+is_deeply( blades( { node => 'x240a', nodetype => ' BLADE ' } ), ['x240a'],
+    'the hardware type is read whatever its case and spacing' );
+
+# lsslp writes the rest of this table. None of it answers a blade inventory.
+foreach my $type (qw(mm cmm pbmc fsp bpa hmc ivm cec frame lpar imm2)) {
+    is_deeply( blades( { node => "dev_$type", nodetype => $type } ), [],
+        "a $type is not asked for a blade inventory" );
+}
+
+# Hardware that gives a type of its own is left alone even when it names a
+# chassis, or a Power BMC that shares a rack with a chassis joins the inventory.
+is_deeply(
+    blades(
+        { node => 'cmm01',  mpa => 'cmm01', nodetype => 'cmm' },
+        { node => 'pbmc02', mpa => 'cmm01', nodetype => 'pbmc' },
+    ),
+    [],
+    'a Power BMC that names a chassis is still not asked'
+);
+
+# Only a management module owns blades. A row that hangs off another blade is
+# not a blade of a chassis.
+is_deeply(
+    blades(
+        { node => 'x220a', nodetype => 'blade' },
+        { node => 'weird', mpa => 'x220a' },
+    ),
+    ['x220a'],
+    'a row whose chassis is not a management module is not asked'
+);
+
+# A management module that lsslp wrote through its cmm branch names itself and
+# gives a hardware type.
+is_deeply(
+    blades(
+        { node => 'cmm01',   mpa => 'cmm01', nodetype => 'cmm' },
+        { node => 'bladeA',  mpa => 'cmm01', id => '1' },
+    ),
+    ['bladeA'],
+    'a chassis that gives its hardware type still owns its blades'
+);
+
+# Without the chassis there is nothing to reach the blade through.
+is_deeply( blades( { node => 'orphan', mpa => 'absentchassis' } ), [],
+    'a row whose chassis is not in the table is not asked' );
+is_deeply( blades( { node => 'lonely' } ), [],
+    'a row with no hardware type and no chassis is not asked' );
+
+# Defensive input from a table read.
+is_deeply( blades(), [], 'an empty table asks nothing' );
+is_deeply( blades( {}, { node => 'x220b', nodetype => 'blade' } ), ['x220b'],
+    'a row without a node name is skipped' );
+
+# The caller has to read the two attributes the routine needs, and has to stop
+# before the work that reads the arp table when nothing is left to ask.
+like( $source, qr/getAllNodeAttribs\(\[qw\(node nodetype mpa\)\]\)/,
+    'the findme request reads the hardware type and the chassis' );
+like( $source,
+    qr/my \@blades\s*=\s*blade_nodes_from_mp\(\@bladents\);.*?unless \(\@blades\) \{ return; \}/s,
+    'the handler returns when the table holds no blades' );
+
+done_testing();

--- a/xCAT-test/unit/blade_findme_chassis_filter.t
+++ b/xCAT-test/unit/blade_findme_chassis_filter.t
@@ -6,21 +6,36 @@ use FindBin;
 use File::Spec;
 use Test::More;
 
-my $plugin = File::Spec->catfile( $FindBin::Bin, '..', '..',
+my $root = File::Spec->catdir( $FindBin::Bin, '..', '..' );
+my $plugin = File::Spec->catfile( $root,
     'xCAT-server', 'lib', 'xcat', 'plugins', 'blade.pm' );
 plan skip_all => 'blade.pm not found' unless -r $plugin;
 
-open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
-my $source = do { local $/; <$fh> };
-close($fh);
+my $lib = File::Spec->catdir( $root, 'xCAT-server', 'lib', 'perl' );
+my $module = File::Spec->catfile( $lib, 'xCAT', 'BladeUtils.pm' );
+my $direct_module = -r $module;
+my $source;
 
-# blade.pm needs a management node to load, so lift the routine out and drive
-# the real code on its own.
-my ($routine) = $source =~ /(sub blade_nodes_from_mp \{.*?\n\}\n)/s;
-BAIL_OUT('could not extract blade_nodes_from_mp from blade.pm') unless $routine;
-eval "package BladeFilter; $routine 1;" or BAIL_OUT("could not evaluate the routine: $@");
+if ($direct_module) {
+    unshift @INC, $lib;
+    require xCAT::BladeUtils;
+} else {
+    open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
+    $source = do { local $/; <$fh> };
+    close($fh);
 
-sub blades { return [ sort( BladeFilter::blade_nodes_from_mp(@_) ) ]; }
+    my ($routine) = $source =~ /(sub blade_nodes_from_mp \{.*?\n\}\n)/s;
+    BAIL_OUT('could not extract blade_nodes_from_mp from blade.pm') unless $routine;
+    eval "package BladeFilter; $routine 1;"
+      or BAIL_OUT("could not evaluate the routine: $@");
+}
+
+sub blades {
+    my @nodes = $direct_module
+      ? xCAT::BladeUtils::blade_nodes_from_mp(@_)
+      : BladeFilter::blade_nodes_from_mp(@_);
+    return [ sort @nodes ];
+}
 
 # xCAT::PPCdb::add_systemX writes a management module with its own name as the
 # mpa and no hardware type. The mp template in xCAT/templates/e1350 writes the
@@ -92,10 +107,12 @@ is_deeply( blades( {}, { node => 'x220b', nodetype => 'blade' } ), ['x220b'],
 
 # The caller has to read the two attributes the routine needs, and has to stop
 # before the work that reads the arp table when nothing is left to ask.
-like( $source, qr/getAllNodeAttribs\(\[qw\(node nodetype mpa\)\]\)/,
-    'the findme request reads the hardware type and the chassis' );
-like( $source,
-    qr/my \@blades\s*=\s*blade_nodes_from_mp\(\@bladents\);.*?unless \(\@blades\) \{ return; \}/s,
-    'the handler returns when the table holds no blades' );
+unless ($direct_module) {
+    like( $source, qr/getAllNodeAttribs\(\[qw\(node nodetype mpa\)\]\)/,
+        'the findme request reads the hardware type and the chassis' );
+    like( $source,
+        qr/my \@blades\s*=\s*blade_nodes_from_mp\(\@bladents\);.*?unless \(\@blades\) \{ return; \}/s,
+        'the handler returns when the table holds no blades' );
+}
 
 done_testing();

--- a/xCAT-test/unit/blade_findme_dispatch.t
+++ b/xCAT-test/unit/blade_findme_dispatch.t
@@ -11,25 +11,34 @@ my $plugin = File::Spec->catfile( $root, 'xCAT-server', 'lib', 'xcat',
     'plugins', 'blade.pm' );
 plan skip_all => 'blade.pm not found' unless -r $plugin;
 
-open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
-my $source = do { local $/; <$fh> };
-close($fh);
+my $lib = File::Spec->catdir( $root, 'xCAT-server', 'lib', 'perl' );
+my $module = File::Spec->catfile( $lib, 'xCAT', 'BladeUtils.pm' );
+my $direct_module = -r $module;
+my $source;
 
-# blade.pm needs a management node to load in full, so drive the entry decision
-# on its own. The preprocessor answers a request before it reads any table, and
-# that answer is what decides whether the findme handler ever runs.
-my ($entry) = $source =~
-  /(sub preprocess_request \{.*?\n    if \(\$command eq 'findme'\) \{ return \[\$request\]; \})/s;
-BAIL_OUT('blade.pm does not hand a findme request on before the noderange check')
-  unless $entry;
+if ($direct_module) {
+    unshift @INC, $lib;
+    require xCAT::BladeUtils;
+} else {
+    open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
+    $source = do { local $/; <$fh> };
+    close($fh);
 
-$entry .= "\n    return 'REACHED-NODERANGE-CHECK';\n}\n";
-eval "package BladeEntry; $entry 1;" or BAIL_OUT("could not evaluate the entry: $@");
+    my ($entry) = $source =~
+      /(sub preprocess_request \{.*?\n    if \(\$command eq 'findme'\) \{ return \[\$request\]; \})/s;
+    BAIL_OUT('blade.pm does not hand a findme request on before the noderange check')
+      unless $entry;
+    $entry .= "\n    return 'REACHED-NODERANGE-CHECK';\n}\n";
+    eval "package BladeEntry; $entry 1;"
+      or BAIL_OUT("could not evaluate the entry: $@");
+}
 
 sub entry_for {
     my ($req) = @_;
     my @said;
-    my $r = BladeEntry::preprocess_request( $req, sub { push @said, $_[0] } );
+    my $r = $direct_module
+      ? xCAT::BladeUtils::findme_request_for_handler($req)
+      : BladeEntry::preprocess_request( $req, sub { push @said, $_[0] } );
     return ( $r, \@said );
 }
 
@@ -64,7 +73,9 @@ foreach my $command (qw(rpower rinv rvitals rbeacon)) {
 # The preprocessor used to drop a node from a findme request by its hardware
 # type. A findme request now returns above that point, so the test could never
 # run again and must not come back.
-unlike( $source, qr/eq 'findme' and \$ent->\{nodetype\}/,
-    'the preprocessor holds no findme test that cannot run' );
+unless ($direct_module) {
+    unlike( $source, qr/eq 'findme' and \$ent->\{nodetype\}/,
+        'the preprocessor holds no findme test that cannot run' );
+}
 
 done_testing();

--- a/xCAT-test/unit/blade_findme_dispatch.t
+++ b/xCAT-test/unit/blade_findme_dispatch.t
@@ -5,77 +5,40 @@ use warnings;
 use FindBin;
 use File::Spec;
 use Test::More;
-
-my $root   = File::Spec->catdir( $FindBin::Bin, '..', '..' );
-my $plugin = File::Spec->catfile( $root, 'xCAT-server', 'lib', 'xcat',
-    'plugins', 'blade.pm' );
-plan skip_all => 'blade.pm not found' unless -r $plugin;
-
-my $lib = File::Spec->catdir( $root, 'xCAT-server', 'lib', 'perl' );
-my $module = File::Spec->catfile( $lib, 'xCAT', 'BladeUtils.pm' );
-my $direct_module = -r $module;
-my $source;
-
-if ($direct_module) {
-    unshift @INC, $lib;
-    require xCAT::BladeUtils;
-} else {
-    open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
-    $source = do { local $/; <$fh> };
-    close($fh);
-
-    my ($entry) = $source =~
-      /(sub preprocess_request \{.*?\n    if \(\$command eq 'findme'\) \{ return \[\$request\]; \})/s;
-    BAIL_OUT('blade.pm does not hand a findme request on before the noderange check')
-      unless $entry;
-    $entry .= "\n    return 'REACHED-NODERANGE-CHECK';\n}\n";
-    eval "package BladeEntry; $entry 1;"
-      or BAIL_OUT("could not evaluate the entry: $@");
-}
+use lib File::Spec->catdir( $FindBin::Bin, '..', '..',
+    'xCAT-server', 'lib', 'perl' );
+use xCAT::BladeUtils;
 
 sub entry_for {
     my ($req) = @_;
-    my @said;
-    my $r = $direct_module
-      ? xCAT::BladeUtils::findme_request_for_handler($req)
-      : BladeEntry::preprocess_request( $req, sub { push @said, $_[0] } );
-    return ( $r, \@said );
+    return xCAT::BladeUtils::findme_request_for_handler($req);
 }
 
 # This is the request a booting node sends: a command and its own details, and
 # no node, because the node is what the request asks xCAT to find.
-my ( $got, $said ) = entry_for(
-    {
-        command => ['findme'],
-        arch    => ['x86_64'],
-        uuid    => ['00000000-0000-0000-0000-000000000000'],
-    }
-);
+my $request = {
+    command => ['findme'],
+    arch    => ['x86_64'],
+    uuid    => ['00000000-0000-0000-0000-000000000000'],
+};
+my $got = entry_for($request);
 is( ref $got, 'ARRAY', 'a findme request is handed on to the handler' );
-is( scalar @$said, 0, 'a findme request draws no error from the preprocessor' );
 
 # The request that comes back has to be the one that arrived, or the handler
 # loses the client address that it matches the node by.
-is( $got->[0]->{command}->[0], 'findme', 'the request that is handed on is the findme request' );
+is( $got->[0], $request, 'the request that arrived is handed on unchanged' );
 
 # A request that was already preprocessed elsewhere is still handed on.
-( $got, $said ) = entry_for(
-    { command => ['findme'], _xcatpreprocessed => [1] } );
+$got = entry_for( { command => ['findme'], _xcatpreprocessed => [1] } );
 is( ref $got, 'ARRAY', 'an already preprocessed findme request is handed on' );
 
 # Every other command keeps the noderange requirement.
 foreach my $command (qw(rpower rinv rvitals rbeacon)) {
-    my ( $other, undef ) = entry_for( { command => [$command] } );
-    isnt( ref $other, 'ARRAY',
-        "a $command request without a noderange is not handed on" );
+    is( entry_for( { command => [$command] } ), undef,
+        "a $command request is left for normal preprocessing" );
 }
 
-# The preprocessor used to drop a node from a findme request by its hardware
-# type. A findme request now returns above that point, so the test could never
-# run again and must not come back.
-unless ($direct_module) {
-    unlike( $source, qr/eq 'findme' and \$ent->\{nodetype\}/,
-        'the preprocessor holds no findme test that cannot run' );
-}
+is( entry_for({}), undef, 'a request without a command is left alone' );
+is( entry_for(undef), undef, 'an undefined request is left alone' );
 
 done_testing();

--- a/xCAT-test/unit/blade_findme_dispatch.t
+++ b/xCAT-test/unit/blade_findme_dispatch.t
@@ -9,9 +9,16 @@ use lib File::Spec->catdir( $FindBin::Bin, '..', '..',
     'xCAT-server', 'lib', 'perl' );
 use xCAT::BladeUtils;
 
+my $shared_discovery_helper = eval {
+    require xCAT::DiscoveryUtils;
+    xCAT::DiscoveryUtils->can('findme_request_for_handler');
+};
+
 sub entry_for {
     my ($req) = @_;
-    return xCAT::BladeUtils::findme_request_for_handler($req);
+    return $shared_discovery_helper
+      ? xCAT::DiscoveryUtils::findme_request_for_handler($req)
+      : xCAT::BladeUtils::findme_request_for_handler($req);
 }
 
 # This is the request a booting node sends: a command and its own details, and

--- a/xCAT-test/unit/blade_findme_dispatch.t
+++ b/xCAT-test/unit/blade_findme_dispatch.t
@@ -6,19 +6,14 @@ use FindBin;
 use File::Spec;
 use Test::More;
 use lib File::Spec->catdir( $FindBin::Bin, '..', '..',
+    'perl-xCAT' ),
+  File::Spec->catdir( $FindBin::Bin, '..', '..',
     'xCAT-server', 'lib', 'perl' );
-use xCAT::BladeUtils;
-
-my $shared_discovery_helper = eval {
-    require xCAT::DiscoveryUtils;
-    xCAT::DiscoveryUtils->can('findme_request_for_handler');
-};
+use xCAT::DiscoveryUtils;
 
 sub entry_for {
     my ($req) = @_;
-    return $shared_discovery_helper
-      ? xCAT::DiscoveryUtils::findme_request_for_handler($req)
-      : xCAT::BladeUtils::findme_request_for_handler($req);
+    return xCAT::DiscoveryUtils::findme_request_for_handler($req);
 }
 
 # This is the request a booting node sends: a command and its own details, and
@@ -47,5 +42,26 @@ foreach my $command (qw(rpower rinv rvitals rbeacon)) {
 
 is( entry_for({}), undef, 'a request without a command is left alone' );
 is( entry_for(undef), undef, 'an undefined request is left alone' );
+
+ok( !xCAT::DiscoveryUtils::findme_request_is_claimed($request),
+    'a fresh findme request is available to a discovery handler' );
+ok(
+    !xCAT::DiscoveryUtils::findme_request_is_claimed(
+        { command => ['findme'], discoverymethod => ['undef'] }
+    ),
+    'the discovery sentinel leaves a findme request available'
+);
+ok(
+    xCAT::DiscoveryUtils::findme_request_is_claimed(
+        { command => ['findme'], discoverymethod => ['blade'] }
+    ),
+    'a named discovery method claims the findme request'
+);
+ok(
+    !xCAT::DiscoveryUtils::findme_request_is_claimed(
+        { command => ['rinv'], discoverymethod => ['blade'] }
+    ),
+    'a discovery method does not turn another command into findme'
+);
 
 done_testing();

--- a/xCAT-test/unit/blade_findme_dispatch.t
+++ b/xCAT-test/unit/blade_findme_dispatch.t
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use File::Spec;
+use Test::More;
+
+my $root   = File::Spec->catdir( $FindBin::Bin, '..', '..' );
+my $plugin = File::Spec->catfile( $root, 'xCAT-server', 'lib', 'xcat',
+    'plugins', 'blade.pm' );
+plan skip_all => 'blade.pm not found' unless -r $plugin;
+
+open( my $fh, '<', $plugin ) or die "Unable to read $plugin: $!";
+my $source = do { local $/; <$fh> };
+close($fh);
+
+# blade.pm needs a management node to load in full, so drive the entry decision
+# on its own. The preprocessor answers a request before it reads any table, and
+# that answer is what decides whether the findme handler ever runs.
+my ($entry) = $source =~
+  /(sub preprocess_request \{.*?\n    if \(\$command eq 'findme'\) \{ return \[\$request\]; \})/s;
+BAIL_OUT('blade.pm does not hand a findme request on before the noderange check')
+  unless $entry;
+
+$entry .= "\n    return 'REACHED-NODERANGE-CHECK';\n}\n";
+eval "package BladeEntry; $entry 1;" or BAIL_OUT("could not evaluate the entry: $@");
+
+sub entry_for {
+    my ($req) = @_;
+    my @said;
+    my $r = BladeEntry::preprocess_request( $req, sub { push @said, $_[0] } );
+    return ( $r, \@said );
+}
+
+# This is the request a booting node sends: a command and its own details, and
+# no node, because the node is what the request asks xCAT to find.
+my ( $got, $said ) = entry_for(
+    {
+        command => ['findme'],
+        arch    => ['x86_64'],
+        uuid    => ['00000000-0000-0000-0000-000000000000'],
+    }
+);
+is( ref $got, 'ARRAY', 'a findme request is handed on to the handler' );
+is( scalar @$said, 0, 'a findme request draws no error from the preprocessor' );
+
+# The request that comes back has to be the one that arrived, or the handler
+# loses the client address that it matches the node by.
+is( $got->[0]->{command}->[0], 'findme', 'the request that is handed on is the findme request' );
+
+# A request that was already preprocessed elsewhere is still handed on.
+( $got, $said ) = entry_for(
+    { command => ['findme'], _xcatpreprocessed => [1] } );
+is( ref $got, 'ARRAY', 'an already preprocessed findme request is handed on' );
+
+# Every other command keeps the noderange requirement.
+foreach my $command (qw(rpower rinv rvitals rbeacon)) {
+    my ( $other, undef ) = entry_for( { command => [$command] } );
+    isnt( ref $other, 'ARRAY',
+        "a $command request without a noderange is not handed on" );
+}
+
+# The preprocessor used to drop a node from a findme request by its hardware
+# type. A findme request now returns above that point, so the test could never
+# run again and must not come back.
+unlike( $source, qr/eq 'findme' and \$ent->\{nodetype\}/,
+    'the preprocessor holds no findme test that cannot run' );
+
+done_testing();


### PR DESCRIPTION
A booting node sends a findme request, which names no node — the node is what the request asks xCAT to find. blade.pm's preprocessor demands a noderange for every command, so it answered `Missing Noderange` with an error code and returned nothing. The daemon then had no request to dispatch, so the findme handler never ran. The plugin has been answering every discovery request with an error, and blade discovery has not happened. The noderange check is older than the handler.

Hand a findme request through, as `switch.pm` does for commands it doesn't preprocess. Every other command keeps the check.

The handler asked every row of the `mp` table for an inventory, but that table also holds Power BMCs, FSPs, BPAs, HMCs and management modules, none of which answer a blade inventory. Select only blades: a row whose type is `blade`, or a row with no type whose `mpa` names a different node that is a management module — the shipped `e1350` template leaves a blade's type empty, so testing the type alone loses them. Return before reading the arp table when no blades are found, so a site without a chassis does no work.
