### PR TITLE
fix(genimage): resolve Mellanox drivers from the target kernel

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/install_new_kernel.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/install_new_kernel.rst
@@ -84,9 +84,13 @@ The default driver list: ::
          sels-ppc: tg3 e1000 e1000e igb ibmveth ehea be2net
          sles-ppcle: scsi_mod libata scsi_tgt jbd2 mbcache crc16 virtio virtio_ring libahci crc-t10dif scsi_transport_srp af_packet ext3 ext4 virtio_pci virtio_blk scsi_dh ahci megaraid_sas sd_mod ibmvscsi
 
-The Mellanox entries are conditional. ``genimage`` retains a real ``mlx_en``
-module from the target kernel, otherwise uses ``mlx4_en`` when available, and
-adds ``mlx5_core`` when available. Missing optional Mellanox modules are omitted.
+The automatically added Mellanox entries are conditional. ``genimage`` retains
+a real ``mlx_en`` module from the target kernel, otherwise uses ``mlx4_en`` when
+available, and adds ``mlx5_core`` when available. Available ``mlx4_ib`` and
+``mlx5_ib`` modules are also added. If either InfiniBand driver and ``ib_ipoib``
+are available, ``ib_ipoib`` is added for IP over InfiniBand. Missing optional
+Mellanox modules are omitted. Explicit ``netdrivers`` entries do not enable
+other optional Mellanox defaults.
 
 Note: With this approach, xCAT will search for the drivers in the rootimage. You need to make sure the drivers have been included in the rootimage before generating the initrd. You can install the drivers manually in an existing rootimage (using chroot) and run genimage again, or you can use a postinstall script to install drivers to the rootimage during your initial genimage run.
 

--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/install_new_kernel.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/install_new_kernel.rst
@@ -77,12 +77,16 @@ Generally, the genimage command has a default driver list which will be added to
 
 The default driver list: ::
 
-         rh-x86:   tg3 bnx2 bnx2x e1000 e1000e igb mlx_en virtio_net be2net
+         rh-x86:   tg3 bnx2 bnx2x e1000 e1000e igb mlx_en mlx5_core virtio_net be2net
          rh-ppc:   e1000 e1000e igb ibmveth ehea
          rh-ppcle: ext3 ext4
-         sles-x86: tg3 bnx2 bnx2x e1000 e1000e igb mlx_en be2net
+         sles-x86: tg3 bnx2 bnx2x e1000 e1000e virtio_net virtio_balloon igb mlx4_en mlx5_core be2net
          sels-ppc: tg3 e1000 e1000e igb ibmveth ehea be2net
          sles-ppcle: scsi_mod libata scsi_tgt jbd2 mbcache crc16 virtio virtio_ring libahci crc-t10dif scsi_transport_srp af_packet ext3 ext4 virtio_pci virtio_blk scsi_dh ahci megaraid_sas sd_mod ibmvscsi
+
+The Mellanox entries are conditional. ``genimage`` retains a real ``mlx_en``
+module from the target kernel, otherwise uses ``mlx4_en`` when available, and
+adds ``mlx5_core`` when available. Missing optional Mellanox modules are omitted.
 
 Note: With this approach, xCAT will search for the drivers in the rootimage. You need to make sure the drivers have been included in the rootimage before generating the initrd. You can install the drivers manually in an existing rootimage (using chroot) and run genimage again, or you can use a postinstall script to install drivers to the rootimage during your initial genimage run.
 

--- a/xCAT-genesis-scripts/usr/sbin/loadmlxeth
+++ b/xCAT-genesis-scripts/usr/sbin/loadmlxeth
@@ -1,2 +1,12 @@
 #!/bin/sh
-/sbin/modprobe mlx4_en
+
+load_mellanox_ethernet()
+{
+    xcat_modprobe=$1
+    xcat_mlx_status=1
+    "$xcat_modprobe" mlx4_en && xcat_mlx_status=0
+    "$xcat_modprobe" mlx5_core && xcat_mlx_status=0
+    return "$xcat_mlx_status"
+}
+
+load_mellanox_ethernet "${1:-/sbin/modprobe}"

