### PR TITLE
fix(postscripts): stop passing the deprecated apt --force-yes flag

### DIFF
--- a/xCAT-test/bats/postscripts_apt_get.bats
+++ b/xCAT-test/bats/postscripts_apt_get.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+
+load 'helpers/shell_source'
+
+setup()
+{
+    PKGUTILS="$(repo_path 'xCAT/postscripts/xcatpkgutils.sh')"
+    OSPKGS="$(repo_path 'xCAT/postscripts/ospkgs')"
+    OTHERPKGS="$(repo_path 'xCAT/postscripts/otherpkgs')"
+    [ -r "$PKGUTILS" ] || skip "$PKGUTILS is required"
+    [ -r "$OSPKGS" ] || skip "$OSPKGS is required"
+    [ -r "$OTHERPKGS" ] || skip "$OTHERPKGS is required"
+    APT_LOG="${BATS_TEST_TMPDIR}/apt-get.log"
+    export PKGUTILS OSPKGS OTHERPKGS APT_LOG
+}
+
+# Every apt-get call is recorded as "<DEBIAN_FRONTEND>|<arguments>" and answers with APT_STATUS.
+shadow_apt_get()
+{
+    apt-get()
+    {
+        printf '%s|%s\n' "${DEBIAN_FRONTEND:-unset}" "$*" >>"$APT_LOG"
+        return "${APT_STATUS:-0}"
+    }
+}
+
+apt_call()
+{
+    sed -n "${1}p" "$APT_LOG"
+}
+
+apt_calls()
+{
+    wc -l <"$APT_LOG" | tr -d ' '
+}
+
+run_ospkgs_apt_block()
+{
+    local block
+    block="$(extract_line_range "$OSPKGS" '# upgrade existing packages' '# remove packages')" || return 99
+    local ENVLIST="" groups="" pkgs=" foo bar" cudapkgs="" RETURNVAL=0 ARCH=x86_64
+    eval "$block"
+    printf 'RETURNVAL=%s\n' "$RETURNVAL"
+}
+
+run_otherpkgs_apt_line()
+{
+    local line
+    line="$(extract_first_matching_line "$OTHERPKGS" "$1")" || return 99
+    local envlist="" repo_pkgs="foo bar" result=""
+    eval "$line"
+    printf 'R=%s\n' "$?"
+    printf '%s\n' "$result"
+}
+
+@test "the postscripts and the package utilities ship executable" {
+    [ -x "$OSPKGS" ]
+    [ -x "$OTHERPKGS" ]
+    [ -x "$PKGUTILS" ]
+}
+
+@test "xcat_apt_get runs apt-get unattended and accepts the unsigned xCAT repositories" {
+    source "$PKGUTILS"
+    shadow_apt_get
+
+    run xcat_apt_get -q install --no-install-recommends foo bar
+    [ "$status" -eq 0 ]
+    [ "$(apt_call 1)" = "noninteractive|-y --allow-unauthenticated -q install --no-install-recommends foo bar" ]
+    [ "$(apt_calls)" -eq 1 ]
+}
+
+@test "xcat_apt_get returns the apt-get status" {
+    source "$PKGUTILS"
+    shadow_apt_get
+
+    APT_STATUS=100 run xcat_apt_get upgrade
+    [ "$status" -eq 100 ]
+}
+
+@test "a pkglist environment prefix reaches apt-get through the eval the postscripts use" {
+    source "$PKGUTILS"
+    apt-get()
+    {
+        printf '%s\n' "${ACCEPT_EULA:-unset}" >>"$APT_LOG"
+    }
+    local ENVLIST="ACCEPT_EULA=y"
+
+    run eval "$ENVLIST xcat_apt_get -q install foo"
+    [ "$status" -eq 0 ]
+    [ "$(apt_call 1)" = "y" ]
+}
+
+@test "ospkgs upgrades and installs through xcat_apt_get without --force-yes" {
+    source "$PKGUTILS"
+    shadow_apt_get
+
+    run run_ospkgs_apt_block
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'RETURNVAL=0'* ]]
+    [ "$(apt_call 1 | cut -d'|' -f2)" = "-y update" ]
+    [ "$(apt_call 2)" = "noninteractive|-y --allow-unauthenticated -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef upgrade" ]
+    [ "$(apt_call 3)" = "noninteractive|-y --allow-unauthenticated -q install --no-install-recommends foo bar" ]
+    [ "$(apt_calls)" -eq 3 ]
+    ! grep -q -- '--force-yes' "$APT_LOG"
+}
+
+@test "ospkgs keeps the apt-get failure status and still runs the later steps" {
+    source "$PKGUTILS"
+    shadow_apt_get
+
+    APT_STATUS=100 run run_ospkgs_apt_block
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'RETURNVAL=100'* ]]
+    [ "$(apt_calls)" -eq 3 ]
+}
+
+@test "otherpkgs upgrades through xcat_apt_get without --force-yes" {
+    source "$PKGUTILS"
+    shadow_apt_get
+
+    run run_otherpkgs_apt_line 'result=`eval [$]envlist .*Dpkg::Options.* upgrade 2>&1`'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'R=0'* ]]
+    [ "$(apt_call 1)" = "noninteractive|-y --allow-unauthenticated -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef upgrade" ]
+    [ "$(apt_calls)" -eq 1 ]
+}
+
+@test "otherpkgs installs through xcat_apt_get without --force-yes" {
+    source "$PKGUTILS"
+    shadow_apt_get
+
+    run run_otherpkgs_apt_line 'result=`eval [$]envlist .*Dpkg::Options.* install [$]repo_pkgs 2>&1`'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'R=0'* ]]
+    [ "$(apt_call 1)" = "noninteractive|-y --allow-unauthenticated -q -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef install foo bar" ]
+    [ "$(apt_calls)" -eq 1 ]
+}

