### PR TITLE
refactor(template): use shared Ubuntu version comparison

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -1786,18 +1786,23 @@ sub ubuntu_subiquity_otherpkg_sources
 sub ubuntu_subiquity_uses_deb822_sources
 {
     my ($media_dir) = @_;
-    my $release = ubuntu_subiquity_release($media_dir);
-
-    return 1 if $release =~ m{ubuntu([2-9][4-9]|[3-9][0-9])\.\d+};
-    return 0;
+    return ubuntu_subiquity_release_at_least( $media_dir, '24.0' );
 }
 
 sub ubuntu_subiquity_uses_generated_cdrom_source
 {
     my ($media_dir) = @_;
+    return ubuntu_subiquity_release_at_least( $media_dir, '26.0' );
+}
+
+sub ubuntu_subiquity_release_at_least
+{
+    my ( $media_dir, $minimum ) = @_;
     my $release = ubuntu_subiquity_release($media_dir);
 
-    return 1 if $release =~ m{ubuntu([2-9][6-9]|[3-9][0-9])\.\d+};
+    foreach my $version ( $release =~ m{ubuntu(\d{2}\.\d+)}g ) {
+        return 1 if xCAT::Utils->version_cmp( $version, $minimum ) >= 0;
+    }
     return 0;
 }
 

--- a/xCAT-test/unit/ubuntu_subiquity_release_policy.t
+++ b/xCAT-test/unit/ubuntu_subiquity_release_policy.t
@@ -1,0 +1,80 @@
+#!/usr/bin/env perl
+## no critic (NamingConventions::Capitalization, TestingAndDebugging::ProhibitNoWarnings)
+use strict;
+use warnings;
+
+our $VERSION = '1.0';
+
+use FindBin;
+use lib "$FindBin::Bin/../../perl-xCAT";
+use lib "$FindBin::Bin/../../xCAT-server/lib/perl";
+use Test::More;
+
+use xCAT::Template;
+
+{
+
+    package UbuntuSubiquityReleaseTable;
+    sub getNodeAttribs { return { os => 'ubuntu26.04' }; }
+}
+
+my @release_cases = (
+    [ '/install/ubuntu23.10/x86_64',   0, 0, 'Ubuntu 23.10' ],
+    [ '/install/ubuntu24.04/x86_64',   1, 0, 'Ubuntu 24.04' ],
+    [ 'ubuntu25.10',                   1, 0, 'Ubuntu 25.10' ],
+    [ '/install/ubuntu26.04/ppc64le',  1, 1, 'Ubuntu 26.04' ],
+    [ 'ubuntu29.10',                   1, 1, 'Ubuntu 29.10' ],
+    [ 'ubuntu99.04',                   1, 1, 'Ubuntu 99.04' ],
+    [ 'ubuntu100.04',                  0, 0, 'three-digit release year' ],
+    [ '/install/ubuntu24.04.1/x86_64', 1, 0, 'Ubuntu 24.04 point release' ],
+    [ '/install/ubuntu26.04.1/x86_64', 1, 1, 'Ubuntu 26.04 point release' ],
+    [ '/install/debian26.04/x86_64',   0, 0, 'non-Ubuntu release' ],
+    [ '/install/ubuntu26/x86_64', 0, 0, 'release without a minor version' ],
+    [
+        '/install/ubuntu26.x/x86_64', 0, 0,
+        'release with a nonnumeric minor version'
+    ],
+);
+
+foreach my $case (@release_cases) {
+    my ( $release, $uses_deb822, $uses_generated_cdrom, $description ) =
+      @{$case};
+    is( xCAT::Template::ubuntu_subiquity_uses_deb822_sources($release),
+        $uses_deb822, "$description keeps the Deb822 source policy" );
+    is(
+        xCAT::Template::ubuntu_subiquity_uses_generated_cdrom_source($release),
+        $uses_generated_cdrom,
+        "$description keeps the generated cdrom source policy"
+    );
+}
+
+{
+    no warnings 'redefine';
+    local *xCAT::Table::new =
+      sub { return bless {}, 'UbuntuSubiquityReleaseTable'; };
+
+    ok(
+        xCAT::Template::ubuntu_subiquity_uses_deb822_sources(),
+        'nodetype OS fallback selects Deb822 sources'
+    );
+    ok(
+        xCAT::Template::ubuntu_subiquity_uses_generated_cdrom_source(),
+        'nodetype OS fallback selects the generated cdrom source'
+    );
+}
+
+{
+    no warnings 'redefine';
+    local *xCAT::Table::new = sub { return; };
+
+    ok(
+        !xCAT::Template::ubuntu_subiquity_uses_deb822_sources(),
+        'missing nodetype data does not select Deb822 sources'
+    );
+    ok(
+        !xCAT::Template::ubuntu_subiquity_uses_generated_cdrom_source(),
+        'missing nodetype data does not select the generated cdrom source'
+    );
+}
+
+done_testing();


### PR DESCRIPTION
Reuse `xCAT::Utils->version_cmp` for the Ubuntu Subiquity source-policy thresholds instead of maintaining separate version regexes.

Centralize the 24.x and 26.x checks while preserving the existing release parsing, nodetype fallback, and boolean behavior.

Add focused unit coverage for release boundaries, point releases, malformed and non-Ubuntu values, nodetype fallback, and missing table data.