### PR TITLE
refactor(dbobjutils): remove redundant group matcher

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -1242,29 +1242,17 @@ sub setobjdefs
             $objhash{$objname}{updated} = 1;
         }
 
+        # Group inheritance is already handled by validate_only_if_attrs and
+        # _only_if_value_matches; only report attributes still unresolved here.
         my $rsp;
         my $object_failed_validation = 0;
         foreach my $att (keys %$invalidattr) {
-            my $pickvalidattr=0;
             if ($invalidattr->{$att}->{valid} != 1) {
-                my $tt = $invalidattr->{$att}->{valid};
-                #if attribute is set invalid, check if its pre-check attribute exists in group objects, pick the attribute into valid.
-                # ex. like if I want to set hdwctrlpoint I will have
-                # to match the right value for mgtmethod
-                # if mgtmethod exists in group objects and its value match the one of only_if value, set hdwctrlpoint valid
                 my $conditionkey=$invalidattr->{$att}->{condition};
-                foreach my $tmpgrp (@tmplgrplist) {
-                    if (($DBgroupsattr{$tmpgrp}{$conditionkey}) && ($conditionlist->{$conditionkey} =~ $DBgroupsattr{$tmpgrp}{$conditionkey})) {
-                        $pickvalidattr=1;
-                        last;
-                    }
-                }
-                if ($pickvalidattr != 1) {
-                    $conditionlist->{$conditionkey}=~s/,/ or /g;
-                    push @{ $rsp->{data} }, "Cannot set the attr=\'$att\' attribute unless $invalidattr->{$att}->{condition} value is $conditionlist->{$conditionkey}.";
-                    xCAT::MsgUtils->message("E", $rsp, $::callback);
-                    $object_failed_validation = 1;
-                }
+                $conditionlist->{$conditionkey}=~s/,/ or /g;
+                push @{ $rsp->{data} }, "Cannot set the attr=\'$att\' attribute unless $invalidattr->{$att}->{condition} value is $conditionlist->{$conditionkey}.";
+                xCAT::MsgUtils->message("E", $rsp, $::callback);
+                $object_failed_validation = 1;
             }
         }
         if ($object_failed_validation) {

--- a/xCAT-test/unit/dbobjutils_only_if.t
+++ b/xCAT-test/unit/dbobjutils_only_if.t
@@ -9,6 +9,7 @@ BEGIN {
 use FindBin;
 use lib "$FindBin::Bin/../../perl-xCAT";
 
+use Scalar::Util qw(refaddr);
 use Test::More;
 
 use xCAT::DBobjUtils;
@@ -140,5 +141,39 @@ sub check_literal_only_if_routing {
 }
 
 check_literal_only_if_routing($_) for qw(explicit database group);
+
+my %external_entries;
+foreach my $type (keys %xCAT::ExtTab::ext_defspec) {
+    foreach my $entry (@{ $xCAT::ExtTab::ext_defspec{$type}{attrs} || [] }) {
+        $external_entries{refaddr($entry)} = 1;
+    }
+}
+
+my @inconsistent_only_if;
+my @falsey_only_if;
+my $checked_only_if = 0;
+foreach my $type (sort keys %xCAT::Schema::defspec) {
+    foreach my $entry (@{ $xCAT::Schema::defspec{$type}{attrs} || [] }) {
+        next if $external_entries{refaddr($entry)};
+        next unless exists($entry->{only_if});
+        my $condition = $entry->{only_if};
+        $checked_only_if++;
+        if ($condition !~ /^([^!=]+)=(.+)$/) {
+            push @inconsistent_only_if, "$type.$entry->{attr_name}:$condition";
+            next;
+        }
+        my ($validator_key, $validator_value) = ($1, $2);
+        my ($router_key, $router_value) = split(/=/, $condition);
+        if ($validator_key ne $router_key || $validator_value ne $router_value) {
+            push @inconsistent_only_if, "$type.$entry->{attr_name}:$condition";
+            next;
+        }
+        push @falsey_only_if, "$type.$entry->{attr_name}:$condition" unless $validator_value;
+    }
+}
+
+cmp_ok($checked_only_if, '>', 0, 'core only_if schema conditions are examined');
+is_deeply(\@inconsistent_only_if, [], 'validator and router parse core only_if conditions consistently');
+is_deeply(\@falsey_only_if, [], 'core only_if schema values are truthy for routing');
 
 done_testing();


### PR DESCRIPTION
Remove the legacy group-specific `only_if` fallback from `setobjdefs`.

Group inheritance is already handled by `validate_only_if_attrs` and `_only_if_value_matches` before unresolved attributes reach the existing diagnostic and rollback path. The fallback introduced a third matching authority and interpreted group values as unquoted regular expressions.

Add schema-invariant coverage to ensure the validator and router parse core `only_if` conditions consistently and that their values remain compatible with routing.