--- a/xCAT-server/share/xcat/netboot/imgutils/imgutils.pm
+++ b/xCAT-server/share/xcat/netboot/imgutils/imgutils.pm
@@ -301,9 +301,12 @@ sub resolve_mellanox_default_net_drivers {
     my ( $rootimg_dir, $kernelver, $requested_drivers, @default_drivers ) = @_;
     my @drivers;
     my %seen;
-    my $has_mellanox_drivers = grep {
+    my $has_mellanox_defaults = grep {
         _kernel_module_name($_) =~ /^mlx(?:_en|4_en|5_core)$/x
-    } (@{$requested_drivers}, @default_drivers);
+    } @default_drivers;
+    my $has_mellanox_drivers = $has_mellanox_defaults || grep {
+        _kernel_module_name($_) =~ /^mlx(?:_en|4_en|5_core)$/x
+    } @{$requested_drivers};
     if (!$has_mellanox_drivers) {
         return grep { !$seen{$_}++ } (@{$requested_drivers}, @default_drivers);
     }
@@ -311,7 +314,7 @@ sub resolve_mellanox_default_net_drivers {
     my %available = target_kernel_module_availability(
         $rootimg_dir,
         $kernelver,
-        qw(mlx_en mlx4_en mlx5_core),
+        qw(mlx_en mlx4_en mlx5_core mlx4_ib mlx5_ib ib_ipoib),
     );
 
     # Keep unavailable explicit requests, except for the historical mlx4 alias.
@@ -337,6 +340,14 @@ sub resolve_mellanox_default_net_drivers {
             next if !$available{$name};
         }
         push @drivers, $driver;
+    }
+
+    if ($has_mellanox_defaults) {
+        my @mellanox_ib_drivers = grep { $available{$_} } qw(mlx4_ib mlx5_ib);
+        push @drivers, map { "$_.ko" } @mellanox_ib_drivers;
+        if (@mellanox_ib_drivers && $available{'ib_ipoib'}) {
+            push @drivers, 'ib_ipoib.ko';
+        }
     }
 
     return grep { !$seen{$_}++ } @drivers;

--- a/xCAT-server/share/xcat/netboot/imgutils/imgutils.pm
+++ b/xCAT-server/share/xcat/netboot/imgutils/imgutils.pm
@@ -7,6 +7,7 @@ use strict;
 use warnings "all";
 
 use File::Basename;
+use File::Find;
 use File::Path;
 use Cwd qw(realpath);
 use xCAT::SvrUtils;
@@ -209,6 +210,136 @@ sub get_package_names {
         }
     }
     return %pkgnames;
