### PR TITLE
fix(debian): declare HTML::Form runtime dependency

### DIFF
--- a/perl-xCAT/debian/control
+++ b/perl-xCAT/debian/control
@@ -8,7 +8,7 @@ Homepage: https://xcat.org/
 
 Package: perl-xcat
 Architecture: all
-Depends: ${perl:Depends}
+Depends: ${perl:Depends}, libhtml-form-perl
 Description: xCAT perl libraries
  Provides perl xCAT libraries for core functionality.  Required for all xCAT installations.
  Includes xCAT::Table, xCAT::NodeRange, among others.

--- a/xCAT-test/autotest/testcase/integration/cases0
+++ b/xCAT-test/autotest/testcase/integration/cases0
@@ -4,5 +4,5 @@ os:Linux
 label:mn_only,ci_test,integration
 cmd:prove -I/opt/xcat/lib/perl -I/opt/xcat/lib/perl/xCAT -r /opt/xcat/share/xcat/tools/autotest/integration
 check:rc==0
-check:output=~Files=3
+check:output=~Files=4
 end

--- a/xCAT-test/integration/README.md
+++ b/xCAT-test/integration/README.md
@@ -27,10 +27,10 @@ against it.
 Note the `-I` flags: unlike the unit tests these run from the installed location, so
 they pick up xCAT modules from `/opt/xcat/lib/perl` rather than from a source tree.
 
-The case checks `rc==0` and `output=~Files=3`. The second assertion is there because
+The case checks `rc==0` and `output=~Files=4`. The second assertion is there because
 `prove` exits 0 both when tests pass and when they all skip, so `rc==0` alone would let
-the case report green having run nothing. Matching `Files=3` proves `prove` actually
-found all three files, which catches a packaging regression or a file being renamed
+the case report green having run nothing. Matching `Files=4` proves `prove` actually
+found all four files, which catches a packaging regression or a file being renamed
 without the count being updated here. **Add to that number when you add a test.** A
 missing directory is already caught by `rc==0` -- `prove -r` on a path that does not
 exist exits 2.

--- a/xCAT-test/integration/html_form_runtime_dependency.t
+++ b/xCAT-test/integration/html_form_runtime_dependency.t
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Test::More;
+
+require_ok('HTML::Form');
+
+my ($form) = HTML::Form->parse(
+    '<form method="post"><input name="user" value="admin"></form>',
+    'http://example.invalid/'
+);
+
+isa_ok($form, 'HTML::Form');
+is($form->value('user'), 'admin', 'HTML form fields can be parsed');
+
+done_testing();


### PR DESCRIPTION
`xCAT::PPCfsp` loads `HTML::Form`, but the Debian `perl-xcat` package does not declare `libhtml-form-perl`. Installations where recommended packages were not pulled in can therefore fail while loading FSP support.

Declare the module as a direct runtime dependency and add an installed-package integration test that exercises form parsing.

Verified with a clean Ubuntu 24.04 package build and installation: APT installed `libhtml-form-perl`, the form parsing check passed, and the test is present in the built `xcat-test` package.