### PR TITLE
refactor(dhcp): reuse shared OS version parsing

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -31,6 +31,7 @@ my $candoipv6 = eval {
 use Sys::Syslog;
 use IPC::Open2;
 use xCAT::Utils;
+use xCAT::SvrUtils;
 use xCAT::DHCP::BootPolicy;
 use xCAT::DHCP::Backend;
 use xCAT::DHCP::OmapiPolicy;
@@ -2835,11 +2836,24 @@ sub kea_apply_ddns_behavior
 sub dhcpd_sysconfig_uses_interface_key
 {
     my $os = shift || "";
-    my $os_ver = $os;
-    $os_ver =~ s/[^0-9.^0-9]//g;
+    my ( $os_family, $os_major, $os_minor ) = xCAT::SvrUtils::parseosver($os);
+    if (!$os_family || !defined $os_major || !length $os_major) {
+        return 0;
+    }
 
-    return 1 if $os =~ /(sles|opensuse[-_]?leap|leap)/i && $os_ver >= 11;
-    return 1 if $os =~ /rhels?/i && $os_ver >= 7;
+    my $os_version = $os_major;
+    if (defined $os_minor && length $os_minor) {
+        $os_version .= ".$os_minor";
+    }
+
+    if (   $os_family =~ /(sles|opensuse[-_]?leap|leap)/i
+        && xCAT::Utils->version_cmp( $os_version, '11' ) >= 0) {
+        return 1;
+    }
+    if (   $os_family =~ /rhels?/i
+        && xCAT::Utils->version_cmp( $os_version, '7' ) >= 0) {
+        return 1;
+    }
     return 0;
 }
 

--- a/xCAT-test/unit/dhcp_kea_plugin_intent.t
+++ b/xCAT-test/unit/dhcp_kea_plugin_intent.t
@@ -122,9 +122,32 @@ my %network_entry = (
     tftpserver   => '<xcatmaster>',
 );
 
-ok(xCAT_plugin::dhcp::dhcpd_sysconfig_uses_interface_key('opensuse-leap15.6'), 'openSUSE Leap head node uses SUSE dhcpd interface key');
-ok(xCAT_plugin::dhcp::dhcpd_sysconfig_uses_interface_key('leap15.6'), 'Leap head node osver uses SUSE dhcpd interface key');
-ok(!xCAT_plugin::dhcp::dhcpd_sysconfig_uses_interface_key('opensuse-tumbleweed'), 'generic openSUSE names do not enable Leap-specific dhcpd handling');
+my @sysconfig_policy_cases = (
+    [ 'sles10',                  0, 'SLES 10' ],
+    [ 'sles11',                  1, 'SLES 11' ],
+    [ 'sles15.10',               1, 'SLES 15.10' ],
+    [ 'sles-sap15.6',            1, 'SLES for SAP 15.6' ],
+    [ 'opensuse-leap15.6',       1, 'openSUSE Leap 15.6' ],
+    [ 'opensuse_leap15.6',       1, 'underscored openSUSE Leap 15.6' ],
+    [ 'leap15.6',                1, 'short Leap 15.6' ],
+    [ 'rhel6',                    0, 'RHEL 6' ],
+    [ 'rhel6.10',                 0, 'RHEL 6.10' ],
+    [ 'rhel7',                    1, 'RHEL 7' ],
+    [ 'rhels7.0',                 1, 'RHEL Server 7.0' ],
+    [ 'rhel10',                   1, 'RHEL 10' ],
+    [ 'RHEL7',                    1, 'uppercase RHEL 7' ],
+    [ 'ubuntu24.04',              0, 'Ubuntu release' ],
+    [ 'debian12',                 0, 'Debian release' ],
+    [ 'opensuse-tumbleweed',      0, 'openSUSE Tumbleweed release' ],
+    [ 'unknown',                  0, 'unknown release' ],
+    [ undef,                      0, 'undefined release' ],
+);
+
+foreach my $case (@sysconfig_policy_cases) {
+    my ( $os, $expected, $description ) = @{$case};
+    my $actual = xCAT_plugin::dhcp::dhcpd_sysconfig_uses_interface_key($os);
+    is( $actual, $expected, "$description keeps the dhcpd sysconfig policy" );
+}
 
 {
     my $tmpdir = tempdir(CLEANUP => 1);

--- a/xCAT-test/unit/dhcp_kea_plugin_intent.t
+++ b/xCAT-test/unit/dhcp_kea_plugin_intent.t
@@ -5,6 +5,7 @@ no warnings 'once';
 
 use FindBin;
 use lib "$FindBin::Bin/../../perl-xCAT";
+use lib "$FindBin::Bin/../../xCAT-server/lib/perl";
 
 use File::Temp qw(tempdir);
 use Socket ();
@@ -23,11 +24,6 @@ BEGIN {
     sub getTftpDir { return '/tftpboot'; }
     sub get_site_attribute { return; }
     $INC{'xCAT/TableUtils.pm'} = __FILE__;
-
-    package xCAT::Utils;
-    sub osver { return 'rhels9'; }
-    sub runcmd { return; }
-    $INC{'xCAT/Utils.pm'} = __FILE__;
 
     package xCAT::NetworkUtils;
     sub import {
@@ -76,6 +72,13 @@ BEGIN {
 
     package xCAT::NodeRange;
     $INC{'xCAT/NodeRange.pm'} = __FILE__;
+}
+
+require xCAT::Utils;
+{
+    no warnings 'redefine';
+    *xCAT::Utils::osver = sub { return 'rhels9'; };
+    *xCAT::Utils::runcmd = sub { return; };
 }
 
 my $source_dhcp_plugin = "$FindBin::Bin/../../xCAT-server/lib/xcat/plugins/dhcp.pm";


### PR DESCRIPTION
Reuse `xCAT::SvrUtils::parseosver` and `xCAT::Utils->version_cmp` for the dhcpd sysconfig interface-key policy, replacing the local digit-stripping and numeric-comparison logic.

Preserve the existing SLES, openSUSE Leap, and RHEL thresholds while keeping unrelated OS families disabled.