### PR TITLE
test(httpd): stage the source-only helper in the RPM builder fixture

### DIFF
--- a/xCAT-test/unit/apache_config_sources.t
+++ b/xCAT-test/unit/apache_config_sources.t
@@ -320,6 +320,9 @@ sub stage_makerpm_fixture {
     chmod 0755,
       File::Spec->catfile( $root, 'build-utils', 'sync-xcat-apache-configs' )
       or die "Unable to make the Apache configuration helper executable: $!";
+    copy( repo_path('build-utils/source-only.sh'),
+        File::Spec->catfile( $root, 'build-utils', 'source-only.sh' ) )
+      or die "Unable to stage the source-only helper: $!";
     write_text( File::Spec->catfile( $root, 'xCAT', 'xcat.conf' ),
         "canonical apache22\n" );
     write_text( File::Spec->catfile( $root, 'xCAT', 'xcat.conf.apach24' ),


### PR DESCRIPTION
`xCAT-test/unit/apache_config_sources.t` fails on master, so every pull request
that merges with it reports a red unit suite. `stage_makerpm_fixture` copies
`makerpm` into a partial tree but stages only
`build-utils/sync-xcat-apache-configs`. `makerpm` also sources
`build-utils/source-only.sh`, so the staged copy dies before it configures the
build mode and never reaches `rpmbuild`. The test arrived before `makerpm`
sourced that helper, and the helper arrived without the fixture that stages it,
so each change passed on its own branch.

Stage the helper alongside the one already staged. It is sourced rather than
executed, so it needs no mode change, and `makerpm` reads no other file from
`build-utils`.