+}
+
+sub default_net_drivers {
+    my ( $family, $arch ) = @_;
+
+    my %drivers = (
+        rh => {
+            x86    => [qw(tg3 bnx2 bnx2x e1000 e1000e igb mlx_en mlx5_core virtio_net be2net)],
+            x86_64 => [qw(tg3 bnx2 bnx2x e1000 e1000e igb mlx_en mlx5_core virtio_net be2net)],
+            aarch64 => [qw(tg3 bnx2 bnx2x e1000e igb mlx_en mlx5_core virtio_net)],
+            ppc64   => [qw(e1000 e1000e igb ibmveth ehea)],
+            s390x   => [qw(qdio ccwgroup)],
+        },
+        sles => {
+            x86    => [qw(tg3 bnx2 bnx2x e1000 e1000e virtio_net virtio_balloon igb mlx4_en mlx5_core be2net)],
+            x86_64 => [qw(tg3 bnx2 bnx2x e1000 e1000e virtio_net virtio_balloon igb mlx4_en mlx5_core be2net)],
+            ppc64   => [qw(tg3 e1000 e1000e igb ibmveth ehea be2net)],
+            s390x   => [qw(qdio ccwgroup qeth qeth_l2 qeth_l3)],
+        },
+        ubuntu => {
+            x86    => [qw(tg3 bnx2 bnx2x e1000 e1000e igb mlx_en mlx5_core virtio_net overlay)],
+            x86_64 => [qw(tg3 bnx2 bnx2x e1000 e1000e igb mlx_en mlx5_core virtio_net overlay)],
+            ppc64el => [qw(tg3 bnx2 bnx2x e1000 e1000e igb ibmveth ehea mlx_en mlx4_en mlx5_core virtio_net overlay)],
+            ppc64   => [qw(e1000 e1000e igb ibmveth ehea)],
+            s390x   => [qw(qdio ccwgroup)],
+        },
+    );
+
+    return () if !exists($drivers{$family}) || !exists($drivers{$family}{$arch});
+    return @{ $drivers{$family}{$arch} };
+}
+
+sub _kernel_module_name {
+    my $path = shift;
+    my $name = basename($path);
+
+    $name =~ s/\.ko(?:\.(?:gz|xz|zst))?$//x;
+    $name =~ tr/-/_/;
+    return $name;
+}
+
+sub target_kernel_module_availability {
+    my ( $rootimg_dir, $kernelver, @modules ) = @_;
+    my %requested = map { _kernel_module_name($_) => 1 } @modules;
+    my %available = map { $_ => 0 } keys %requested;
+    my $module_root = "$rootimg_dir/lib/modules/$kernelver";
+
+    my $modules_dep = "$module_root/modules.dep";
+    if (open(my $dep_fh, '<', $modules_dep)) {
+        while (my $line = <$dep_fh>) {
+            my ($path) = split /:/x, $line, 2;
+            my $name = _kernel_module_name($path);
+            if ($requested{$name} && -f "$module_root/$path") {
+                $available{$name} = 1;
+            }
+        }
+        close($dep_fh);
+    }
+
+    my $modules_builtin = "$module_root/modules.builtin";
+    if (open(my $builtin_fh, '<', $modules_builtin)) {
+        while (my $path = <$builtin_fh>) {
+            chomp($path);
+            my $name = _kernel_module_name($path);
+            $available{$name} = 1 if $requested{$name};
+        }
+        close($builtin_fh);
+    }
+
+    if (-d $module_root && grep { !$available{$_} } keys %requested) {
+        find(
+            {
+                no_chdir => 1,
+                wanted   => sub {
+                    return if !-f $File::Find::name;
+                    return if $File::Find::name !~ /\.ko(?:\.(?:gz|xz|zst))?$/x;
+                    my $name = _kernel_module_name($File::Find::name);
+                    $available{$name} = 1 if $requested{$name};
+                },
+            },
+            $module_root,
+        );
+    }
+
+    return %available;
+}
+
+sub resolve_mellanox_default_net_drivers {
+    my ( $rootimg_dir, $kernelver, $requested_drivers, @default_drivers ) = @_;
+    my @drivers;
+    my %seen;
+    my $has_mellanox_drivers = grep {
+        _kernel_module_name($_) =~ /^mlx(?:_en|4_en|5_core)$/x
+    } (@{$requested_drivers}, @default_drivers);
+    if (!$has_mellanox_drivers) {
+        return grep { !$seen{$_}++ } (@{$requested_drivers}, @default_drivers);
+    }
+
+    my %available = target_kernel_module_availability(
+        $rootimg_dir,
+        $kernelver,
+        qw(mlx_en mlx4_en mlx5_core),
+    );
+
+    # Keep unavailable explicit requests, except for the historical mlx4 alias.
+    foreach my $driver (@{$requested_drivers}) {
+        my $name = _kernel_module_name($driver);
+        if ($name eq 'mlx_en'
+            && !$available{'mlx_en'}
+            && $available{'mlx4_en'})
+        {
+            $driver =~ s/mlx_en/mlx4_en/;
+        }
+        push @drivers, $driver;
+    }
+
+    foreach my $driver (@default_drivers) {
+        my $name = _kernel_module_name($driver);
+        if ($name eq 'mlx_en') {
+            if (!$available{'mlx_en'}) {
+                next if !$available{'mlx4_en'};
+                $driver =~ s/mlx_en/mlx4_en/;
+            }
+        } elsif ($name eq 'mlx4_en' || $name eq 'mlx5_core') {
+            next if !$available{$name};
+        }
+        push @drivers, $driver;
+    }
+
+    return grep { !$seen{$_}++ } @drivers;
 }
 
 1;

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -293,6 +293,7 @@ unless ($osver and $profile) {
 }
 
 my @ndrivers;
