### PR TITLE
fix(xcat-core): make xCAT work on Ubuntu 26.04 (resolute)

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -270,7 +270,10 @@ unless ($onlyinitrd) {
         my $mirror = (defined $aptmirror[0] && length $aptmirror[0])
                    ? $aptmirror[0] : 'http://archive.ubuntu.com/ubuntu';
         (my $codename = $osver) =~ s/^ubuntu//;
-        $codename =~ s/\.\d+$//;                  # 24.04.4 -> 24.04
+        # Strip ONLY a trailing third component. A bare s/\.\d+$// also strips the minor from a
+        # two-part osvers (ubuntu26.04 -> "26"), which misses the %cn map below and reaches
+        # debootstrap as a bogus suite ("E: No such script: .../debootstrap/scripts/26").
+        $codename =~ s/^(\d+\.\d+)\.\d+$/$1/;   # 24.04.4 -> 24.04; 26.04 stays 26.04
         my %cn = ('24.04' => 'noble', '22.04' => 'jammy', '20.04' => 'focal',
                   '18.04' => 'bionic', '26.04' => 'resolute');
         $codename = $cn{$codename} if exists $cn{$codename};

--- a/xCAT-test/unit/ubuntu_bind9_dependency.t
+++ b/xCAT-test/unit/ubuntu_bind9_dependency.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use File::Spec;
+use FindBin;
+use Test::More;
+
+# Regression: xCAT manages the cluster DNS with `makedns`, which drives named, so a management
+# node (and a service node) requires a DNS server as surely as it requires a DHCP backend.
+# bind9 was only a Recommends, which is installed only while the system's APT recommendation
+# policy asks for it -- nothing guarantees named is on the node.
+#
+# On an Ubuntu 26.04 management node it was not there: no /usr/sbin/named, `makedns` failed with
+# "failed to start named", and provisioning broke before a node was ever deployed.
+#
+# Make bind9 a hard Depends on both metapackages so the DNS backend is guaranteed regardless of
+# that policy, mirroring the existing "isc-dhcp-server | kea" Depends.
+
+my $repo_root = File::Spec->rel2abs(
+    File::Spec->catdir( $FindBin::Bin, '..', '..' )
+);
+
+sub read_file {
+    my ($filename) = @_;
+    open( my $fh, '<', $filename ) or die "Unable to read $filename: $!";
+    my $content = do { local $/; <$fh> };
+    close($fh);
+    return $content;
+}
+
+foreach my $pkg ( [ 'xCAT', 'xcat' ], [ 'xCATsn', 'xcatsn' ] ) {
+    my ( $dir, $name ) = @$pkg;
+    my $control = read_file( File::Spec->catfile( $repo_root, $dir, 'debian', 'control' ) );
+
+    my ($depends)    = $control =~ /^Depends:\s*(.*)$/m;
+    my ($recommends) = $control =~ /^Recommends:\s*(.*)$/m;
+
+    ok( defined $depends, "$name debian/control has a Depends line" );
+
+    like( $depends, qr/(?:^|,)\s*bind9\s*(?:,|$)/,
+        "$name Depends on bind9 (required by makedns, so not a Recommends)" );
+
+    unlike( $recommends, qr/(?:^|,)\s*bind9\s*(?:,|$)/,
+        "$name no longer carries bind9 as a Recommends" );
+}
+
+done_testing();

--- a/xCAT-test/unit/ubuntu_genimage_codename.t
+++ b/xCAT-test/unit/ubuntu_genimage_codename.t
@@ -1,0 +1,64 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use File::Spec;
+use FindBin;
+use Test::More;
+
+# Regression: the Ubuntu netboot genimage derives a debootstrap suite from the osimage's
+# osvers. It reduced "ubuntu24.04.4" to "24.04" with a bare s/\.\d+$//, which ALSO strips the
+# minor from a two-part osvers -- an initial release with no point-release ISO, e.g.
+# "ubuntu26.04" -> "26". "26" is not in the codename map and is not a debootstrap suite, so
+# the rootimg build dies with:
+#
+#     E: No such script: /usr/share/debootstrap/scripts/26
+#
+# Only a trailing THIRD component may be stripped, so 24.04.4 -> 24.04 while 26.04 (and 18.04,
+# 20.04, 22.04 from an initial-release ISO) survive intact and reach the codename map.
+#
+# Driven by the real derivation code: the substitution and the codename map are extracted from
+# genimage and evaluated here, so this test tracks the script rather than a copy of it.
+
+my $repo_root = File::Spec->rel2abs(
+    File::Spec->catdir( $FindBin::Bin, '..', '..' )
+);
+
+my $genimage_path = File::Spec->catfile(
+    $repo_root, 'xCAT-server', 'share', 'xcat', 'netboot', 'ubuntu', 'genimage'
+);
+plan skip_all => "genimage not found at $genimage_path" unless -f $genimage_path;
+
+my $src = do { local $/; open my $fh, '<', $genimage_path or die $!; <$fh> };
+
+my ($strip) = $src =~ /^\s*(\$codename\s*=~\s*s\/.*?;)\s*(?:#.*)?$/m;
+ok( defined $strip, 'found the codename point-release substitution in genimage' )
+  or done_testing(), exit;
+
+my ($map) = $src =~ /^\s*(my\s+%cn\s*=\s*\(.*?\);)\s*$/ms;
+ok( defined $map, 'found the codename map in genimage' )
+  or done_testing(), exit;
+
+sub derive {
+    my ($osver) = @_;
+    my $codename = $osver;
+    $codename =~ s/^ubuntu//;
+    ## no critic
+    eval "$strip $map \$codename = \$cn{\$codename} if exists \$cn{\$codename}; 1"
+      or die "failed to evaluate genimage codename derivation: $@";
+    ## use critic
+    return $codename;
+}
+
+is( derive('ubuntu24.04.4'), 'noble',
+    'a point release still reduces to its MAJOR.MINOR codename (24.04.4 -> noble)' );
+is( derive('ubuntu26.04'), 'resolute',
+    'an initial release keeps its minor and maps to a codename (26.04 -> resolute, not "26")' );
+is( derive('ubuntu20.04'), 'focal',
+    'an initial 20.04 osvers is not over-stripped to "20"' );
+is( derive('ubuntu22.04'), 'jammy',
+    'an initial 22.04 osvers is not over-stripped to "22"' );
+is( derive('ubuntu18.04'), 'bionic',
+    'an initial 18.04 osvers is not over-stripped to "18"' );
+
+done_testing();

--- a/xCAT/debian/control
+++ b/xCAT/debian/control
@@ -9,8 +9,8 @@ Homepage: https://xcat.org/
 
 Package: xcat
 Architecture: amd64 ppc64el
-Depends: ${perl:Depends}, goconserver(>= 0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, isc-dhcp-server | kea, apache2, nfs-kernel-server, libxml-parser-perl, rsync, tftpd-hpa, libnet-telnet-perl, xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
-Recommends: bind9, net-tools, nmap, kea, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
+Depends: ${perl:Depends}, goconserver(>= 0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, isc-dhcp-server | kea, bind9, apache2, nfs-kernel-server, libxml-parser-perl, rsync, tftpd-hpa, libnet-telnet-perl, xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
+Recommends: net-tools, nmap, kea, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
 Suggests: yaboot-xcat
 Description: Metapackage for a common, default xCAT setup
  xCAT is Extreme Cluster/Cloud Administration Toolkit. xCAT offers complete

--- a/xCATsn/debian/control
+++ b/xCATsn/debian/control
@@ -8,8 +8,8 @@ Homepage: https://xcat.org/
 
 Package: xcatsn
 Architecture: amd64 ppc64el
-Depends: ${perl:Depends}, goconserver (>=0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, libnet-telnet-perl, isc-dhcp-server | kea, apache2, nfs-kernel-server, xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
-Recommends: bind9, net-tools, nmap, kea, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
+Depends: ${perl:Depends}, goconserver (>=0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, libnet-telnet-perl, isc-dhcp-server | kea, bind9, apache2, nfs-kernel-server, xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
+Recommends: net-tools, nmap, kea, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
 Suggests: yaboot-xcat
 Description: Metapackage for a common, default xCAT service node setup
  xCATsn is a service node management package intended for at-scale


### PR DESCRIPTION
Two independent defects stop xCAT working on Ubuntu 26.04 (resolute).

`bind9` is only a `Recommends` on the `xcat` and `xcatsn` metapackages. `bind9` is required by `makedns`, so it must be a hard dependency regardless of the system's APT recommendation policy — as a `Recommends` it is installed only while that policy asks for it, and nothing guarantees `named` is on the node. On an Ubuntu 26.04 management node it was not there: no `/usr/sbin/named`, and `makedns` failed with "failed to start named".

The Ubuntu netboot `genimage` reduces an osimage's `osvers` to a debootstrap suite with a bare `s/\.\d+$//`. That also strips the minor from a two-part `osvers` — an initial release with no point-release ISO — so `ubuntu26.04` becomes `26` and debootstrap dies with `E: No such script: /usr/share/debootstrap/scripts/26`. It is not 26.04-specific: an initial-release 18.04/20.04/22.04 ISO hits it too.

Assert `bind9` is a hard `Depends` on both metapackages, and drive `genimage`'s real codename derivation over a table of `osvers`. Both fail today.