### PR TITLE
feat(build): add a source-only build mode

### DIFF
--- a/build-utils/buildcore-source-only.sh
+++ b/build-utils/buildcore-source-only.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Source-only artifact delivery used by buildcore.sh.
+
+function xcat_deliver_noarch_package {
+    local rpmname="$1"
+
+    if ! xcat_source_only; then
+        rm -f $DESTDIR/$rpmname*rpm
+        mv $source/RPMS/$NOARCH/$rpmname-$VER*rpm $DESTDIR
+    fi
+    rm -f $SRCDIR/$rpmname*rpm
+    mv $source/SRPMS/$rpmname-$VER*rpm $SRCDIR
+}
+
+function xcat_deliver_genesis_packages {
+    if ! xcat_source_only; then
+        rm -f $DESTDIR/xCAT-genesis-scripts*rpm
+        mv $source/RPMS/noarch/xCAT-genesis-scripts-*rpm $DESTDIR
+    fi
+    rm -f $SRCDIR/xCAT-genesis-scripts*rpm
+    mv $source/SRPMS/xCAT-genesis-scripts-*rpm $SRCDIR
+}
+
+function xcat_deliver_arch_package {
+    local rpmname="$1"
+
+    if ! xcat_source_only; then
+        rm -f $DESTDIR/$rpmname-$SHORTSHORTVER*rpm
+        mv $source/RPMS/*/$rpmname-$VER*rpm $DESTDIR
+    fi
+    rm -f $SRCDIR/$rpmname-$SHORTSHORTVER*rpm
+    mv $source/SRPMS/$rpmname-$VER*rpm $SRCDIR
+}
+
+function xcat_deliver_embed_links {
+    if xcat_source_only; then
+        return
+    fi
+    if [ -n "$EMBED" -a -n "$EMBEDLINK" ]; then
+        cd $DESTDIR
+        maindir="../../$XCATCORE"
+        for rpmname in $EMBEDLINK; do
+            if [ "$rpmname" = "xCAT" -o "$rpmname" = "xCATsn" ]; then
+                if [ "$EMBED" = "zvm" ]; then
+                    echo "Creating link for $rpmname-$SHORTSHORTVER"'*.s390x.rpm'
+                    rm -f $rpmname-$SHORTSHORTVER*rpm
+                    ln -s $maindir/$rpmname-$SHORTSHORTVER*.s390x.rpm .
+                fi
+            else
+                echo "Creating link for $rpmname-$SHORTSHORTVER"'*rpm'
+                rm -f $rpmname-$SHORTSHORTVER*rpm
+                ln -s $maindir/$rpmname-$SHORTSHORTVER*rpm .
+            fi
+        done
+        cd - >/dev/null
+    fi
+}
+
+function xcat_create_binary_tarball {
+    if xcat_source_only; then
+        echo "Not creating $TARNAME: a source-only build makes no binary rpms."
+        return
+    fi
+
+    echo "Creating $(dirname $DESTDIR)/$TARNAME ..."
+    if [[ -e $TARNAME ]]; then
+        mkdir -p previous
+        mv -f $TARNAME previous
+    fi
+    if [ "$OSNAME" = "AIX" ]; then
+        tar $verboseflag -hcf ${TARNAME%.gz} $XCATCORE
+        gzip ${TARNAME%.gz}
+    else
+        tar $verboseflag -hjcf $TARNAME $XCATCORE
+    fi
+    chgrp $SYSGRP $TARNAME
+    chmod g+w $TARNAME
+}
+
+function xcat_publish_tarball_link {
+    if [ -n "$DEST" ] && ! xcat_source_only; then
+        ln -sf $(basename `pwd`)/$TARNAME ../$TARNAME
+        if [ $? != 0 ]; then
+            echo "ERROR: Failed to make symbol link $DEST/$TARNAME"
+        fi
+    fi
+}

--- a/build-utils/buildcore-source-only.sh
+++ b/build-utils/buildcore-source-only.sh
@@ -86,3 +86,46 @@ function xcat_publish_tarball_link {
         fi
     fi
 }
+
+function xcat_finalize_repository {
+    local artifact_kind="$1"
+    local repository="$2"
+
+    if [ "$artifact_kind" = "binary" ] && xcat_source_only; then
+        return
+    fi
+
+    if [ "$RPMSIGN" = "1" ]; then
+        if [ "$artifact_kind" = "binary" ]; then
+            build-utils/rpmsign.exp `find "$repository" -type f -name '*.rpm'` | grep -v -E '(already contains identical signature|was already signed|rpm --quiet --resign|WARNING: standard input reopened)'
+        else
+            build-utils/rpmsign.exp "$repository"/*rpm | grep -v -E '(already contains identical signature|was already signed|rpm --quiet --resign|WARNING: standard input reopened)'
+        fi
+    fi
+
+    createrepo "$repository"
+
+    if [ "$RPMSIGN" = "1" ]; then
+        rm -f "$repository/repodata/repomd.xml.asc"
+        gpg -a --detach-sign --default-key "xCAT Automatic Signing Key" "$repository/repodata/repomd.xml"
+        if [ ! -f "$repository/repodata/repomd.xml.key" ]; then
+            gpg -a --export "xCAT Automatic Signing Key" > "$repository/repodata/repomd.xml.key"
+        fi
+    fi
+}
+
+function xcat_write_binary_buildinfo {
+    local buildinfo="$1"
+
+    if xcat_source_only; then
+        echo "Not updating $buildinfo: a source-only build makes no binary bundle."
+        return
+    fi
+
+    echo "VERSION=$VER" > "$buildinfo"
+    echo "RELEASE=$XCAT_RELEASE" >> "$buildinfo"
+    echo "BUILD_TIME=$BUILD_TIME" >> "$buildinfo"
+    echo "BUILD_MACHINE=$BUILD_MACHINE" >> "$buildinfo"
+    echo "COMMIT_ID=$COMMIT_ID" >> "$buildinfo"
+    echo "COMMIT_ID_LONG=$COMMIT_ID_LONG" >> "$buildinfo"
+}

--- a/build-utils/source-only.sh
+++ b/build-utils/source-only.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Shared source-only build decisions used by makerpm and buildcore.sh.
+
+function xcat_source_only {
+    [ "$SRCONLY" = "1" -o "$SRCONLY" = "yes" ]
+}
+
+function xcat_configure_rpm_build_mode {
+    local osname="$1"
+
+    if xcat_source_only; then
+        if [ "$osname" = "AIX" ]; then
+            echo "Error: SRCONLY is not supported on AIX."
+            return 1
+        fi
+        SPECBUILD="-bs"
+        TARBUILD="-ts"
+    else
+        SPECBUILD="-ba"
+        TARBUILD="-ta"
+    fi
+}
+
+function xcat_announce_build {
+    if [ "$SPECBUILD" = "-bs" ]; then
+        echo "Building $RPMROOT/SRPMS/$1-snap*.src.rpm $EMBEDTXT..."
+    else
+        echo "Building $2 $EMBEDTXT..."
+    fi
+}
+
+function xcat_rpmbuild_spec {
+    rpmbuild $QUIET "$SPECBUILD" "$@"
+}
+
+function xcat_rpmbuild_tar {
+    rpmbuild $QUIET "$TARBUILD" "$@"
+}
+
+function xcat_require_binary_build {
+    local package="$1"
+
+    if xcat_source_only; then
+        echo "Error: SRCONLY is not supported for $package."
+        return 1
+    fi
+}

--- a/build-utils/source-only.sh
+++ b/build-utils/source-only.sh
@@ -3,7 +3,7 @@
 # Shared source-only build decisions used by makerpm and buildcore.sh.
 
 function xcat_source_only {
-    [ "$SRCONLY" = "1" -o "$SRCONLY" = "yes" ]
+    [ "$SRCONLY" = "1" -o "$SRCONLY" = "yes" -o "$SRCONLY" = "true" ]
 }
 
 function xcat_configure_rpm_build_mode {

--- a/build-utils/source-only.sh
+++ b/build-utils/source-only.sh
@@ -6,6 +6,14 @@ function xcat_source_only {
     [ "$SRCONLY" = "1" -o "$SRCONLY" = "yes" -o "$SRCONLY" = "true" ]
 }
 
+function xcat_rpm_build_arches {
+    if xcat_source_only; then
+        printf '%s\n' "$1"
+    else
+        printf '%s\n' "$@"
+    fi
+}
+
 function xcat_configure_rpm_build_mode {
     local osname="$1"
 

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -450,35 +450,19 @@ if [ "$OSNAME" != "AIX" ]; then
             echo '%_gpg_name xCAT Automatic Signing Key' >> $MACROS
         fi
         echo "Signing RPMs..."
-        build-utils/rpmsign.exp `find $DESTDIR -type f -name '*.rpm'` | grep -v -E '(already contains identical signature|was already signed|rpm --quiet --resign|WARNING: standard input reopened)'
-        build-utils/rpmsign.exp $SRCDIR/*rpm | grep -v -E '(already contains identical signature|was already signed|rpm --quiet --resign|WARNING: standard input reopened)'
-        # RHEL5 is archaic. Use the default hash algorithm to do the checksum.
-        # Which is SHA-256 on RHEL6.
-        createrepo $DESTDIR
-        createrepo $SRCDIR
-        rm -f $SRCDIR/repodata/repomd.xml.asc
-        rm -f $DESTDIR/repodata/repomd.xml.asc
-        # Use the xCAT Automatic Signing Key to do the signing
-        gpg -a --detach-sign --default-key "xCAT Automatic Signing Key" $DESTDIR/repodata/repomd.xml
-        gpg -a --detach-sign --default-key "xCAT Automatic Signing Key" $SRCDIR/repodata/repomd.xml
-        if [ ! -f $DESTDIR/repodata/repomd.xml.key ]; then
-            gpg -a --export "xCAT Automatic Signing Key" > $DESTDIR/repodata/repomd.xml.key
-        fi
-        if [ ! -f $SRCDIR/repodata/repomd.xml.key ]; then
-            gpg -a --export "xCAT Automatic Signing Key" > $SRCDIR/repodata/repomd.xml.key
-        fi
-    else
-        createrepo $DESTDIR
-        createrepo $SRCDIR
     fi
+    xcat_finalize_repository binary "$DESTDIR"
+    xcat_finalize_repository source "$SRCDIR"
 fi
 
 # set group and permissions correctly on the built rpms
 if [ "$OSNAME" = "AIX" ]; then
     chmod +x $DESTDIR/instxcat
 fi
-chgrp -R $SYSGRP $DESTDIR
-chmod -R g+w $DESTDIR
+if ! xcat_source_only; then
+    chgrp -R $SYSGRP $DESTDIR
+    chmod -R g+w $DESTDIR
+fi
 chgrp -R $SYSGRP $SRCDIR
 chmod -R g+w $SRCDIR
 
@@ -496,7 +480,7 @@ fi
 
 cd $DESTDIR
 
-if [ "$OSNAME" != "AIX" ]; then
+if [ "$OSNAME" != "AIX" ] && ! xcat_source_only; then
 
     # Modify the repo file to point to either xcat-core or core-snap
     # Always recreate it, in case the whole dir was copied from devel to 2.x
@@ -550,12 +534,7 @@ fi
 # Add a buildinfo file into the tar.bz2 file to track information about the build
 #
 BUILDINFO=$XCATCORE/buildinfo
-echo "VERSION=$VER" > $BUILDINFO
-echo "RELEASE=$XCAT_RELEASE" >> $BUILDINFO
-echo "BUILD_TIME=$BUILD_TIME" >> $BUILDINFO
-echo "BUILD_MACHINE=$BUILD_MACHINE" >> $BUILDINFO
-echo "COMMIT_ID=$COMMIT_ID" >> $BUILDINFO
-echo "COMMIT_ID_LONG=$COMMIT_ID_LONG" >> $BUILDINFO
+xcat_write_binary_buildinfo "$BUILDINFO"
 
 xcat_create_binary_tarball
 xcat_publish_tarball_link
@@ -572,7 +551,7 @@ if [ "$OSNAME" = "AIX" ]; then
 else
     YUM=yum
 fi
-if [ ! -e core-snap ]; then
+if ! xcat_source_only && [ ! -e core-snap ]; then
     ln -s xcat-core core-snap
 fi
 if xcat_source_only; then

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -367,10 +367,10 @@ if [ "$OSNAME" != "AIX" ]; then
         if [ "$BUILDALL" == 1 ] || $GREP xCAT-genesis-scripts $GITUP; then
             UPLOAD=1
             ORIGFAILEDRPMS="$FAILEDRPMS"
-            ./makerpm xCAT-genesis-scripts x86_64 "$EMBED"
-            if [ $? -ne 0 ]; then FAILEDRPMS="$FAILEDRPMS xCAT-genesis-scripts-x86_64"; fi
-            ./makerpm xCAT-genesis-scripts ppc64 "$EMBED"
-            if [ $? -ne 0 ]; then FAILEDRPMS="$FAILEDRPMS xCAT-genesis-scripts-ppc64"; fi
+            for arch in x86_64 ppc64; do
+                ./makerpm xCAT-genesis-scripts $arch "$EMBED"
+                if [ $? -ne 0 ]; then FAILEDRPMS="$FAILEDRPMS xCAT-genesis-scripts-$arch"; fi
+            done
             # Do not build xCAT-genesis-scripts-aarch64 yet
             #./makerpm xCAT-genesis-scripts aarch64 "$EMBED"
             #if [ $? -ne 0 ]; then FAILEDRPMS="$FAILEDRPMS xCAT-genesis-scripts-aarch64"; fi
@@ -392,7 +392,7 @@ for rpmname in xCAT xCATsn; do
             ./makerpm $rpmname "$EMBED"
             if [ $? -ne 0 ]; then FAILEDRPMS="$FAILEDRPMS $rpmname"; fi
         else
-            for arch in x86_64 ppc64 ppc64le s390x aarch64; do
+            for arch in $(xcat_rpm_build_arches x86_64 ppc64 ppc64le s390x aarch64); do
                 if [ "$rpmname" = "xCAT-OpenStack" -a "$arch" != "x86_64" ] || [ "$rpmname" = "xCAT-OpenStack-baremetal" -a "$arch" != "x86_64" ] ; then continue; fi         # only bld openstack for x86_64 for now
                 ./makerpm $rpmname $arch "$EMBED"
                 if [ $? -ne 0 ]; then FAILEDRPMS="$FAILEDRPMS $rpmname-$arch"; fi

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -38,6 +38,9 @@
 SCRIPT=$(readlink -f $0)
 SCRIPTPATH=`dirname $SCRIPT`
 
+. "$SCRIPTPATH/build-utils/source-only.sh"
+. "$SCRIPTPATH/build-utils/buildcore-source-only.sh"
+
 UPLOADUSER=litingt
 USER=xcat
 SERVER=xcat.org
@@ -322,10 +325,7 @@ function maker {
     if [ $? -ne 0 ]; then
         FAILEDRPMS="$FAILEDRPMS $rpmname"
     else
-        rm -f $DESTDIR/$rpmname*rpm
-        rm -f $SRCDIR/$rpmname*rpm
-        mv $source/RPMS/$NOARCH/$rpmname-$VER*rpm $DESTDIR
-        mv $source/SRPMS/$rpmname-$VER*rpm $SRCDIR
+        xcat_deliver_noarch_package "$rpmname"
     fi
 }
 
@@ -375,10 +375,7 @@ if [ "$OSNAME" != "AIX" ]; then
             #./makerpm xCAT-genesis-scripts aarch64 "$EMBED"
             #if [ $? -ne 0 ]; then FAILEDRPMS="$FAILEDRPMS xCAT-genesis-scripts-aarch64"; fi
             if [ "$FAILEDRPMS" = "$ORIGFAILEDRPMS" ]; then    # all succeeded
-                rm -f $DESTDIR/xCAT-genesis-scripts*rpm
-                rm -f $SRCDIR/xCAT-genesis-scripts*rpm
-                mv $source/RPMS/noarch/xCAT-genesis-scripts-*rpm $DESTDIR
-                mv $source/SRPMS/xCAT-genesis-scripts-*rpm $SRCDIR
+                xcat_deliver_genesis_packages
             fi
         fi
     fi
@@ -402,10 +399,7 @@ for rpmname in xCAT xCATsn; do
             done
         fi
         if [ "$FAILEDRPMS" = "$ORIGFAILEDRPMS" ]; then    # all succeeded
-            rm -f $DESTDIR/$rpmname-$SHORTSHORTVER*rpm
-            rm -f $SRCDIR/$rpmname-$SHORTSHORTVER*rpm
-            mv $source/RPMS/*/$rpmname-$VER*rpm $DESTDIR
-            mv $source/SRPMS/$rpmname-$VER*rpm $SRCDIR
+            xcat_deliver_arch_package "$rpmname"
         fi
     fi
 done
@@ -415,24 +409,7 @@ if [ "$OSNAME" = "AIX" ]; then
 fi
 
 # Make sym links in the embed subdirs for the rpms we do not have to build special
-if [ -n "$EMBED" -a -n "$EMBEDLINK" ]; then
-    cd $DESTDIR
-    maindir="../../$XCATCORE"
-    for rpmname in $EMBEDLINK; do
-        if [ "$rpmname" = "xCAT" -o "$rpmname" = "xCATsn" ]; then
-            if [ "$EMBED" = "zvm" ]; then
-                echo "Creating link for $rpmname-$SHORTSHORTVER"'*.s390x.rpm'
-                rm -f $rpmname-$SHORTSHORTVER*rpm
-                ln -s $maindir/$rpmname-$SHORTSHORTVER*.s390x.rpm .
-            fi
-        else
-            echo "Creating link for $rpmname-$SHORTSHORTVER"'*rpm'
-            rm -f $rpmname-$SHORTSHORTVER*rpm
-            ln -s $maindir/$rpmname-$SHORTSHORTVER*rpm .
-        fi
-    done
-    cd - >/dev/null
-fi
+xcat_deliver_embed_links
 
 
 # Decide if anything was built or not
@@ -580,26 +557,8 @@ echo "BUILD_MACHINE=$BUILD_MACHINE" >> $BUILDINFO
 echo "COMMIT_ID=$COMMIT_ID" >> $BUILDINFO
 echo "COMMIT_ID_LONG=$COMMIT_ID_LONG" >> $BUILDINFO
 
-echo "Creating $(dirname $DESTDIR)/$TARNAME ..."
-if [[ -e $TARNAME ]]; then
-    mkdir -p previous
-    mv -f $TARNAME previous
-fi
-if [ "$OSNAME" = "AIX" ]; then
-    tar $verboseflag -hcf ${TARNAME%.gz} $XCATCORE
-    gzip ${TARNAME%.gz}
-else
-    tar $verboseflag -hjcf $TARNAME $XCATCORE
-fi
-chgrp $SYSGRP $TARNAME
-chmod g+w $TARNAME
-
-if [ -n "$DEST" ]; then
-    ln -sf $(basename `pwd`)/$TARNAME ../$TARNAME
-    if [ $? != 0 ]; then
-        echo "ERROR: Failed to make symbol link $DEST/$TARNAME"
-    fi
-fi
+xcat_create_binary_tarball
+xcat_publish_tarball_link
 
 # Decide whether to upload or not
 if [ -n "$UP" ] && [ "$UP" == 0 ]; then
@@ -616,7 +575,9 @@ fi
 if [ ! -e core-snap ]; then
     ln -s xcat-core core-snap
 fi
-if [ "$REL" = "devel" -o "$PREGA" != 1 ]; then
+if xcat_source_only; then
+    echo "Not uploading the binary rpms: a source-only build makes none."
+elif [ "$REL" = "devel" -o "$PREGA" != 1 ]; then
     i=0
     echo "Uploading RPMs from $CORE to $YUMDIR/$YUM/$REL$EMBEDDIR/ ..."
     while [ $((i+=1)) -le 5 ] && ! rsync -urLv --delete $CORE $USER@$SERVER:$YUMDIR/$YUM/$REL$EMBEDDIR/
@@ -630,7 +591,9 @@ while [ $((i+=1)) -le 5 ] && ! rsync -urLv --delete $SRCD $USER@$SERVER:$YUMDIR/
 do : ; done
 
 # Upload the tarball to xcat.org
-if [ "$PROMOTE" = 1 -a "$REL" != "devel" -a "$PREGA" != 1 ]; then
+if xcat_source_only; then
+    echo "Not uploading $TARNAME: a source-only build makes no binary rpms."
+elif [ "$PROMOTE" = 1 -a "$REL" != "devel" -a "$PREGA" != 1 ]; then
     # upload tarball to FRS area
     i=0
     echo "Uploading $TARNAME to $FRS/xcat/$REL.x_$OSNAME$EMBEDDIR/ ..."

--- a/docs/source/developers/guides/code/builds.rst
+++ b/docs/source/developers/guides/code/builds.rst
@@ -9,6 +9,17 @@ Clone the xCAT project from `GitHub <https://github.com/xcat2/xcat-core>`_::
     cd xcat-core
     ./buildcore.sh
 
+To build the source rpms and no binary rpms, set ``SRCONLY``::
+
+    cd xcat-core
+    ./buildcore.sh SRCONLY=1
+
+A source rpm is the input that a build service such as mock, koji, COPR or OBS
+takes, and it lets one machine make the source rpms while another makes the
+binary rpms for each architecture. ``rpmbuild`` does not need the packages named
+in ``BuildRequires`` to make a source rpm, so this also builds on a machine that
+cannot complete a full build. ``SRCONLY`` is not supported on AIX.
+
 xcat-deps
 ---------
 

--- a/makerpm
+++ b/makerpm
@@ -6,8 +6,11 @@
 #   ./makerpm xCAT-server
 #   ./makerpm xCAT x86_64
 # If you want verbose output:  export VERBOSE=1
+# If you want source rpms only:  export SRCONLY=1
 
 # set -x
+
+. "$(dirname "$0")/build-utils/source-only.sh"
 
 function xcat_probe_copy {
     # xCAT-probe uses some functions shipped with xCAT,  copying for the following reasons:
@@ -42,7 +45,7 @@ function makenoarch {
 		rpm $QUIET -ba $RPMNAME/$RPMNAME.spec
 		RC=$?
 	else	# linux
-		echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$VER-snap*.noarch.rpm $EMBEDTXT..."
+		xcat_announce_build "$RPMNAME-$VER" "$RPMROOT/RPMS/noarch/$RPMNAME-$VER-snap*.noarch.rpm"
 		# TODO: should fix this up, this is a hack for the new build machine
 		if [ $RPMNAME = "xCAT-UI" ]; then
 			# Only if the old compiler.jar file does not exist.....
@@ -66,7 +69,7 @@ function makenoarch {
 
 		tar --exclude .svn -czf $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz $RPMNAME
 		rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
-		rpmbuild $QUIET -ta $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz --define "version $VER" $REL "$EASE"
+		xcat_rpmbuild_tar $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz --define "version $VER" $REL "$EASE"
 		RC=$?
 
 		if [ $RPMNAME = "xCAT-UI" ]; then
@@ -159,8 +162,8 @@ function makexcat {
 		fi
 
 		rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/$ARCH/$RPMNAME-$VER*rpm
-		echo "Building $RPMROOT/RPMS/$ARCH/$RPMNAME-$VER-snap*.$ARCH.rpm $EMBEDTXT..."
-		rpmbuild $QUIET -ba $RPMNAME/$RPMNAME.spec $TARGET --define "version $VER" $REL "$EASE"
+		xcat_announce_build "$RPMNAME-$VER" "$RPMROOT/RPMS/$ARCH/$RPMNAME-$VER-snap*.$ARCH.rpm"
+		xcat_rpmbuild_spec $RPMNAME/$RPMNAME.spec $TARGET --define "version $VER" $REL "$EASE"
 		RC=$?
 		if [ "$RPMNAME" = "xCAT" ]; then
 			files=("bmcsetup" "getipmi")
@@ -202,8 +205,8 @@ function makegenesis {
 	cp $RPMNAME.spec $RPMROOT/SOURCES
 	cd - >/dev/null
 	rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
-	echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$VER-snap*.noarch.rpm $EMBEDTXT..."
-	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec --define "version $VER" $REL "$EASE"
+	xcat_announce_build "$RPMNAME-$VER" "$RPMROOT/RPMS/noarch/$RPMNAME-$VER-snap*.noarch.rpm"
+	xcat_rpmbuild_spec $DIR/$RPMNAME.spec --define "version $VER" $REL "$EASE"
 }
 
 function makegenesisscripts {
@@ -222,8 +225,8 @@ function makegenesisscripts {
 	cp $DIR/$RPMNAME.spec $RPMROOT/SOURCES
 	cd - >/dev/null
 	rm -f $RPMROOT/SRPMS/$RPMNAME-$ARCH-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$ARCH-$VER*rpm
-	echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$ARCH-$VER-snap*.noarch.rpm $EMBEDTXT..."
-	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec $TARGET --define "version $VER" $REL "$EASE"
+	xcat_announce_build "$RPMNAME-$ARCH-$VER" "$RPMROOT/RPMS/noarch/$RPMNAME-$ARCH-$VER-snap*.noarch.rpm"
+	xcat_rpmbuild_spec $DIR/$RPMNAME.spec $TARGET --define "version $VER" $REL "$EASE"
 }
 
 
@@ -260,6 +263,9 @@ if [ "$VERBOSE" = "1" -o "$VERBOSE" = "yes" ];then
 else
 	QUIET="--quiet"
 fi
+if ! xcat_configure_rpm_build_mode "$OSNAME"; then
+	exit 1
+fi
 
 if [ "$OSNAME" = "AIX" ]; then
 	RPMROOT=/opt/freeware/src/packages
@@ -286,6 +292,9 @@ elif [ "$1" = "xCAT-genesis-scripts" ]; then
 	exportEmbed $3
 	makegenesisscripts $1 $2
 elif [ "$1" = "xCAT-OpenStack-ironic" ]; then
+	if ! xcat_require_binary_build "$1"; then
+		exit 1
+	fi
 	makeironic $1 $2
 else	# must be one of the noarch rpms
 	exportEmbed $2

--- a/xCAT-test/unit/buildcore_source_only.t
+++ b/xCAT-test/unit/buildcore_source_only.t
@@ -1,0 +1,199 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use File::Path qw(make_path);
+use File::Slurper qw(write_text);
+use File::Temp qw(tempdir);
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+
+use XCAT::Test::File qw(repo_path);
+
+my $helper = repo_path('build-utils/source-only.sh');
+my $buildcore_helper = repo_path('build-utils/buildcore-source-only.sh');
+plan skip_all => 'source-only build helper not found' unless -r $helper;
+plan skip_all => 'buildcore source-only helper not found' unless -r $buildcore_helper;
+plan skip_all => 'bash not found' unless -x '/bin/bash';
+
+sub _touch {
+    write_text( $_[0], '' );
+}
+
+sub run_helper {
+    my ( $root, $name, $body ) = @_;
+    my $script = "$root/$name.sh";
+    write_text( $script,
+        "#!/bin/bash\nset -e\n. \"$helper\"\n. \"$buildcore_helper\"\n$body\n" );
+    my $output = `/bin/bash "$script" 2>&1`;
+    return ( $output, $? >> 8 );
+}
+
+sub deliver_noarch {
+    my ($source_only) = @_;
+    my $root = tempdir( CLEANUP => 1 );
+    make_path( "$root/rpmbuild/RPMS/noarch", "$root/rpmbuild/SRPMS",
+        "$root/dest", "$root/src" );
+    _touch("$root/rpmbuild/RPMS/noarch/xCAT-server-2.19.0-snap1.noarch.rpm");
+    _touch("$root/rpmbuild/SRPMS/xCAT-server-2.19.0-snap1.src.rpm");
+    _touch("$root/dest/xCAT-server-2.19.0-snap0.noarch.rpm");
+    _touch("$root/src/xCAT-server-2.19.0-snap0.src.rpm");
+
+    my ( $said, $status ) = run_helper( $root, 'deliver-noarch', <<"SH" );
+SRCONLY=$source_only
+source=$root/rpmbuild
+DESTDIR=$root/dest
+SRCDIR=$root/src
+NOARCH=noarch
+VER=2.19.0
+xcat_deliver_noarch_package xCAT-server
+SH
+    return {
+        said      => $said,
+        status    => $status,
+        delivered => [ sort map { s{.*/}{}r } glob("$root/dest/*") ],
+        sources   => [ sort map { s{.*/}{}r } glob("$root/src/*") ],
+        left      => [ sort map { s{.*/}{}r } glob("$root/rpmbuild/RPMS/noarch/*") ],
+    };
+}
+
+sub deliver_arch {
+    my ($source_only) = @_;
+    my $root = tempdir( CLEANUP => 1 );
+    make_path( "$root/rpmbuild/RPMS/riscv64", "$root/rpmbuild/SRPMS",
+        "$root/dest", "$root/src" );
+    _touch("$root/rpmbuild/RPMS/riscv64/xCAT-2.19.0-snap1.riscv64.rpm");
+    _touch("$root/rpmbuild/SRPMS/xCAT-2.19.0-snap1.src.rpm");
+    _touch("$root/dest/xCAT-2-snap0.riscv64.rpm");
+    _touch("$root/src/xCAT-2-snap0.src.rpm");
+
+    my ( $said, $status ) = run_helper( $root, 'deliver-arch', <<"SH" );
+SRCONLY=$source_only
+source=$root/rpmbuild
+DESTDIR=$root/dest
+SRCDIR=$root/src
+VER=2.19.0
+SHORTSHORTVER=2
+xcat_deliver_arch_package xCAT
+SH
+    return {
+        said      => $said,
+        status    => $status,
+        delivered => [ sort map { s{.*/}{}r } glob("$root/dest/*") ],
+        sources   => [ sort map { s{.*/}{}r } glob("$root/src/*") ],
+        left      => [ sort map { s{.*/}{}r } glob("$root/rpmbuild/RPMS/riscv64/*") ],
+    };
+}
+
+sub deliver_tarball {
+    my ($source_only) = @_;
+    my $root = tempdir( CLEANUP => 1 );
+    make_path( "$root/build/xcat-core", "$root/dest" );
+    _touch("$root/build/xcat-core/build-input");
+
+    my ( $said, $status ) = run_helper( $root, 'deliver-tarball', <<"SH" );
+cd "$root/build"
+SRCONLY=$source_only
+TARNAME=xCAT-core-test.tar.bz2
+XCATCORE=xcat-core
+DESTDIR="$root/dest"
+DEST=1
+OSNAME=Linux
+SYSGRP=\$(id -gn)
+verboseflag=
+xcat_create_binary_tarball
+xcat_publish_tarball_link
+SH
+    return {
+        said        => $said,
+        status      => $status,
+        tarball     => -f "$root/build/xCAT-core-test.tar.bz2" ? 1 : 0,
+        link        => -l "$root/xCAT-core-test.tar.bz2" ? 1 : 0,
+        link_target => -l "$root/xCAT-core-test.tar.bz2"
+          ? readlink("$root/xCAT-core-test.tar.bz2") : undef,
+    };
+}
+
+sub deliver_embed_link {
+    my ($source_only) = @_;
+    my $root = tempdir( CLEANUP => 1 );
+    make_path( "$root/core", "$root/stage/embed" );
+    _touch("$root/core/xCAT-server-2.19.0-snap1.noarch.rpm");
+
+    my ( $said, $status ) = run_helper( $root, 'deliver-embed', <<"SH" );
+cd "$root"
+SRCONLY=$source_only
+EMBED=linux
+EMBEDLINK=xCAT-server
+DESTDIR="$root/stage/embed"
+XCATCORE=core
+SHORTSHORTVER=2.19.0
+xcat_deliver_embed_links
+SH
+    my $link = "$root/stage/embed/xCAT-server-2.19.0-snap1.noarch.rpm";
+    return {
+        said        => $said,
+        status      => $status,
+        link        => -l $link ? 1 : 0,
+        link_target => -l $link ? readlink($link) : undef,
+    };
+}
+
+my $normal = deliver_noarch('');
+is( $normal->{status}, 0, 'normal noarch delivery exits cleanly' );
+is_deeply( $normal->{delivered}, ['xCAT-server-2.19.0-snap1.noarch.rpm'],
+    'a normal build replaces the delivered binary package' );
+is_deeply( $normal->{sources}, ['xCAT-server-2.19.0-snap1.src.rpm'],
+    'a normal build replaces the delivered source package' );
+is_deeply( $normal->{left}, [],
+    'a normal build moves the binary package out of the build tree' );
+
+my $source_only = deliver_noarch('1');
+is( $source_only->{status}, 0, 'source-only noarch delivery exits cleanly' );
+is_deeply( $source_only->{delivered}, ['xCAT-server-2.19.0-snap0.noarch.rpm'],
+    'a source-only build keeps the earlier binary package' );
+is_deeply( $source_only->{sources}, ['xCAT-server-2.19.0-snap1.src.rpm'],
+    'a source-only build delivers the new source package' );
+is_deeply( $source_only->{left}, ['xCAT-server-2.19.0-snap1.noarch.rpm'],
+    'a source-only build leaves the binary artifact in the build tree' );
+
+my $normal_arch = deliver_arch('0');
+is( $normal_arch->{status}, 0, 'normal architecture delivery exits cleanly' );
+is_deeply( $normal_arch->{delivered}, ['xCAT-2.19.0-snap1.riscv64.rpm'],
+    'a normal architecture build replaces the delivered binary package' );
+is_deeply( $normal_arch->{sources}, ['xCAT-2.19.0-snap1.src.rpm'],
+    'a normal architecture build replaces the delivered source package' );
+
+my $source_arch = deliver_arch('yes');
+is( $source_arch->{status}, 0, 'source-only architecture delivery exits cleanly' );
+is_deeply( $source_arch->{delivered}, ['xCAT-2-snap0.riscv64.rpm'],
+    'a source-only architecture build keeps the earlier binary package' );
+is_deeply( $source_arch->{sources}, ['xCAT-2.19.0-snap1.src.rpm'],
+    'a source-only architecture build delivers the new source package' );
+
+my $normal_tarball = deliver_tarball('0');
+is( $normal_tarball->{status}, 0, 'normal tarball delivery exits cleanly' );
+ok( $normal_tarball->{tarball}, 'a normal build creates the binary tarball' );
+ok( $normal_tarball->{link}, 'a normal build publishes the tarball link' );
+is( $normal_tarball->{link_target}, 'build/xCAT-core-test.tar.bz2',
+    'the tarball link points to the generated archive' );
+
+my $source_tarball = deliver_tarball('1');
+is( $source_tarball->{status}, 0, 'source-only tarball delivery exits cleanly' );
+ok( !$source_tarball->{tarball}, 'a source-only build creates no binary tarball' );
+ok( !$source_tarball->{link}, 'a source-only build creates no dangling tarball link' );
+like( $source_tarball->{said}, qr/Not creating xCAT-core-test\.tar\.bz2/,
+    'source-only tarball delivery explains the omission' );
+
+my $normal_embed = deliver_embed_link('');
+is( $normal_embed->{status}, 0, 'normal embedded-link delivery exits cleanly' );
+ok( $normal_embed->{link}, 'a normal build publishes the embedded-package link' );
+is( $normal_embed->{link_target}, '../../core/xCAT-server-2.19.0-snap1.noarch.rpm',
+    'the embedded-package link points to the built binary package' );
+
+my $source_embed = deliver_embed_link('1');
+is( $source_embed->{status}, 0, 'source-only embedded-link delivery exits cleanly' );
+ok( !$source_embed->{link}, 'a source-only build creates no embedded-package link' );
+
+done_testing();

--- a/xCAT-test/unit/buildcore_source_only.t
+++ b/xCAT-test/unit/buildcore_source_only.t
@@ -86,6 +86,32 @@ SH
     };
 }
 
+sub deliver_genesis {
+    my ($source_only) = @_;
+    my $root = tempdir( CLEANUP => 1 );
+    make_path( "$root/rpmbuild/RPMS/noarch", "$root/rpmbuild/SRPMS",
+        "$root/dest", "$root/src" );
+    for my $arch (qw(x86_64 ppc64)) {
+        _touch("$root/rpmbuild/RPMS/noarch/xCAT-genesis-scripts-$arch-2.19.0-snap1.noarch.rpm");
+        _touch("$root/rpmbuild/SRPMS/xCAT-genesis-scripts-$arch-2.19.0-snap1.src.rpm");
+        _touch("$root/src/xCAT-genesis-scripts-$arch-2.19.0-snap0.src.rpm");
+    }
+
+    my ( $said, $status ) = run_helper( $root, 'deliver-genesis', <<"SH" );
+SRCONLY=$source_only
+source=$root/rpmbuild
+DESTDIR=$root/dest
+SRCDIR=$root/src
+xcat_deliver_genesis_packages
+SH
+    return {
+        said      => $said,
+        status    => $status,
+        delivered => [ sort map { s{.*/}{}r } glob("$root/dest/*") ],
+        sources   => [ sort map { s{.*/}{}r } glob("$root/src/*") ],
+    };
+}
+
 sub deliver_tarball {
     my ($source_only) = @_;
     my $root = tempdir( CLEANUP => 1 );
@@ -172,6 +198,20 @@ is_deeply( $source_arch->{delivered}, ['xCAT-2-snap0.riscv64.rpm'],
 is_deeply( $source_arch->{sources}, ['xCAT-2.19.0-snap1.src.rpm'],
     'a source-only architecture build delivers the new source package' );
 
+my $source_genesis = deliver_genesis('1');
+is( $source_genesis->{status}, 0,
+    'source-only Genesis delivery exits cleanly' );
+is_deeply( $source_genesis->{delivered}, [],
+    'source-only Genesis delivery publishes no binary packages' );
+is_deeply(
+    $source_genesis->{sources},
+    [
+        'xCAT-genesis-scripts-ppc64-2.19.0-snap1.src.rpm',
+        'xCAT-genesis-scripts-x86_64-2.19.0-snap1.src.rpm',
+    ],
+    'source-only delivery preserves both architecture-specific Genesis SRPMs',
+);
+
 my $normal_tarball = deliver_tarball('0');
 is( $normal_tarball->{status}, 0, 'normal tarball delivery exits cleanly' );
 ok( $normal_tarball->{tarball}, 'a normal build creates the binary tarball' );
@@ -195,5 +235,27 @@ is( $normal_embed->{link_target}, '../../core/xCAT-server-2.19.0-snap1.noarch.rp
 my $source_embed = deliver_embed_link('1');
 is( $source_embed->{status}, 0, 'source-only embedded-link delivery exits cleanly' );
 ok( !$source_embed->{link}, 'a source-only build creates no embedded-package link' );
+
+my ( $binary_arches, $binary_arches_status ) = run_helper(
+    tempdir( CLEANUP => 1 ),
+    'binary-arches',
+    "SRCONLY=0\nxcat_rpm_build_arches x86_64 ppc64 ppc64le s390x aarch64\n",
+);
+is( $binary_arches_status, 0, 'normal architecture selection exits cleanly' );
+is(
+    $binary_arches,
+    "x86_64\nppc64\nppc64le\ns390x\naarch64\n",
+    'a binary build keeps every target architecture',
+);
+
+my ( $source_xcat_arches, $source_xcat_arches_status ) = run_helper(
+    tempdir( CLEANUP => 1 ),
+    'source-arches',
+    "SRCONLY=true\nxcat_rpm_build_arches x86_64 ppc64 ppc64le s390x aarch64\n",
+);
+is( $source_xcat_arches_status, 0,
+    'source architecture selection exits cleanly' );
+is( $source_xcat_arches, "x86_64\n",
+    'a source-only xCAT or xCATsn build creates its target-independent SRPM once' );
 
 done_testing();

--- a/xCAT-test/unit/buildcore_source_only.t
+++ b/xCAT-test/unit/buildcore_source_only.t
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 use File::Path qw(make_path);
-use File::Slurper qw(write_text);
+use File::Slurper qw(read_text write_text);
 use File::Temp qw(tempdir);
 use FindBin;
 use lib "$FindBin::Bin/../lib";
@@ -257,5 +257,76 @@ is( $source_xcat_arches_status, 0,
     'source architecture selection exits cleanly' );
 is( $source_xcat_arches, "x86_64\n",
     'a source-only xCAT or xCATsn build creates its target-independent SRPM once' );
+
+sub finalized_repositories {
+    my ($source_only) = @_;
+    my $root = tempdir( CLEANUP => 1 );
+    make_path( "$root/binary", "$root/source" );
+    my ( $output, $status ) = run_helper( $root, 'repositories', <<"SH" );
+function createrepo {
+    printf 'indexed %s\n' "\$1"
+}
+SRCONLY=$source_only
+RPMSIGN=0
+xcat_finalize_repository binary "$root/binary"
+xcat_finalize_repository source "$root/source"
+SH
+    return ( $output, $status, $root );
+}
+
+my ( $binary_repositories, $binary_repositories_status, $binary_root ) =
+  finalized_repositories('0');
+is( $binary_repositories_status, 0, 'normal repository finalization exits cleanly' );
+is(
+    $binary_repositories,
+    "indexed $binary_root/binary\nindexed $binary_root/source\n",
+    'a normal build refreshes both binary and source repositories',
+);
+
+my ( $source_repositories, $source_repositories_status, $source_root ) =
+  finalized_repositories('1');
+is( $source_repositories_status, 0, 'source repository finalization exits cleanly' );
+is(
+    $source_repositories,
+    "indexed $source_root/source\n",
+    'a source-only build refreshes only the source repository',
+);
+
+sub write_buildinfo {
+    my ($source_only) = @_;
+    my $root = tempdir( CLEANUP => 1 );
+    my $buildinfo = "$root/buildinfo";
+    write_text( $buildinfo, "previous binary build\n" );
+    my ( $output, $status ) = run_helper( $root, 'buildinfo', <<"SH" );
+SRCONLY=$source_only
+VER=2.19.0
+XCAT_RELEASE=snap1
+BUILD_TIME=2026-08-26T12:00:00Z
+BUILD_MACHINE=builder.example.test
+COMMIT_ID=abc123
+COMMIT_ID_LONG=abc123def456
+xcat_write_binary_buildinfo "$buildinfo"
+SH
+    return ( $output, $status, read_text($buildinfo) );
+}
+
+my ( $binary_buildinfo_output, $binary_buildinfo_status, $binary_buildinfo ) =
+  write_buildinfo('0');
+is( $binary_buildinfo_status, 0, 'normal buildinfo generation exits cleanly' );
+is( $binary_buildinfo_output, '', 'normal buildinfo generation is quiet' );
+is(
+    $binary_buildinfo,
+    "VERSION=2.19.0\nRELEASE=snap1\nBUILD_TIME=2026-08-26T12:00:00Z\n"
+      . "BUILD_MACHINE=builder.example.test\nCOMMIT_ID=abc123\nCOMMIT_ID_LONG=abc123def456\n",
+    'a normal build describes the newly built binary bundle',
+);
+
+my ( $source_buildinfo_output, $source_buildinfo_status, $source_buildinfo ) =
+  write_buildinfo('yes');
+is( $source_buildinfo_status, 0, 'source-only buildinfo handling exits cleanly' );
+like( $source_buildinfo_output, qr/source-only build makes no binary bundle/,
+    'source-only buildinfo handling explains the omission' );
+is( $source_buildinfo, "previous binary build\n",
+    'a source-only build leaves the previous binary buildinfo untouched' );
 
 done_testing();

--- a/xCAT-test/unit/makerpm_source_only.t
+++ b/xCAT-test/unit/makerpm_source_only.t
@@ -1,0 +1,116 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use File::Slurper qw(write_text);
+use File::Temp qw(tempdir);
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+
+use XCAT::Test::File qw(repo_path);
+
+my $helper = repo_path('build-utils/source-only.sh');
+plan skip_all => 'source-only build helper not found' unless -r $helper;
+plan skip_all => 'bash not found' unless -x '/bin/bash';
+
+my $dir = tempdir( CLEANUP => 1 );
+my $sequence = 0;
+
+sub run_shell {
+    my ($body) = @_;
+    my $script = "$dir/run-" . ++$sequence . '.sh';
+    write_text( $script, "#!/bin/bash\nset -e\n. \"$helper\"\n$body\n" );
+    my $output = `/bin/bash "$script" 2>&1`;
+    return ( $output, $? >> 8 );
+}
+
+my @modes = (
+    [ 'unset',       'unset SRCONLY', '-ba -ta' ],
+    [ 'empty',       'SRCONLY=',      '-ba -ta' ],
+    [ 'SRCONLY=0',   'SRCONLY=0',     '-ba -ta' ],
+    [ 'SRCONLY=no',  'SRCONLY=no',    '-ba -ta' ],
+    [ 'SRCONLY=1',   'SRCONLY=1',     '-bs -ts' ],
+    [ 'SRCONLY=yes', 'SRCONLY=yes',   '-bs -ts' ],
+);
+foreach my $case (@modes) {
+    my ( $name, $assignment, $expected ) = @{$case};
+    my ( $got, $rc ) = run_shell(<<"SH");
+$assignment
+xcat_configure_rpm_build_mode Linux
+echo "\$SPECBUILD \$TARBUILD"
+SH
+    chomp $got;
+    is( $got, $expected, "$name selects '$expected'" );
+    is( $rc, 0, "$name exits cleanly" );
+}
+
+my ( $aix, $aix_rc ) = run_shell(<<'SH');
+SRCONLY=1
+xcat_configure_rpm_build_mode AIX
+SH
+isnt( $aix_rc, 0, 'a source-only build on AIX stops with an error' );
+like( $aix, qr/not supported on AIX/, 'the error names AIX' );
+
+my ( $aix_default, $aix_default_rc ) = run_shell(<<'SH');
+unset SRCONLY
+xcat_configure_rpm_build_mode AIX
+echo "$SPECBUILD $TARBUILD"
+SH
+is( $aix_default_rc, 0, 'a normal build on AIX is unchanged' );
+like( $aix_default, qr/^-ba -ta$/m, 'a normal AIX build keeps its flags' );
+
+my ( $binary_message, undef ) = run_shell(<<'SH');
+SPECBUILD=-ba
+RPMROOT=/build
+EMBEDTXT=
+xcat_announce_build xCAT-server-2.19.0 /build/RPMS/noarch/xCAT-server-2.19.0-snap\*.noarch.rpm
+SH
+like( $binary_message, qr{/build/RPMS/noarch/xCAT-server-2\.19\.0-snap\*\.noarch\.rpm},
+    'a normal build names the binary package' );
+unlike( $binary_message, qr/src\.rpm/, 'a normal build names no source package' );
+
+my ( $source_message, undef ) = run_shell(<<'SH');
+SPECBUILD=-bs
+RPMROOT=/build
+EMBEDTXT=
+xcat_announce_build xCAT-server-2.19.0 /build/RPMS/noarch/xCAT-server-2.19.0-snap\*.noarch.rpm
+SH
+like( $source_message, qr{/build/SRPMS/xCAT-server-2\.19\.0-snap\*\.src\.rpm},
+    'a source-only build names the source package' );
+unlike( $source_message, qr{RPMS/noarch}, 'a source-only build names no binary package' );
+
+my ( $build_calls, $build_calls_rc ) = run_shell(<<'SH');
+function rpmbuild {
+    printf 'rpmbuild'
+    printf ' <%s>' "$@"
+    printf '\n'
+}
+QUIET=--quiet
+SRCONLY=1
+xcat_configure_rpm_build_mode Linux
+xcat_rpmbuild_spec package.spec --target riscv64 --define 'version 2.19.0'
+xcat_rpmbuild_tar package.tar.gz --define 'version 2.19.0'
+SH
+is( $build_calls_rc, 0, 'source-only rpm wrappers exit cleanly' );
+like( $build_calls, qr/^rpmbuild <--quiet> <-bs> <package\.spec>/m,
+    'spec builds receive the source-only mode' );
+like( $build_calls, qr/^rpmbuild <--quiet> <-ts> <package\.tar\.gz>/m,
+    'tar builds receive the source-only mode' );
+unlike( $build_calls, qr/<-ba>|<-ta>/, 'source-only wrappers pass no binary mode' );
+
+my ( $ironic, $ironic_rc ) = run_shell(<<'SH');
+SRCONLY=1
+xcat_require_binary_build xCAT-OpenStack-ironic
+SH
+isnt( $ironic_rc, 0, 'the ironic package refuses source-only mode' );
+like( $ironic, qr/not supported for xCAT-OpenStack-ironic/,
+    'the ironic error names the package' );
+
+my ( undef, $ironic_normal_rc ) = run_shell(<<'SH');
+SRCONLY=0
+xcat_require_binary_build xCAT-OpenStack-ironic
+SH
+is( $ironic_normal_rc, 0, 'the ironic package still accepts a normal build' );
+
+done_testing();

--- a/xCAT-test/unit/makerpm_source_only.t
+++ b/xCAT-test/unit/makerpm_source_only.t
@@ -2,7 +2,10 @@
 use strict;
 use warnings;
 
+use Cwd qw(getcwd);
+use File::Path qw(make_path);
 use File::Slurper qw(write_text);
+use File::Spec;
 use File::Temp qw(tempdir);
 use FindBin;
 use lib "$FindBin::Bin/../lib";
@@ -11,6 +14,7 @@ use Test::More;
 use XCAT::Test::File qw(repo_path);
 
 my $helper = repo_path('build-utils/source-only.sh');
+my $makerpm = repo_path('makerpm');
 plan skip_all => 'source-only build helper not found' unless -r $helper;
 plan skip_all => 'bash not found' unless -x '/bin/bash';
 
@@ -113,5 +117,52 @@ SRCONLY=0
 xcat_require_binary_build xCAT-OpenStack-ironic
 SH
 is( $ironic_normal_rc, 0, 'the ironic package still accepts a normal build' );
+
+my $makerpm_root = tempdir( CLEANUP => 1 );
+my $makerpm_bin = File::Spec->catdir( $makerpm_root, 'bin' );
+my $rpm_root = File::Spec->catdir( $makerpm_root, 'rpmbuild' );
+my $rpmbuild_log = File::Spec->catfile( $makerpm_root, 'rpmbuild.log' );
+make_path( $makerpm_bin, map { File::Spec->catdir( $rpm_root, $_ ) }
+    qw(SOURCES SRPMS RPMS BUILD) );
+my $fake_rpmbuild = File::Spec->catfile( $makerpm_bin, 'rpmbuild' );
+write_text( $fake_rpmbuild, <<'SH' );
+#!/bin/sh
+case "$1" in
+    --version) exit 0 ;;
+    --eval) printf '%s\n' "$XCAT_TEST_RPMROOT"; exit 0 ;;
+esac
+printf '%s\n' "$*" >>"$XCAT_TEST_RPMBUILD_LOG"
+exit 0
+SH
+chmod 0755, $fake_rpmbuild
+  or die "Unable to make $fake_rpmbuild executable: $!";
+
+my $original_directory = getcwd();
+my $repository_root = File::Spec->catdir( $FindBin::Bin, '..', '..' );
+chdir($repository_root) or die "Unable to enter $repository_root: $!";
+my $makerpm_status;
+{
+    local %ENV = (
+        %ENV,
+        PATH                    => "$makerpm_bin:$ENV{PATH}",
+        SRCONLY                 => 1,
+        XCATVER                 => '2.19.0',
+        XCAT_TEST_RPMROOT       => $rpm_root,
+        XCAT_TEST_RPMBUILD_LOG  => $rpmbuild_log,
+    );
+    $makerpm_status = system( $makerpm, 'perl-xCAT' ) >> 8;
+}
+chdir($original_directory)
+  or die "Unable to return to $original_directory: $!";
+is( $makerpm_status, 0,
+    'the real makerpm caller completes a source-only tar build' );
+open( my $rpmbuild_fh, '<', $rpmbuild_log )
+  or die "Unable to read $rpmbuild_log: $!";
+my $rpmbuild_arguments = do { local $/; <$rpmbuild_fh> };
+close($rpmbuild_fh);
+like( $rpmbuild_arguments, qr/(?:^|\s)-ts(?:\s|$)/m,
+    'the real makerpm caller passes the source-only tar mode to rpmbuild' );
+unlike( $rpmbuild_arguments, qr/(?:^|\s)-ta(?:\s|$)/m,
+    'the real makerpm caller does not request a binary tar build' );
 
 done_testing();

--- a/xCAT-test/unit/makerpm_source_only.t
+++ b/xCAT-test/unit/makerpm_source_only.t
@@ -32,6 +32,7 @@ my @modes = (
     [ 'SRCONLY=no',  'SRCONLY=no',    '-ba -ta' ],
     [ 'SRCONLY=1',   'SRCONLY=1',     '-bs -ts' ],
     [ 'SRCONLY=yes', 'SRCONLY=yes',   '-bs -ts' ],
+    [ 'SRCONLY=true', 'SRCONLY=true', '-bs -ts' ],
 );
 foreach my $case (@modes) {
     my ( $name, $assignment, $expected ) = @{$case};


### PR DESCRIPTION
There is no way to build just the source rpms today. A source rpm is what a
build service takes: mock, koji, COPR and OBS each build the binaries
themselves from one. rpmbuild also does not need the BuildRequires packages
installed to make a source rpm, so a machine that cannot finish a build can
still produce one for a machine that can.

Set SRCONLY to build them:

    ./buildcore.sh SRCONLY=1

The default is unchanged. In this mode buildcore.sh delivers no binary rpms,
does not build the binary tarball, and does not publish the binary repository
or the tarball when uploading with UP=1. The binary repository is synced with
rsync --delete, so publishing a source-only build would remove the rpms that
are already there. Source rpms are still delivered and uploaded.

SRCONLY is refused for AIX and for the ironic package, which build with rpm and
with setup.py rather than with rpmbuild, so the mode cannot reach them.

Recovered from the lenovobuild branch, reimplemented: the original enables the
mode when SRCONLY=0, leaves the build messages naming binary rpms it does not
produce, and does not touch buildcore.sh.