--- a/xCAT-test/bats/postscripts_apt_get.bats
+++ b/xCAT-test/bats/postscripts_apt_get.bats
@@ -38,7 +38,7 @@ run_ospkgs_apt_block()
 {
     local block
     block="$(extract_line_range "$OSPKGS" '# upgrade existing packages' '# remove packages')" || return 99
-    local ENVLIST="" groups="" pkgs=" foo bar" cudapkgs="" RETURNVAL=0 ARCH=x86_64
+    local ENVLIST="" groups="" pkgs=" foo bar" cudapkgs="${1:-}" RETURNVAL=0 ARCH=x86_64
     eval "$block"
     printf 'RETURNVAL=%s\n' "$RETURNVAL"
 }
@@ -112,6 +112,48 @@ run_otherpkgs_apt_line()
     [ "$status" -eq 0 ]
     [[ "$output" == *'RETURNVAL=100'* ]]
     [ "$(apt_calls)" -eq 3 ]
+}
+
+@test "ospkgs reports a failed cuda package install" {
+    source "$PKGUTILS"
+    apt-get()
+    {
+        printf '%s|%s\n' "${DEBIAN_FRONTEND:-unset}" "$*" >>"$APT_LOG"
+        case "$*" in
+        *cuda*) return 100 ;;
+        esac
+        return 0
+    }
+
+    run run_ospkgs_apt_block " cuda-toolkit"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'RETURNVAL=100'* ]]
+    [ "$(apt_call 4)" = "noninteractive|-y --allow-unauthenticated -q install --no-install-recommends cuda-toolkit" ]
+    [ "$(apt_calls)" -eq 4 ]
+}
+
+run_ospkgs_rpm_cuda_block()
+{
+    local block tail="${BATS_TEST_TMPDIR}/ospkgs-rpm-tail"
+    sed -n '/#install cuda package if any/,$p' "$OSPKGS" >"$tail"
+    block="$(extract_shell_if_block "$tail" 'if [ -n "$cudapkgs" ]; then')" || return 99
+    local ENVLIST="" yumcmd=fake_dnf cudapkgs=" cuda-toolkit" RETURNVAL=0 ARCH=x86_64 debug=0 log_label=ospkgs
+    logger() { :; }
+    fake_dnf()
+    {
+        printf '%s\n' "$*" >>"$APT_LOG"
+        return 100
+    }
+    eval "$block"
+    printf 'RETURNVAL=%s\n' "$RETURNVAL"
+}
+
+@test "ospkgs reports a failed cuda package install on yum and dnf nodes" {
+    run run_ospkgs_rpm_cuda_block
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'RETURNVAL=100'* ]]
+    [ "$(apt_call 1)" = "-y install cuda-toolkit" ]
+    [ "$(apt_calls)" -eq 1 ]
 }
 
 @test "otherpkgs upgrades through xcat_apt_get without --force-yes" {

--- a/xCAT/postscripts/ospkgs
+++ b/xCAT/postscripts/ospkgs
@@ -829,7 +829,7 @@ elif ( pmatch "$OSVER" "ubuntu*" ); then
 
 	# upgrade existing packages
         apt-get -y update
-        command="DEBIAN_FRONTEND=noninteractive apt-get -y --allow-unauthenticated --force-yes -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' upgrade "
+        command="xcat_apt_get -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' upgrade"
         echo "=== $command"
 	eval $command
         R=$?
@@ -841,7 +841,7 @@ elif ( pmatch "$OSVER" "ubuntu*" ); then
 	# but keeping this here doesn't really hurt. Anything that looks like a group will
 	# be installed as though it were a package.)
 	if [ -n "$groups" ]; then
-		command="$ENVLIST apt-get -q -y --force-yes install --no-install-recommends $groups"
+		command="$ENVLIST xcat_apt_get -q install --no-install-recommends $groups"
 		echo "=== $command"
 		eval $command
                 R=$?
@@ -855,7 +855,7 @@ elif ( pmatch "$OSVER" "ubuntu*" ); then
 
 	# install packages
 	if [ -n "$pkgs" ]; then
-		command="$ENVLIST apt-get -q -y --force-yes install --no-install-recommends $pkgs"
+		command="$ENVLIST xcat_apt_get -q install --no-install-recommends $pkgs"
 		echo "=== $command"
 		eval $command
                 R=$?
@@ -865,7 +865,7 @@ elif ( pmatch "$OSVER" "ubuntu*" ); then
 	fi
         if [ -n "$cudapkgs" ]; then
 
-                command="$ENVLIST apt-get -q -y --force-yes install --no-install-recommends $cudapkgs"
+                command="$ENVLIST xcat_apt_get -q install --no-install-recommends $cudapkgs"
                 echo "=== $command"
                 # the nvidia-346 postinstall script will trigger the building of nvidia driver, it will use the ARCH environment parameter, unset the ARCH env variable will resolve this issue
                 original_arch=$ARCH

--- a/xCAT/postscripts/ospkgs
+++ b/xCAT/postscripts/ospkgs
@@ -871,10 +871,10 @@ elif ( pmatch "$OSVER" "ubuntu*" ); then
                 original_arch=$ARCH
                 unset ARCH
                 eval $command
+                R=$?
                 # re declare the ARCH env after installing cuda command done
                 ARCH=$original_arch
                 export ARCH
-                R=$?
                 if [ $R -ne 0 ]; then
                    RETURNVAL=$R
                 fi
@@ -997,10 +997,10 @@ else
         original_arch=$ARCH
         unset ARCH
         result=`eval $cmd 2>&1`
+        R=$?
         # re declare the ARCH env after installing cuda command done
         ARCH=$original_arch
         export ARCH
-        R=$?
         if [ $R -ne 0 ]; then
             RETURNVAL=$R
             logger -t $log_label -p local4.info "ospkgs: $cmd\n    $result"

--- a/xCAT/postscripts/otherpkgs
+++ b/xCAT/postscripts/otherpkgs
@@ -905,9 +905,9 @@ EOF`
     elif [ $hasapt -eq 1 ]; then
 	apt_get_update_if_repos_changed $REPOFILE
         if [ $VERBOSE  ]; then
-          echo "$envlist DEBIAN_FRONTEND=noninteractive apt-get -y --allow-unauthenticated --force-yes -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' upgrade"
+          echo "$envlist xcat_apt_get -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' upgrade"
         fi
-        result=`eval $envlist DEBIAN_FRONTEND=noninteractive apt-get -y --allow-unauthenticated --force-yes -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' upgrade 2>&1`
+        result=`eval $envlist xcat_apt_get -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' upgrade 2>&1`
         R=$?
         if [ $R -ne 0 ]; then
               RETURNVAL=$R
@@ -1022,9 +1022,9 @@ EOF`
 	elif [ $hasapt -eq 1 ]; then
 	    apt_get_update_if_repos_changed $REPOFILE
             if [ $VERBOSE  ]; then
-	      echo "$envlist DEBIAN_FRONTEND=noninteractive apt-get -q -y --force-yes  -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' install $repo_pkgs"
+	      echo "$envlist xcat_apt_get -q -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' install $repo_pkgs"
 	    fi
-	    result=`eval $envlist DEBIAN_FRONTEND=noninteractive apt-get -q -y --force-yes  -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' install $repo_pkgs 2>&1`
+	    result=`eval $envlist xcat_apt_get -q -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' install $repo_pkgs 2>&1`
             R=$?
             if [ $R -ne 0 ]; then
               RETURNVAL=$R

--- a/xCAT/postscripts/xcatpkgutils.sh
+++ b/xCAT/postscripts/xcatpkgutils.sh
@@ -14,6 +14,12 @@ xcat_find_rpm_package_manager()
     fi
 }
 
+# The xCAT repositories are unsigned, and an unattended node cannot answer a debconf prompt.
+xcat_apt_get()
+{
+    DEBIAN_FRONTEND=noninteractive apt-get -y --allow-unauthenticated "$@"
+}
+
 # Keep the marker assignment last so callers know the whole library loaded.
 
 xcat_is_el_modular_pkgdir()


### PR DESCRIPTION
ospkgs and otherpkgs passed --force-yes to every apt-get upgrade and install. apt has printed a deprecation warning for it since 1.1, and the flag also allowed downgrades, changes to held packages and the removal of essential packages, none of which an unattended package update should do. Three of the ospkgs installs relied on it alone for the unsigned xCAT repositories and ran without DEBIAN_FRONTEND=noninteractive.

The eight apt-get calls now go through xcat_apt_get in xcatpkgutils.sh, which runs apt-get with -y and --allow-unauthenticated under DEBIAN_FRONTEND=noninteractive, and each call site keeps its own quiet, Dpkg and recommends options. A held package or an explicit older version now fails the install instead of being forced, as on the rpm side.

There is also a fix for the cuda install of ospkgs: both blocks read the package manager status after restoring ARCH, so a failed cuda install reported success on apt and on yum and dnf nodes.
