### PR TITLE
refactor(netboot): centralize volatile kernel arguments

### DIFF
--- a/perl-xCAT/xCAT/BootUtils.pm
+++ b/perl-xCAT/xCAT/BootUtils.pm
@@ -1,0 +1,18 @@
+# IBM(c) 2026 EPL license http://www.eclipse.org/legal/epl-v10.html
+package xCAT::BootUtils;
+
+use strict;
+use warnings;
+
+use xCAT::Utils;
+
+sub volatile_addkcmdline {
+    my ($kcmdline) = @_;
+
+    return $kcmdline unless $kcmdline;
+
+    my $cmdhashref = xCAT::Utils->splitkcmdline($kcmdline);
+    return $cmdhashref->{volatile} // '';
+}
+
+1;

--- a/xCAT-server/lib/xcat/plugins/pxe.pm
+++ b/xCAT-server/lib/xcat/plugins/pxe.pm
@@ -9,6 +9,7 @@ use File::Copy;
 use File::Path;
 use Getopt::Long;
 require xCAT::Utils;
+require xCAT::BootUtils;
 require xCAT::TableUtils;
 use xCAT::ServiceNodeUtils;
 my $dhcpconf      = "/etc/dhcpd.conf";
@@ -114,16 +115,7 @@ sub setstate {
 
         my $kcmdlinehack = ($imgaddkcmdline) ? $kern->{addkcmdline} . " " . $imgaddkcmdline : $kern->{addkcmdline};
 
-        my $cmdhashref;
-        if ($kcmdlinehack) {
-            $cmdhashref = xCAT::Utils->splitkcmdline($kcmdlinehack);
-        }
-
-        if ($cmdhashref) {
-            # Use only volatile options for netboot; persistent (R::) options
-            # are handled separately for the installed OS via PERSKCMDLINE
-            $kcmdlinehack = $cmdhashref->{volatile} // "";
-        }
+        $kcmdlinehack = xCAT::BootUtils::volatile_addkcmdline($kcmdlinehack);
 
 
         while ($kcmdlinehack =~ /#NODEATTRIB:([^:#]+):([^:#]+)#/) {

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -9,6 +9,7 @@ use xCAT::Scope;
 use xCAT::MsgUtils;
 use Getopt::Long;
 use xCAT::Utils;
+require xCAT::BootUtils;
 use xCAT::TableUtils;
 use xCAT::ServiceNodeUtils;
 use xCAT::Usage;
@@ -190,16 +191,7 @@ sub setstate {
 
             my $kcmdlinehack = ($imgaddkcmdline) ? $kern->{addkcmdline} . " " . $imgaddkcmdline : $kern->{addkcmdline};
 
-            my $cmdhashref;
-            if ($kcmdlinehack) {
-                $cmdhashref = xCAT::Utils->splitkcmdline($kcmdlinehack);
-            }
-
-            if ($cmdhashref) {
-                # Use only volatile options for netboot; persistent (R::) options
-                # are handled separately for the installed OS via PERSKCMDLINE
-                $kcmdlinehack = $cmdhashref->{volatile} // "";
-            }
+            $kcmdlinehack = xCAT::BootUtils::volatile_addkcmdline($kcmdlinehack);
 
 
             while ($kcmdlinehack =~ /#NODEATTRIB:([^:#]+):([^:#]+)#/) {

--- a/xCAT-test/unit/boot_utils.t
+++ b/xCAT-test/unit/boot_utils.t
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/../../perl-xCAT";
+
+use Test::More;
+
+use xCAT::BootUtils;
+
+my @cases = (
+    [ undef, undef, 'undefined input remains undefined' ],
+    [ '', '', 'empty input remains empty' ],
+    [ '0', '0', 'false string input remains unchanged' ],
+    [ 'console=ttyS0 quiet', 'console=ttyS0 quiet ', 'volatile options are retained' ],
+    [ 'R::root=/dev/sda R::console=ttyS0', '', 'persistent-only options are omitted' ],
+    [
+        'console=ttyS0 R::root=/dev/sda quiet',
+        'console=ttyS0 quiet ',
+        'persistent options are omitted from mixed input'
+    ],
+    [
+        'first R::persist=1 second R::last=1 third',
+        'first second third ',
+        'volatile option ordering is preserved'
+    ],
+);
+
+for my $case (@cases) {
+    my ($input, $expected, $description) = @{$case};
+    is( xCAT::BootUtils::volatile_addkcmdline($input), $expected, $description );
+}
+
+my $original = 'first R::persist=1 second';
+is( xCAT::BootUtils::volatile_addkcmdline($original), 'first second ', 'the normalized value is returned' );
+is( $original, 'first R::persist=1 second', 'the caller value is not modified' );
+
+done_testing();


### PR DESCRIPTION
Centralize the volatile addkcmdline selection shared by the PXE and xNBA boot paths.

The new boot helper preserves the existing R:: split, ordering, and empty-value behavior while keeping persistent arguments out of generated netboot command lines.