+my @default_ndrivers = imgutils::default_net_drivers('rh', $arch);
 if ($netdriver) {
     foreach (split /,/, $netdriver) {
         if (/^allupdate$/) {
@@ -310,18 +311,7 @@ if ($netdriver) {
     }
 }
 
-# Add the default driver list
-if ($arch eq 'x86' or $arch eq 'x86_64') {
-    push @ndrivers, qw/tg3 bnx2 bnx2x e1000 e1000e igb mlx_en virtio_net be2net/;
-} elsif ($arch eq 'aarch64') {
-    push @ndrivers, qw/tg3 bnx2 bnx2x e1000e igb mlx_en virtio_net/;
-} elsif ($arch eq 'ppc64') {
-    push @ndrivers, qw/e1000 e1000e igb ibmveth ehea/;
-} elsif ($arch eq 's390x') {
-    push @ndrivers, qw/qdio ccwgroup/;
-}
-
-foreach (@ndrivers) {
+foreach (@ndrivers, @default_ndrivers) {
     unless (/\.ko$/) {
         s/$/.ko/;
     }
@@ -744,6 +734,12 @@ if (-e "$rootimg_dir/boot/vmlinux-$kernelver") {
 }
 
 # Load driver update disk, and copy them to the root image
+@ndrivers = imgutils::resolve_mellanox_default_net_drivers(
+    $rootimg_dir,
+    $kernelver,
+    \@ndrivers,
+    @default_ndrivers,
+);
 my @dd_drivers = &load_dd();
 
 # Push the drivers into the @ndrivers base on the order
@@ -759,11 +755,6 @@ if (@new_order) {
     @ndrivers = (@new_order, @ndrivers);
 }
 
-if (-d "$rootimg_dir/lib/modules/$kernelver/kernel/drivers/net/ethernet/mellanox/mlx4") {
-    for (@ndrivers) {
-        s/mlx_en/mlx4_en/;
-    }
-}
 open($moddeps, "<", "$rootimg_dir/lib/modules/$kernelver/modules.dep");
 my @moddeps   = <$moddeps>;
 my @checkdeps = @ndrivers;

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -734,13 +734,13 @@ if (-e "$rootimg_dir/boot/vmlinux-$kernelver") {
 }
 
 # Load driver update disk, and copy them to the root image
+my @dd_drivers = &load_dd();
 @ndrivers = imgutils::resolve_mellanox_default_net_drivers(
     $rootimg_dir,
     $kernelver,
     \@ndrivers,
     @default_ndrivers,
 );
-my @dd_drivers = &load_dd();
 
 # Push the drivers into the @ndrivers base on the order
 my @new_order = ();

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -913,13 +913,13 @@ unless (-e "$rootimg_dir/usr/bin/keyctl") {
 umount();
 
 # Load driver update disk, and copy them to the root image
+my @dd_drivers = &load_dd();
 @ndrivers = imgutils::resolve_mellanox_default_net_drivers(
     $rootimg_dir,
     $kernelver,
     \@ndrivers,
     @default_ndrivers,
 );
-my @dd_drivers = &load_dd();
 
 # Push the drivers into the @ndrivers base on the order
 my @new_order = ();

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -187,6 +187,7 @@ unless ($osver and $profile) {
     exit 1;
 }
 my @ndrivers;
+my @default_ndrivers = imgutils::default_net_drivers('sles', $arch);
 
 if ($netdriver) {
     foreach (split /,/, $netdriver) {
@@ -210,16 +211,7 @@ if ($netdriver) {
     }
 }
 
-# Add the default driver list
-if ($arch eq 'x86' or $arch eq 'x86_64') {
-    push @ndrivers, qw/tg3 bnx2 bnx2x e1000 e1000e virtio_net virtio_balloon igb mlx4_en be2net/;
-} elsif ($arch eq 'ppc64') {
-    push @ndrivers, qw/tg3 e1000 e1000e igb ibmveth ehea be2net/;
-} elsif ($arch eq "s390x") {
-    push @ndrivers, qw/qdio ccwgroup qeth qeth_l2 qeth_l3/;
-}
-
-foreach (@ndrivers) {
+foreach (@ndrivers, @default_ndrivers) {
     unless (/\.ko$/) {
         s/$/.ko/;
     }
@@ -921,6 +913,12 @@ unless (-e "$rootimg_dir/usr/bin/keyctl") {
 umount();
 
 # Load driver update disk, and copy them to the root image
+@ndrivers = imgutils::resolve_mellanox_default_net_drivers(
+    $rootimg_dir,
+    $kernelver,
+    \@ndrivers,
+    @default_ndrivers,
+);
 my @dd_drivers = &load_dd();
 
 # Push the drivers into the @ndrivers base on the order
@@ -948,12 +946,6 @@ if ($osver_host >= 12) {
     }
 } else {    # for sles11 or lower
     push @ndrivers, ("ibmvscsic.ko", "ata_piix.ko", "pcieport.ko");
-}
-
-if (-f "$rootimg_dir/lib/modules/$kernelver/kernel/drivers/net/ethernet/mellanox/mlx4/mlx4_en.ko") {
-    for (@ndrivers) {
-        s/mlx_en/mlx4_en/;
-    }
 }
 
 open($moddeps, "<", "$rootimg_dir/lib/modules/$kernelver/modules.dep");

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -744,13 +744,13 @@ if (-e "$rootimg_dir/boot/vmlinux-$kernelver") {
 }
 
 # Load driver update disk, and copy them to the root image
+my @dd_drivers = &load_dd();
 @ndrivers = imgutils::resolve_mellanox_default_net_drivers(
     $rootimg_dir,
     $kernelver,
     \@ndrivers,
     @default_ndrivers,
 );
-my @dd_drivers = &load_dd();
 
 # Push the drivers into the @ndrivers base on the order
 my @new_order = ();

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -193,20 +193,13 @@ unless ($osver and $profile) {
 }
 
 my @ndrivers;
+my @default_ndrivers;
 if ($netdriver) {
     if (($updates{'netdrivers'} ne $netdriver) and ($tempfile)) {
         $updates{'netdrivers'} = $netdriver;
     }
 } else {
-    if ($arch eq 'x86' or $arch eq 'x86_64') {
-        @ndrivers = qw/tg3 bnx2 bnx2x e1000 e1000e igb mlx_en virtio_net overlay/;
-    } elsif ($arch eq 'ppc64el') {
-        @ndrivers = qw/tg3 bnx2 bnx2x e1000 e1000e igb ibmveth ehea mlx_en mlx4_en virtio_net overlay/;
-    } elsif ($arch eq 'ppc64') {
-        @ndrivers = qw/e1000 e1000e igb ibmveth ehea/;
-    } elsif ($arch eq 's390x') {
-        @ndrivers = qw/qdio ccwgroup/;
-    }
+    @default_ndrivers = imgutils::default_net_drivers('ubuntu', $arch);
 }
 foreach (split /,/, $netdriver) {
     unless (/\.ko$/) {
@@ -216,7 +209,7 @@ foreach (split /,/, $netdriver) {
     push @ndrivers, $_;
 }
 
-foreach (@ndrivers) {
+foreach (@ndrivers, @default_ndrivers) {
     unless (/\.ko$/) {
         s/$/.ko/;
     }
@@ -751,6 +744,12 @@ if (-e "$rootimg_dir/boot/vmlinux-$kernelver") {
 }
 
 # Load driver update disk, and copy them to the root image
+@ndrivers = imgutils::resolve_mellanox_default_net_drivers(
+    $rootimg_dir,
+    $kernelver,
+    \@ndrivers,
+    @default_ndrivers,
+);
 my @dd_drivers = &load_dd();
 
 # Push the drivers into the @ndrivers base on the order

--- a/xCAT-test/unit/mellanox_netdrivers.t
+++ b/xCAT-test/unit/mellanox_netdrivers.t
@@ -1,0 +1,301 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Carp qw(croak);
+use File::Basename qw(dirname);
+use File::Path qw(make_path);
+use File::Slurper qw(read_text write_text);
+use File::Temp qw(tempdir);
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use lib "$FindBin::Bin/../../perl-xCAT";
+use lib "$FindBin::Bin/../../xCAT-server/lib/perl";
+use lib "$FindBin::Bin/../../xCAT-server/share/xcat/netboot/imgutils";
+use Test::More;
+
+use XCAT::Test::File qw(repo_path);
+use imgutils;
+
+my @cases = (
+    [ 'rh', 'x86', [qw(tg3 bnx2 bnx2x e1000 e1000e igb mlx_en mlx5_core virtio_net be2net)] ],
+    [ 'rh', 'x86_64', [qw(tg3 bnx2 bnx2x e1000 e1000e igb mlx_en mlx5_core virtio_net be2net)] ],
+    [ 'rh', 'aarch64', [qw(tg3 bnx2 bnx2x e1000e igb mlx_en mlx5_core virtio_net)] ],
+    [ 'rh', 'ppc64', [qw(e1000 e1000e igb ibmveth ehea)] ],
+    [ 'rh', 's390x', [qw(qdio ccwgroup)] ],
+    [ 'sles', 'x86', [qw(tg3 bnx2 bnx2x e1000 e1000e virtio_net virtio_balloon igb mlx4_en mlx5_core be2net)] ],
+    [ 'sles', 'x86_64', [qw(tg3 bnx2 bnx2x e1000 e1000e virtio_net virtio_balloon igb mlx4_en mlx5_core be2net)] ],
+    [ 'sles', 'ppc64', [qw(tg3 e1000 e1000e igb ibmveth ehea be2net)] ],
+    [ 'sles', 's390x', [qw(qdio ccwgroup qeth qeth_l2 qeth_l3)] ],
+    [ 'ubuntu', 'x86', [qw(tg3 bnx2 bnx2x e1000 e1000e igb mlx_en mlx5_core virtio_net overlay)] ],
+    [ 'ubuntu', 'x86_64', [qw(tg3 bnx2 bnx2x e1000 e1000e igb mlx_en mlx5_core virtio_net overlay)] ],
+    [ 'ubuntu', 'ppc64el', [qw(tg3 bnx2 bnx2x e1000 e1000e igb ibmveth ehea mlx_en mlx4_en mlx5_core virtio_net overlay)] ],
+    [ 'ubuntu', 'ppc64', [qw(e1000 e1000e igb ibmveth ehea)] ],
+    [ 'ubuntu', 's390x', [qw(qdio ccwgroup)] ],
+);
+
+foreach my $case (@cases) {
+    my ( $family, $arch, $expected ) = @{$case};
+    is_deeply(
+        [ imgutils::default_net_drivers( $family, $arch ) ],
+        $expected,
+        "$family $arch uses the expected default network drivers",
+    );
+}
+
+is_deeply(
+    [ imgutils::default_net_drivers( 'unknown', 'x86_64' ) ],
+    [],
+    'an unknown image family has no default drivers',
+);
+
+sub create_target_kernel {
+    my (%args) = @_;
+    my $root = tempdir( CLEANUP => 1 );
+    my $kernelver = 'test-kernel';
+    my $module_root = "$root/lib/modules/$kernelver";
+    make_path($module_root);
+
+    foreach my $path (@{ $args{'files'} || [] }) {
+        my $full_path = "$module_root/$path";
+        make_path(dirname($full_path));
+        write_text($full_path, 'module');
+    }
+    write_text(
+        "$module_root/modules.dep",
+        join('', map { "$_:\n" } @{ $args{'dependencies'} || [] }),
+    );
+    write_text(
+        "$module_root/modules.builtin",
+        join('', map { "$_\n" } @{ $args{'builtins'} || [] }),
+    );
+    return ( $root, $kernelver );
+}
+
+{
+    my $mlx5 = 'kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.xz';
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => [$mlx5],
+        dependencies => [$mlx5],
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root,
+            $kernelver,
+            [qw(e1000.ko)],
+            qw(tg3.ko mlx_en.ko mlx5_core.ko),
+        ) ],
+        [qw(e1000.ko tg3.ko mlx5_core.ko)],
+        'an EL10-like target uses mlx5_core without stale mlx_en or mlx4_en',
+    );
+}
+
+{
+    my $mlx4 = 'kernel/drivers/net/ethernet/mellanox/mlx4/mlx4_en.ko.xz';
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => [$mlx4],
+        dependencies => [$mlx4],
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root, $kernelver, [], qw(mlx_en.ko),
+        ) ],
+        [qw(mlx4_en.ko)],
+        'an older in-box kernel resolves the legacy placeholder to mlx4_en',
+    );
+}
+
+{
+    my $mlx_en = 'updates/mlnx-ofed/drivers/net/mlx_en.ko.zst';
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => [$mlx_en],
+        dependencies => [$mlx_en],
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root, $kernelver, [], qw(mlx_en.ko),
+        ) ],
+        [qw(mlx_en.ko)],
+        'a real legacy MLNX_OFED mlx_en module is retained',
+    );
+}
+
+{
+    my ( $root, $kernelver ) = create_target_kernel();
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root,
+            $kernelver,
+            [],
+            qw(tg3.ko mlx_en.ko mlx4_en.ko mlx5_core.ko),
+        ) ],
+        [qw(tg3.ko)],
+        'unavailable optional Mellanox defaults are omitted',
+    );
+}
+
+{
+    my @paths = (
+        'weak-updates/vendor/mlx4_en.ko.xz',
+        'extra/vendor/mlx5_core.ko.zst',
+    );
+    my ( $root, $kernelver ) = create_target_kernel(files => \@paths);
+    my %available = imgutils::target_kernel_module_availability(
+        $root, $kernelver, qw(mlx4_en mlx5_core),
+    );
+    ok($available{'mlx4_en'}, 'a recursively installed .ko.xz module is available');
+    ok($available{'mlx5_core'}, 'a recursively installed .ko.zst module is available');
+}
+
+{
+    my @paths = (
+        'weak-updates/vendor/mlx4_en.ko.xz',
+        'extra/vendor/mlx5_core.ko.zst',
+    );
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => \@paths,
+        dependencies => \@paths,
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root,
+            $kernelver,
+            [],
+            qw(mlx_en.ko mlx4_en.ko mlx5_core.ko mlx5_core.ko),
+        ) ],
+        [qw(mlx4_en.ko mlx5_core.ko)],
+        'resolved Mellanox defaults are deduplicated',
+    );
+}
+
+{
+    my $mlx5 = 'kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.xz';
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => [$mlx5],
+        dependencies => [$mlx5],
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root,
+            $kernelver,
+            [qw(mlx_en.ko e1000.ko)],
+            qw(mlx_en.ko mlx5_core.ko),
+        ) ],
+        [qw(mlx_en.ko e1000.ko mlx5_core.ko)],
+        'a missing explicitly requested driver is not discarded as an optional default',
+    );
+}
+
+{
+    my $mlx4 = 'kernel/drivers/net/ethernet/mellanox/mlx4/mlx4_en.ko.xz';
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => [$mlx4],
+        dependencies => [$mlx4],
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root,
+            $kernelver,
+            [qw(mlx_en.ko mlx4_en.ko e1000.ko)],
+            qw(tg3.ko),
+        ) ],
+        [qw(mlx4_en.ko e1000.ko tg3.ko)],
+        'an explicitly requested legacy alias resolves to the in-box mlx4 driver',
+    );
+}
+
+{
+    my $builtin = 'kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko';
+    my ( $root, $kernelver ) = create_target_kernel(builtins => [$builtin]);
+    my %available = imgutils::target_kernel_module_availability(
+        $root, $kernelver, qw(mlx5_core),
+    );
+    ok($available{'mlx5_core'}, 'modules.builtin identifies an available target module');
+}
+
+my $tmpdir = tempdir( CLEANUP => 1 );
+my $modprobe_log = "$tmpdir/modprobe.log";
+my $fake_modprobe = "$tmpdir/modprobe";
+write_text(
+    $fake_modprobe,
+    "#!/bin/sh\nprintf '%s\\n' \"\$1\" >>\"\$MODPROBE_LOG\"\n" .
+    "case \" \${FAIL_MODPROBE:-} \" in\n" .
+    "    *\" \$1 \"*) exit 1 ;;\n" .
+    "esac\n" .
+    "exit 0\n",
+);
+chmod( 0755, $fake_modprobe ) or croak "chmod $fake_modprobe: $!";
+
+sub run_mellanox_loader {
+    return system(
+        repo_path('xCAT-genesis-scripts/usr/sbin/loadmlxeth'),
+        $fake_modprobe,
+    ) >> 8;
+}
+
+{
+    local %ENV = (
+        %ENV,
+        MODPROBE_LOG => $modprobe_log,
+    );
+    is(
+        run_mellanox_loader(),
+        0,
+        'the Genesis Mellanox loader succeeds when both modules load',
+    );
+}
+is(
+    read_text($modprobe_log),
+    "mlx4_en\nmlx5_core\n",
+    'the Genesis loader requests both Mellanox Ethernet driver generations',
+);
+
+unlink($modprobe_log) or croak "unlink $modprobe_log: $!";
+{
+    local %ENV = (
+        %ENV,
+        FAIL_MODPROBE => 'mlx4_en',
+        MODPROBE_LOG  => $modprobe_log,
+    );
+    is(run_mellanox_loader(), 0,
+        'the Genesis Mellanox loader succeeds when mlx5 loads');
+}
+is(
+    read_text($modprobe_log),
+    "mlx4_en\nmlx5_core\n",
+    'a failed mlx4 load does not suppress the independent mlx5 attempt',
+);
+
+unlink($modprobe_log) or croak "unlink $modprobe_log: $!";
+{
+    local %ENV = (
+        %ENV,
+        FAIL_MODPROBE => 'mlx5_core',
+        MODPROBE_LOG  => $modprobe_log,
+    );
+    is(run_mellanox_loader(), 0,
+        'the Genesis Mellanox loader succeeds when mlx4 loads');
+}
+is(
+    read_text($modprobe_log),
+    "mlx4_en\nmlx5_core\n",
+    'the Genesis loader tries both generations before reporting failure',
+);
+
+unlink($modprobe_log) or croak "unlink $modprobe_log: $!";
+{
+    local %ENV = (
+        %ENV,
+        FAIL_MODPROBE => 'mlx4_en mlx5_core',
+        MODPROBE_LOG  => $modprobe_log,
+    );
+    isnt(run_mellanox_loader(), 0,
+        'the Genesis Mellanox loader fails when neither module loads');
+}
+is(
+    read_text($modprobe_log),
+    "mlx4_en\nmlx5_core\n",
+    'both generations are attempted when neither module loads',
+);
+
+done_testing();

