### PR TITLE
fix(debian): declare the perl modules and tools the Ubuntu packages need

### DIFF
--- a/perl-xCAT/debian/control
+++ b/perl-xCAT/debian/control
@@ -8,7 +8,7 @@ Homepage: https://xcat.org/
 
 Package: perl-xcat
 Architecture: all
-Depends: ${perl:Depends}, libhtml-form-perl
+Depends: ${perl:Depends}, libhtml-form-perl, libxml-simple-perl, libxml-parser-perl, libio-socket-ssl-perl, libdbi-perl, libjson-perl, libwww-perl, libxml-libxml-perl, libexpect-perl, libsnmp-perl, libsocket6-perl, libio-socket-inet6-perl
 Description: xCAT perl libraries
  Provides perl xCAT libraries for core functionality.  Required for all xCAT installations.
  Includes xCAT::Table, xCAT::NodeRange, among others.

--- a/xCAT-client/debian/control
+++ b/xCAT-client/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.4
 
 Package: xcat-client
 Architecture: all
-Depends: ${perl:Depends}, perl-xcat (>= 2.13-snap000000000000)
+Depends: ${perl:Depends}, perl-xcat (>= 2.13-snap000000000000), libcapture-tiny-perl
 Recommends: libsort-versions-perl, nmap
 Description: Core executables and data of the xCAT management project
  xCAT-client provides the fundamental xCAT commands (chtab, chnode, rpower,

--- a/xCAT-client/debian/control
+++ b/xCAT-client/debian/control
@@ -7,8 +7,8 @@ Standards-Version: 3.9.4
 
 Package: xcat-client
 Architecture: all
-Depends: ${perl:Depends}, perl-xcat (>= 2.13-snap000000000000), libcapture-tiny-perl
-Recommends: libsort-versions-perl, nmap
+Depends: ${perl:Depends}, perl-xcat (>= 2.13-snap000000000000), libcapture-tiny-perl, nmap
+Recommends: libsort-versions-perl
 Description: Core executables and data of the xCAT management project
  xCAT-client provides the fundamental xCAT commands (chtab, chnode, rpower,
  etc) helpful in administrating systems at scale, with particular attention

--- a/xCAT-server/debian/control
+++ b/xCAT-server/debian/control
@@ -8,7 +8,7 @@ Homepage: https://xcat.org/
 
 Package: xcat-server
 Architecture: all
-Depends: ${perl:Depends}, grub-common, grub2-xcat (>= 2.02-0.76.el7.1.snap201905160255), perl-xcat (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libsys-syslog-perl, libio-socket-ssl-perl, libxml-simple-perl, make, ucf, libdbd-sqlite3-perl, libexpect-perl, libnet-dns-perl, libsoap-lite-perl, libxml-libxml-perl, libsnmp-perl, debootstrap, libdigest-sha-perl,libcrypt-rijndael-perl,libcrypt-cbc-perl,libjson-perl, libnet-https-nb-perl, libhttp-async-perl
+Depends: ${perl:Depends}, grub-common, libcgi-pm-perl, grub2-xcat (>= 2.02-0.76.el7.1.snap201905160255), perl-xcat (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libsys-syslog-perl, libio-socket-ssl-perl, libxml-simple-perl, make, ucf, libdbd-sqlite3-perl, libexpect-perl, libnet-dns-perl, libsoap-lite-perl, libxml-libxml-perl, libsnmp-perl, debootstrap, libdigest-sha-perl,libcrypt-rijndael-perl,libcrypt-cbc-perl,libjson-perl, libnet-https-nb-perl, libhttp-async-perl
 Description: Server and configuration utilities of xCAT
  xCAT-server provides the core server and configuration management components
  of xCAT.

--- a/xCAT-test/unit/debian_control_declarations.t
+++ b/xCAT-test/unit/debian_control_declarations.t
@@ -1,0 +1,73 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use File::Spec;
+use FindBin;
+use Test::More;
+
+# dh_perl adds no module dependencies, unlike the rpm generator, so a deb declares only what its
+# control file names. perl-xcat declared libhtml-form-perl alone while its files load nine other
+# modules at top level, xcat-server shipped the REST API without CGI, xcat-client ships z/VM
+# helpers that load Capture::Tiny, and nmap and ipmitool-xcat were recommendations where the rpm
+# packages require them.
+
+my $repo_root = File::Spec->rel2abs( File::Spec->catdir( $FindBin::Bin, '..', '..' ) );
+
+# The relation fields of one binary package stanza as sets of package names, plus the version
+# bound of each relation that has one.
+sub relations_of {
+    my ( $source, $package ) = @_;
+    my $file = File::Spec->catfile( $repo_root, $source, 'debian', 'control' );
+    open( my $fh, '<', $file ) or die "Unable to read $file: $!";
+    my $control = do { local $/; <$fh> };
+    close($fh);
+    my ($stanza) = $control =~ /^Package:\s*\Q$package\E\s*\n(.*?)(?:\n\n|\z)/ms;
+    die "no stanza for $package in $file" unless defined $stanza;
+    my %rel;
+    foreach my $field (qw(Depends Recommends)) {
+        my ($line) = $stanza =~ /^$field:\s*(.*)$/m;
+        foreach my $entry ( split( /[,|]/, $line // '' ) ) {
+            my ( $name, $bound ) = $entry =~ /^\s*(\S+?)\s*(?:\(([^)]*)\))?\s*(?:\[[^\]]*\])?\s*$/;
+            next unless defined $name;
+            $rel{$field}{$name} = 1;
+            $rel{version}{$name} = $bound if defined $bound;
+        }
+    }
+    return \%rel;
+}
+
+sub depends_on {
+    my ( $rel, $name, $label ) = @_;
+    ok( $rel->{Depends}{$name}, "$label depends on $name" );
+    ok( !$rel->{Recommends}{$name}, "... and no longer only recommends it" ) if $rel->{Recommends}{$name};
+}
+
+my $perl_xcat = relations_of( 'perl-xCAT', 'perl-xcat' );
+depends_on( $perl_xcat, $_, 'perl-xcat' ) for qw(
+    libhtml-form-perl libxml-simple-perl libxml-parser-perl libio-socket-ssl-perl libdbi-perl libjson-perl
+    libwww-perl libxml-libxml-perl libexpect-perl libsnmp-perl libsocket6-perl libio-socket-inet6-perl
+);
+
+my $client = relations_of( 'xCAT-client', 'xcat-client' );
+depends_on( $client, 'libcapture-tiny-perl', 'xcat-client' );
+
+my $server = relations_of( 'xCAT-server', 'xcat-server' );
+depends_on( $server, 'libcgi-pm-perl', 'xcat-server' );
+
+# nmap and ipmitool-xcat are hard requirements on EL and were only recommended here.
+my $xcat   = relations_of( 'xCAT',   'xcat' );
+my $xcatsn = relations_of( 'xCATsn', 'xcatsn' );
+foreach my $case ( [ $xcat, 'xcat' ], [ $xcatsn, 'xcatsn' ], [ $client, 'xcat-client' ] ) {
+    my ( $rel, $label ) = @$case;
+    ok( $rel->{Depends}{nmap},        "$label depends on nmap" );
+    ok( !$rel->{Recommends}{nmap},    "... and does not recommend it as well" );
+}
+foreach my $case ( [ $xcat, 'xcat' ], [ $xcatsn, 'xcatsn' ] ) {
+    my ( $rel, $label ) = @$case;
+    ok( $rel->{Depends}{'ipmitool-xcat'},     "$label depends on ipmitool-xcat" );
+    ok( !$rel->{Recommends}{'ipmitool-xcat'}, "... and does not recommend it as well" );
+    is( $rel->{version}{'ipmitool-xcat'}, '>= 1.8.18-4', "... at the floor xCAT.spec requires" );
+}
+
+done_testing();

--- a/xCAT/debian/control
+++ b/xCAT/debian/control
@@ -9,8 +9,8 @@ Homepage: https://xcat.org/
 
 Package: xcat
 Architecture: amd64 ppc64el riscv64
-Depends: ${perl:Depends}, goconserver(>= 0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, isc-dhcp-server | kea, bind9, apache2, nfs-kernel-server, libxml-parser-perl, rsync, tftpd-hpa, libnet-telnet-perl, chrony | ntp, xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000) [!riscv64]
-Recommends: net-tools, nmap, kea, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, util-linux-extra, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000), xcat-genesis-openembedded-x86-64, xcat-genesis-openembedded-ppc64le, xcat-genesis-openembedded-riscv64, xcat-genesis-openembedded-s390x
+Depends: ${perl:Depends}, goconserver(>= 0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, isc-dhcp-server | kea, bind9, apache2, nfs-kernel-server, libxml-parser-perl, rsync, tftpd-hpa, libnet-telnet-perl, chrony | ntp, nmap, ipmitool-xcat (>= 1.8.18-4), xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000) [!riscv64]
+Recommends: net-tools, kea, tftp-hpa, syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, util-linux-extra, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000), xcat-genesis-openembedded-x86-64, xcat-genesis-openembedded-ppc64le, xcat-genesis-openembedded-riscv64, xcat-genesis-openembedded-s390x
 Suggests: yaboot-xcat
 Description: Metapackage for a common, default xCAT setup
  xCAT is Extreme Cluster/Cloud Administration Toolkit. xCAT offers complete

