### PR TITLE
test(build): stage the source-only helper in the makerpm fixture

### DIFF
--- a/xCAT-test/unit/apache_config_sources.t
+++ b/xCAT-test/unit/apache_config_sources.t
@@ -320,6 +320,9 @@ sub stage_makerpm_fixture {
     chmod 0755,
       File::Spec->catfile( $root, 'build-utils', 'sync-xcat-apache-configs' )
       or die "Unable to make the Apache configuration helper executable: $!";
+    copy( repo_path('build-utils/source-only.sh'),
+        File::Spec->catfile( $root, 'build-utils', 'source-only.sh' ) )
+      or die "Unable to stage the source-only build helper: $!";
     write_text( File::Spec->catfile( $root, 'xCAT', 'xcat.conf' ),
         "canonical apache22\n" );
     write_text( File::Spec->catfile( $root, 'xCAT', 'xcat.conf.apach24' ),


### PR DESCRIPTION
`makerpm` sources `build-utils/source-only.sh` since #7774, but the legacy RPM builder fixture in `apache_config_sources.t` stages `makerpm` without it. The staged script fails at line 13, so the test fails on master and blocks CI for every open pull request. The two changes were green on their own branches and only conflict once merged.

The fixture now stages `source-only.sh` next to the sync helper it already copies.