--- a/xCAT-test/unit/mellanox_netdrivers.t
+++ b/xCAT-test/unit/mellanox_netdrivers.t
@@ -34,6 +34,21 @@ my @cases = (
     [ 'ubuntu', 's390x', [qw(qdio ccwgroup)] ],
 );
 
+foreach my $family (qw(rh sles ubuntu)) {
+    my $source = read_text(repo_path(
+        "xCAT-server/share/xcat/netboot/$family/genimage",
+    ));
+    my $load_dd = index($source, 'my @dd_drivers = &load_dd();');
+    my $resolve = index(
+        $source,
+        '@ndrivers = imgutils::resolve_mellanox_default_net_drivers(',
+    );
+    ok(
+        $load_dd >= 0 && $resolve > $load_dd,
+        "$family resolves Mellanox defaults after installing driver updates",
+    );
+}
+
 foreach my $case (@cases) {
     my ( $family, $arch, $expected ) = @{$case};
     is_deeply(
@@ -87,6 +102,124 @@ sub create_target_kernel {
         ) ],
         [qw(e1000.ko tg3.ko mlx5_core.ko)],
         'an EL10-like target uses mlx5_core without stale mlx_en or mlx4_en',
+    );
+}
+
+{
+    my @doca_modules = (
+        'updates/dkms/mlx5_core.ko.zst',
+        'updates/dkms/mlx5_ib.ko.zst',
+        'updates/dkms/ib_ipoib.ko.zst',
+    );
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => \@doca_modules,
+        dependencies => \@doca_modules,
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root,
+            $kernelver,
+            [],
+            qw(mlx_en.ko mlx5_core.ko),
+        ) ],
+        [qw(mlx5_core.ko mlx5_ib.ko ib_ipoib.ko)],
+        'a DOCA-OFED target includes the available mlx5 InfiniBand and IPoIB modules',
+    );
+}
+
+{
+    my @mlx4_modules = (
+        'kernel/drivers/net/ethernet/mellanox/mlx4/mlx4_en.ko.xz',
+        'kernel/drivers/infiniband/hw/mlx4/mlx4_ib.ko.xz',
+        'kernel/drivers/infiniband/ulp/ipoib/ib_ipoib.ko.xz',
+    );
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => \@mlx4_modules,
+        dependencies => \@mlx4_modules,
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root, $kernelver, [], qw(mlx_en.ko),
+        ) ],
+        [qw(mlx4_en.ko mlx4_ib.ko ib_ipoib.ko)],
+        'an older mlx4 target includes its available InfiniBand and IPoIB modules',
+    );
+}
+
+{
+    my @modules = (
+        'kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.xz',
+        'kernel/drivers/infiniband/ulp/ipoib/ib_ipoib.ko.xz',
+    );
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => \@modules,
+        dependencies => \@modules,
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root, $kernelver, [], qw(mlx5_core.ko),
+        ) ],
+        [qw(mlx5_core.ko)],
+        'IPoIB is not added without an available Mellanox InfiniBand driver',
+    );
+}
+
+{
+    my @modules = (
+        'updates/dkms/mlx5_core.ko.zst',
+        'updates/dkms/mlx5_ib.ko.zst',
+        'updates/dkms/ib_ipoib.ko.zst',
+    );
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => \@modules,
+        dependencies => \@modules,
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root,
+            $kernelver,
+            [qw(mlx5_ib.ko ib_ipoib.ko)],
+            qw(mlx5_core.ko),
+        ) ],
+        [qw(mlx5_ib.ko ib_ipoib.ko mlx5_core.ko)],
+        'explicit and optional InfiniBand drivers are deduplicated',
+    );
+}
+
+{
+    my @modules = (
+        'updates/dkms/mlx5_core.ko.zst',
+        'updates/dkms/mlx5_ib.ko.zst',
+        'updates/dkms/ib_ipoib.ko.zst',
+    );
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => \@modules,
+        dependencies => \@modules,
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root, $kernelver, [qw(mlx5_core.ko)],
+        ) ],
+        [qw(mlx5_core.ko)],
+        'an explicit Mellanox request does not enable optional InfiniBand defaults',
+    );
+}
+
+{
+    my @modules = (
+        'updates/mlnx-ofed/mlx4_ib.ko.zst',
+        'updates/mlnx-ofed/ib_ipoib.ko.zst',
+    );
+    my ( $root, $kernelver ) = create_target_kernel(
+        files        => \@modules,
+        dependencies => \@modules,
+    );
+    is_deeply(
+        [ imgutils::resolve_mellanox_default_net_drivers(
+            $root, $kernelver, [], qw(mlx_en.ko),
+        ) ],
+        [qw(mlx4_ib.ko ib_ipoib.ko)],
+        'an InfiniBand-only OFED stack does not require an Ethernet frontend',
     );
 }
 


### PR DESCRIPTION
`genimage` adds its default network-driver list independently of the hardware installed in the management node. That list still contained `mlx_en`, so EL10 target kernels without mlx4 emitted a nonfatal missing-module diagnostic even though image generation completed.

Resolve optional Mellanox defaults from the target kernel: keep a real `mlx_en`, otherwise use `mlx4_en` when available, add `mlx5_core` when available, and omit unavailable defaults. Available `mlx4_ib`, `mlx5_ib`, and `ib_ipoib` modules are included for automatic defaults, including modules installed through driver updates. Explicit-only `netdrivers` lists are not expanded.

Genesis now tries mlx4 and mlx5 independently and succeeds when either loads. Regression tests cover legacy/OFED, mlx4, EL10, compressed modules, duplicate entries, InfiniBand, and explicit requests.

Closes #7781.