--- a/xCATsn/debian/control
+++ b/xCATsn/debian/control
@@ -8,8 +8,8 @@ Homepage: https://xcat.org/
 
 Package: xcatsn
 Architecture: amd64 ppc64el riscv64
-Depends: ${perl:Depends}, goconserver (>=0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, libnet-telnet-perl, isc-dhcp-server | kea, bind9, apache2, nfs-kernel-server, xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000) [!riscv64]
-Recommends: net-tools, nmap, kea, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000), xcat-genesis-openembedded-x86-64, xcat-genesis-openembedded-ppc64le, xcat-genesis-openembedded-riscv64, xcat-genesis-openembedded-s390x
+Depends: ${perl:Depends}, goconserver (>=0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, libnet-telnet-perl, isc-dhcp-server | kea, bind9, apache2, nfs-kernel-server, nmap, ipmitool-xcat (>= 1.8.18-4), xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000) [!riscv64]
+Recommends: net-tools, kea, tftp-hpa, syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000), xcat-genesis-openembedded-x86-64, xcat-genesis-openembedded-ppc64le, xcat-genesis-openembedded-riscv64, xcat-genesis-openembedded-s390x
 Suggests: yaboot-xcat
 Description: Metapackage for a common, default xCAT service node setup
  xCATsn is a service node management package intended for at-scale


### PR DESCRIPTION
dh_perl adds no module dependencies, so a deb depends only on what its control file names. perl-xcat named libhtml-form-perl alone while its files load other modules at top level, and the XML::Parser that Client.pm selects for XML::Simple came only from the xcat and xcatsn metapackages. On a client-only install every command died loading Client.pm, and without libio-socket-inet6-perl the client and xcatd fell back to IPv4 silently.

The control files now declare what the packages load:

- perl-xcat depends on the modules its files and Client.pm load, XML::Parser and the IPv6 sockets included.
- xcat-client depends on libcapture-tiny-perl for the z/VM helpers it ships.
- xcat-server depends on libcgi-pm-perl, which the REST API loads on every request.
- xcat, xcatsn and xcat-client require nmap, and xcat and xcatsn require ipmitool-xcat, as the rpm packages do. The ipmitool-xcat floor is the one xCAT.spec has, 1.8.18-4.
