### PR TITLE
fix(rflash): show NeXtScale FPC URL syntax

### DIFF
--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -415,6 +415,8 @@ my %usage = (
 	rflash <noderange> -p <rpm_directory> [--activate {disruptive|deferred}] [-d <data_directory>]
 	rflash <noderange> [--commit | --recover]
         rflash <noderange> [--bpa_acdl]
+    NeXtScale FPC specific:
+        rflash <noderange> http://<server>/path/to/update.rom
     OpenPOWER BMC specific (using IPMI):
         rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>]
         rflash <noderange> --recover <bmc_file_path>

--- a/xCAT-test/unit/rflash_usage.t
+++ b/xCAT-test/unit/rflash_usage.t
@@ -1,0 +1,34 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/../../perl-xCAT";
+use Test::More;
+
+BEGIN {
+    package xCAT::Utils;
+    sub Version { return 'test'; }
+}
+
+{
+    local $INC{'xCAT/Utils.pm'} = __FILE__;
+    require xCAT::Usage;
+}
+
+my $usage = xCAT::Usage->parseCommand( 'rflash', '--help' );
+
+like( $usage, qr/\QNeXtScale FPC specific:\E/x,
+    'rflash help identifies the NeXtScale FPC form' );
+like(
+    $usage,
+    qr{\Qrflash <noderange> http://<server>/path/to/update.rom\E}x,
+    'rflash help gives the complete FPC firmware URL syntax'
+);
+
+like( $usage, qr/\QPPC (using Direct FSP Management) specific:\E/x,
+    'rflash help retains the Direct FSP form' );
+like( $usage, qr/\QOpenPOWER BMC specific (using IPMI):\E/x,
+    'rflash help retains the OpenPOWER IPMI form' );
+
+done_testing();


### PR DESCRIPTION
`rflash` already supports firmware updates for NeXtScale FPC nodes, and its man page documents the required HTTP URL. The shorter `rflash --help` output omitted this hardware-specific form.

Add the FPC syntax to the existing hardware-specific usage block and cover the rendered help through `xCAT::Usage->parseCommand`. The regression test also confirms that the adjacent Direct FSP and OpenPOWER forms remain present.

Recovered from [`340d7072d6`](https://github.com/xcat2/xcat-core/commit/340d7072d6f444be9c9f46fce63637e4d1375845), originally authored by Jarrod Johnson.