### PR TITLE
fix(detect_dhcpd): capture into a private file and stop only its own tcpdump

### DIFF
--- a/xCAT-probe/subcmds/detect_dhcpd
+++ b/xCAT-probe/subcmds/detect_dhcpd
@@ -7,6 +7,8 @@ use lib "$::XCATROOT/probe/lib/perl";
 use probe_utils;
 use xCAT::CommandUtils;
 use File::Basename;
+use File::Temp qw(tempfile);
+use POSIX qw(_exit sigprocmask WNOHANG SIG_BLOCK SIG_SETMASK SIGINT SIGTERM);
 use IO::Socket::INET;
 use Time::HiRes qw(gettimeofday sleep);
 use Getopt::Long;
@@ -17,7 +19,6 @@ my $program_name = basename("$0");
 my $output       = "stdout";
 my $duration     = 10;
 my $test         = 0;
-my $dumpfile     = "/tmp/dhcpdumpfile.log";
 my $nic;
 
 $::USAGE = "Usage:
@@ -153,44 +154,57 @@ my $package = packdhcppkg($MAC);
 probe_utils->send_msg("$output", "i", "Start to detect DHCP, please wait $duration seconds");
 
 $msg = "fork a process to capture the packet by tcpdump";
+my ($dumpfh, $dumpfile) = tempfile("detect_dhcpd.XXXXXX", TMPDIR => 1, UNLINK => 1);
+close($dumpfh);
+# INT and TERM stay blocked from the fork until the handler that stops the capture is in place.
+my $stop_signals = POSIX::SigSet->new(SIGINT, SIGTERM);
+my $signal_mask  = POSIX::SigSet->new();
+sigprocmask(SIG_BLOCK, $stop_signals, $signal_mask);
 my $pid = fork;
 if (!defined $pid) {
+    sigprocmask(SIG_SETMASK, $signal_mask);
     probe_utils->send_msg("$output", "f", $msg);
     exit 1;
 } elsif ($pid == 0) {
 
-    # Child process
-    my $cmd = "$tcpdump -i $nic port 68 -n -vvvvvv > $dumpfile 2>/dev/null";
-    `$cmd`;
-    exit 0;
+    # Child process: tcpdump itself, so the parent owns exactly this pid.
+    sigprocmask(SIG_SETMASK, $signal_mask);
+    open(STDOUT, '>', $dumpfile) or _exit(1);
+    open(STDERR, '>', '/dev/null');
+    exec($tcpdump, '-i', $nic, 'port', '68', '-n', '-vvvvvv');
+    _exit(1);
 }
+$SIG{INT} = $SIG{TERM} = sub { kill_child(); exit 1; };
+sigprocmask(SIG_SETMASK, $signal_mask);
 probe_utils->send_msg("$output", "d", "The id of process which is used to capture the packet by tcpdump is $pid") if ($::VERBOSE);
 
 my $start = Time::HiRes::gettimeofday();
 $start =~ s/(\d.*)\.(\d.*)/$1/;
 my $end = $start;
 while ($end - $start <= $duration) {
-    $sock->send($package);
-    probe_utils->send_msg("$output", "d", "Send DHCP rquest result: $@") if ($::VERBOSE && $@);
+    unless ($sock->send($package)) {
+        probe_utils->send_msg("$output", "d", "Send DHCP discover error: $!") if ($::VERBOSE);
+        probe_utils->send_msg("$output", "f", "Send out DHCP discover");
+        kill_child();
+        exit 1;
+    }
     sleep 2;
     $end = Time::HiRes::gettimeofday();
     $end =~ s/(\d.*)\.(\d.*)/$1/;
 }
 
-$msg = "Kill the process which is used to capture the packet by tcpdump";
-kill_child();
-waitpid($pid, 0);
-sleep 1;
-`ps aux|grep -v grep |grep $pid > /dev/null 2>&1`;
-if (!$?) {
+$msg = "Capture the packets by tcpdump";
+my $capture_problem = kill_child();
+if ($capture_problem) {
+    probe_utils->send_msg("$output", "d", "tcpdump $capture_problem") if ($::VERBOSE);
     probe_utils->send_msg("$output", "f", $msg);
+    exit 1;
 }
 
 $msg = "Dump test result";
 unless (open(FILE, "<$dumpfile")) {
     probe_utils->send_msg("$output", "d", "Open dump file $dumpfile failed") if ($::VERBOSE);
     probe_utils->send_msg("$output", "f", $msg);
-    `rm -f $dumpfile` if (-e "$dumpfile");
     exit 1;
 }
 my %output;
@@ -273,7 +287,6 @@ if (scalar(@server)) {
     }
 }
 
-`rm -f $dumpfile` if (-e "$dumpfile");
 exit 0;
 
 
@@ -379,11 +392,39 @@ sub packdhcppkg {
     return $package;
 }
 
+# Stop the capture and reap it, once: INT and TERM are blocked while the pid is taken and until
+# tcpdump is reaped, so an interrupt in that window cannot orphan it or reach a recycled pid. The
+# handlers stay installed, so a later signal still leaves through exit and the END cleanup.
+# Returns '' when tcpdump ran until this TERM and stopped cleanly, otherwise what went wrong: it
+# ended on its own, ignored TERM and was killed, or left on another signal or with a non-zero
+# status.
 sub kill_child {
-    kill 15, $pid;
-    my @pidoftcpdump = `ps -ef | grep -E "[0-9]+:[0-9]+:[0-9]+ $tcpdump -i $nic" | awk -F' ' '{print \$2}'`;
-    foreach my $cpid (@pidoftcpdump) {
-        kill 15, $cpid;
+    sigprocmask(SIG_BLOCK, $stop_signals);
+    my $child = $pid;
+    $pid = undef;
+    unless ($child) {
+        sigprocmask(SIG_SETMASK, $signal_mask);
+        return '';
     }
-    probe_utils->send_msg("$output", "d", "Kill process $pid used to capture the packet by 'tcpdump'") if ($::VERBOSE);
+    my $reaped = waitpid($child, WNOHANG);
+    my $early = ($reaped == $child) ? 1 : 0;
+    if ($reaped == 0) {
+        kill 'TERM', $child;
+        foreach (1 .. 50) {
+            last if ($reaped = waitpid($child, WNOHANG)) != 0;
+            select(undef, undef, undef, 0.1);
+        }
+        if ($reaped == 0) {
+            kill 'KILL', $child;
+            $reaped = waitpid($child, 0);
+        }
+    }
+    sigprocmask(SIG_SETMASK, $signal_mask);
+    return "could not be reaped" if $reaped != $child;
+    my ($signal, $status) = ($? & 127, $? >> 8);
+    probe_utils->send_msg("$output", "d", "Kill process $child used to capture the packet by 'tcpdump'") if ($::VERBOSE);
+    my $how = $signal ? "on signal $signal" : "with status $status";
+    return "ended before the capture window did, $how" if $early;
+    return '' if $signal == 15 || (!$signal && !$status);
+    return "left the capture $how";
 }

--- a/xCAT-server/share/xcat/tools/detect_dhcpd
+++ b/xCAT-server/share/xcat/tools/detect_dhcpd
@@ -5,6 +5,8 @@ BEGIN {
 use lib "$::XCATROOT/lib/perl";
 use xCAT::CommandUtils;
 use IO::Socket::INET;
+use File::Temp qw(tempfile);
+use POSIX qw(_exit sigprocmask WNOHANG SIG_BLOCK SIG_SETMASK SIGINT SIGTERM);
 use Time::HiRes qw(gettimeofday sleep);
 use Getopt::Long;
 Getopt::Long::Configure("bundling");
@@ -92,16 +94,25 @@ if (-f "/etc/redhat-release") {
 }
 
 # fork a process to capture the packet by tcpdump
+my ($dumpfh, $dumpfile) = tempfile("detect_dhcpd.XXXXXX", TMPDIR => 1, UNLINK => 1);
+close($dumpfh);
+# INT and TERM stay blocked from the fork until the handler that stops the capture is in place.
+my $stop_signals = POSIX::SigSet->new(SIGINT, SIGTERM);
+my $signal_mask  = POSIX::SigSet->new();
+sigprocmask(SIG_BLOCK, $stop_signals, $signal_mask);
 my $pid = fork;
-if (!defined $pid) { print "Fork failed.\n"; exit 1; }
-my $dumpfile = "/tmp/dhcpdumpfile.log";
+if (!defined $pid) { sigprocmask(SIG_SETMASK, $signal_mask); print "Fork failed.\n"; exit 1; }
 if ($pid == 0) {
 
-    # Child process
-    my $cmd = "$tcpdump -i $IF port 68 -n -vvvvvv > $dumpfile 2>/dev/null";
-    `$cmd`;
-    exit 0;
+    # Child process: tcpdump itself, so the parent owns exactly this pid.
+    sigprocmask(SIG_SETMASK, $signal_mask);
+    open(STDOUT, '>', $dumpfile) or _exit(1);
+    open(STDERR, '>', '/dev/null');
+    exec($tcpdump, '-i', $nic, 'port', '68', '-n', '-vvvvvv');
+    _exit(1);
 }
+$SIG{INT} = $SIG{TERM} = sub { kill_child(); exit 1; };
+sigprocmask(SIG_SETMASK, $signal_mask);
 
 # generate the discover package
 my $package = packdhcppkg($MAC);
@@ -141,25 +152,24 @@ if ($::TIMEOUT) {
 my $end = Time::HiRes::gettimeofday();
 $end =~ s/(\d.*)\.(\d.*)/$1/;
 while ($end - $start <= $timeout) {
-    $sock->send($package) or die "Send discover error: $@\n";
+    unless ($sock->send($package)) {
+        print "Send discover error: $!\n";
+        kill_child();
+        exit 1;
+    }
     sleep 2;
     $end = Time::HiRes::gettimeofday();
     $end =~ s/(\d.*)\.(\d.*)/$1/;
 }
 
 
-kill_child();
-
 #kill the child process
-kill 15, $pid;
-my @pidoftcpdump = `ps -ef | grep -E "[0-9]+:[0-9]+:[0-9]+ $tcpdump -i $IF" | awk -F' ' '{print \$2}'`;
-foreach my $cpid (@pidoftcpdump) {
-    kill 15, $cpid;
-
-    #  print "try to kill $cpid\n";
+my $capture_problem = kill_child();
+if ($capture_problem) {
+    print "tcpdump $capture_problem.\n";
+    exit 1;
 }
 
-sleep 2;
 open(FILE, "<$dumpfile") or die "Cannot open $dumpfile\n";
 my %output;
 my @snack      = ();
@@ -239,7 +249,6 @@ if (scalar(@server)) {
     }
 }
 
-#`rm -f $dumpfile`;
 exit 0;
 
 
@@ -345,12 +354,38 @@ sub packdhcppkg {
     return $package;
 }
 
+# Stop the capture and reap it, once: INT and TERM are blocked while the pid is taken and until
+# tcpdump is reaped, so an interrupt in that window cannot orphan it or reach a recycled pid. The
+# handlers stay installed, so a later signal still leaves through exit and the END cleanup.
+# Returns '' when tcpdump ran until this TERM and stopped cleanly, otherwise what went wrong: it
+# ended on its own, ignored TERM and was killed, or left on another signal or with a non-zero
+# status.
 sub kill_child {
-    kill 15, $pid;
-    my @pidoftcpdump = `ps -ef | grep -E "[0-9]+:[0-9]+:[0-9]+ $tcpdump -i $IF" | awk -F' ' '{print \$2}'`;
-    foreach my $cpid (@pidoftcpdump) {
-        kill 15, $cpid;
-
-        #print "try to kill $cpid\n";
+    sigprocmask(SIG_BLOCK, $stop_signals);
+    my $child = $pid;
+    $pid = undef;
+    unless ($child) {
+        sigprocmask(SIG_SETMASK, $signal_mask);
+        return '';
     }
+    my $reaped = waitpid($child, WNOHANG);
+    my $early = ($reaped == $child) ? 1 : 0;
+    if ($reaped == 0) {
+        kill 'TERM', $child;
+        foreach (1 .. 50) {
+            last if ($reaped = waitpid($child, WNOHANG)) != 0;
+            select(undef, undef, undef, 0.1);
+        }
+        if ($reaped == 0) {
+            kill 'KILL', $child;
+            $reaped = waitpid($child, 0);
+        }
+    }
+    sigprocmask(SIG_SETMASK, $signal_mask);
+    return "could not be reaped" if $reaped != $child;
+    my ($signal, $status) = ($? & 127, $? >> 8);
+    my $how = $signal ? "on signal $signal" : "with status $status";
+    return "ended before the capture window did, $how" if $early;
+    return '' if $signal == 15 || (!$signal && !$status);
+    return "left the capture $how";
 }

--- a/xCAT-test/unit/detect_dhcpd_tcpdump_lookup.t
+++ b/xCAT-test/unit/detect_dhcpd_tcpdump_lookup.t
@@ -52,8 +52,8 @@ my $marker = File::Spec->catfile( tempdir( @fixture_dir, CLEANUP => 1 ), 'tcpdum
 sub fixture_bin {
     my (%with) = @_;
     my $bindir = tempdir( @fixture_dir, CLEANUP => 1 );
-    write_script( "$bindir/tcpdump", qq{printf '%s\\n' "\$0" "\$*" > '$marker'\nexit 0\n} );
-    foreach my $tool (qw(awk head grep ps)) {
+    write_script( "$bindir/tcpdump", qq{printf '%s\\n' "\$0" "\$*" > '$marker'\ntrap 'exit 0' TERM\nwhile :; do sleep 1; done\n} );
+    foreach my $tool (qw(awk head grep ps sleep)) {
         my $real = xCAT::CommandUtils::find_executable($tool) or next;
         symlink( $real, "$bindir/$tool" ) or die "symlink $tool: $!";
     }
@@ -140,6 +140,138 @@ SKIP: {
     ( $ran, $args ) = recorded_invocation();
     is( $ran,  "$isolated/tcpdump",         '... by the path it resolved' );
     is( $args, "-i lo port 68 -n -vvvvvv", '... with the capture arguments' );
+}
+
+# ---- capture lifecycle: a private dump file, tcpdump run directly and stopped by pid ------------
+# Both copies wrote /tmp/dhcpdumpfile.log, ran tcpdump behind a shell, killed every tcpdump on the
+# interface by pattern, and reported zero servers when tcpdump failed to start. The fake tcpdump
+# below records who started it and where its output goes, waits for the TERM the script owes it,
+# and a second one fails at once. ps records any use, since the scripts no longer need it.
+sub lifecycle_bin {
+    my (%with) = @_;
+    my $bindir = tempdir( @fixture_dir, CLEANUP => 1 );
+    my $record = "$with{record}";
+    if ( $with{fail} ) {
+        write_script( "$bindir/tcpdump", qq{printf 'started\\n' >> '$record'\nexit 1\n} );
+    } elsif ( $with{quit} ) {
+        write_script( "$bindir/tcpdump", qq{printf 'started\\n' >> '$record'\nexit 0\n} );
+    } elsif ( $with{killed} ) {
+        write_script( "$bindir/tcpdump", qq{printf 'started\\n' >> '$record'\nkill -9 \$\$\n} );
+    } elsif ( $with{stubborn} ) {
+        write_script( "$bindir/tcpdump", qq{trap '' TERM\nprintf 'started\\n' >> '$record'\nwhile :; do sleep 1; done\n} );
+    } else {
+        write_script( "$bindir/tcpdump",
+                qq{parent=\$(cat /proc/\$PPID/comm 2>/dev/null)\n}
+              . qq{out=\$(readlink /proc/\$\$/fd/1 2>/dev/null)\n}
+              . qq{printf 'pid=%s ppid=%s parent=%s out=%s\\n' "\$\$" "\$PPID" "\$parent" "\$out" >> '$record'\n}
+              . qq{trap 'printf "TERM\\n" >> "$record"; exit 0' TERM\n}
+              . qq{while :; do sleep 1; done\n} );
+    }
+    write_script( "$bindir/ps", qq{printf 'ps %s\\n' "\$*" >> '$record.ps'\nexit 0\n} );
+    foreach my $tool (qw(awk head grep cat readlink sleep)) {
+        my $real = xCAT::CommandUtils::find_executable($tool) or next;
+        symlink( $real, "$bindir/$tool" ) or die "symlink $tool: $!";
+    }
+    symlink( $with{real_ip}, "$bindir/ip" ) or die "symlink ip: $!";
+    return $bindir;
+}
+
+sub run_isolated_status {
+    my ( $ns, $bindir, $tmpdir, $script, @args ) = @_;
+    my $command = "env PATH='$bindir' XCATROOT='$root' TMPDIR='$tmpdir' " . script_command( $script, @args );
+    my $shell   = "$ns->{unshare} $ns->{flags} sh -c \"$ns->{setup} && exec $command\" 2>&1";
+    my $out     = `$shell`;
+    return ( $out, $? >> 8 );
+}
+
+sub slurp_lines {
+    my ($path) = @_;
+    open( my $fh, '<', $path ) or return;
+    chomp( my @lines = <$fh> );
+    close($fh);
+    return @lines;
+}
+
+SKIP: {
+    skip 'the private /tmp would hide this checkout or its fixtures', 44
+      if index( $repo, '/tmp/' ) == 0 || !@fixture_dir;
+    my $ns = isolation();
+    skip 'no private network namespace on this host', 44 unless $ns;
+
+    foreach my $case ( [ $tools, 'the tool', '-t' ], [ $probe, 'the probe', '-d' ] ) {
+        my ( $script, $label, $window ) = @$case;
+        my $tmpdir = tempdir( @fixture_dir, CLEANUP => 1 );
+        my $record = File::Spec->catfile( tempdir( @fixture_dir, CLEANUP => 1 ), 'tcpdump.record' );
+        my $bindir = lifecycle_bin( record => $record, real_ip => $ns->{ip} );
+
+        my ( $out, $status ) = run_isolated_status( $ns, $bindir, $tmpdir, $script, '-i', 'lo', '-m', $mac, $window, '1' );
+        is( $status, 0, "$label exits 0 after a capture window" );
+        my @rec = slurp_lines($record);
+        my ($start) = grep { /^pid=/ } @rec;
+        ok( defined $start, "$label started tcpdump" ) or diag($out);
+        like( $start // '', qr/ parent=perl /, '... directly from the script, with no shell in between' );
+        like( $start // '', qr{ out=\Q$tmpdir\E/detect_dhcpd\.\w+$}, '... writing a private capture file under TMPDIR' );
+        ok( ( grep { $_ eq 'TERM' } @rec ), '... and stopped it with TERM when the window ended' );
+        ok( !-e "$record.ps", '... without searching the process table' );
+        my @left = glob("$tmpdir/detect_dhcpd.*");
+        is( scalar(@left), 0, '... and removed the capture file on exit' );
+
+        my $failing = lifecycle_bin( record => $record, real_ip => $ns->{ip}, fail => 1 );
+        ( $out, $status ) = run_isolated_status( $ns, $failing, $tmpdir, $script, '-i', 'lo', '-m', $mac, $window, '1' );
+        is( $status, 1, "$label exits 1 when tcpdump fails to start" ) or diag($out);
+        like( $out, qr/tcpdump ended before the capture window did, with status 1|Capture the packets by tcpdump/, '... and says the capture failed' );
+        unlike( $out, qr/0 servers repl/, '... instead of reporting zero servers' );
+        @left = glob("$tmpdir/detect_dhcpd.*");
+        is( scalar(@left), 0, '... and leaves no capture file behind' );
+
+        my $quitting = lifecycle_bin( record => $record, real_ip => $ns->{ip}, quit => 1 );
+        ( $out, $status ) = run_isolated_status( $ns, $quitting, $tmpdir, $script, '-i', 'lo', '-m', $mac, $window, '1' );
+        is( $status, 1, "$label exits 1 when tcpdump quits early with status 0" ) or diag($out);
+        unlike( $out, qr/0 servers repl/, '... instead of reporting zero servers' );
+
+        my $dying = lifecycle_bin( record => $record, real_ip => $ns->{ip}, killed => 1 );
+        ( $out, $status ) = run_isolated_status( $ns, $dying, $tmpdir, $script, '-i', 'lo', '-m', $mac, $window, '1' );
+        is( $status, 1, "$label exits 1 when tcpdump dies on another signal" ) or diag($out);
+        like( $out, qr/on signal 9|Capture the packets by tcpdump/, '... and names the signal or the failed step' );
+
+        my $stubborn = lifecycle_bin( record => $record, real_ip => $ns->{ip}, stubborn => 1 );
+        my $began = time;
+        ( $out, $status ) = run_isolated_status( $ns, $stubborn, $tmpdir, $script, '-i', 'lo', '-m', $mac, $window, '1' );
+        is( $status, 1, "$label exits 1 when tcpdump ignores TERM" ) or diag($out);
+        cmp_ok( time - $began, '<', 20, '... after a bounded grace period' );
+        like( $out, qr/on signal 9|Capture the packets by tcpdump/, '... having killed it' );
+
+        # An interrupt while the capture runs: the script is signalled once the fake tcpdump has
+        # reported the script's pid, and must stop tcpdump and remove the file on its way out.
+        my $int_record = File::Spec->catfile( tempdir( @fixture_dir, CLEANUP => 1 ), 'tcpdump.record' );
+        my $int_bin    = lifecycle_bin( record => $int_record, real_ip => $ns->{ip} );
+        my $runner     = fork;
+        die "fork: $!" unless defined $runner;
+        if ( $runner == 0 ) {
+            my ( undef, $st ) = run_isolated_status( $ns, $int_bin, $tmpdir, $script, '-i', 'lo', '-m', $mac, $window, '30' );
+            exit $st;
+        }
+        my $started;
+        foreach ( 1 .. 150 ) {
+            ($started) = grep { /^pid=/ } slurp_lines($int_record);
+            last if $started;
+            select( undef, undef, undef, 0.2 );
+        }
+        my ($tcpdump_pid) = ( $started // '' ) =~ /^pid=(\d+)/;
+        my ($script_pid)  = ( $started // '' ) =~ / ppid=(\d+)/;
+        ok( $script_pid, "$label reports the pid to interrupt" ) or diag( $started // 'tcpdump never started' );
+        if ($script_pid) {
+            kill 'INT', $script_pid;
+            select( undef, undef, undef, 0.3 );
+            kill 'INT', $script_pid;
+        }
+        waitpid( $runner, 0 );
+        is( $? >> 8, 1, '... and exits 1 on a double interrupt during the capture' );
+        ok( ( grep { $_ eq 'TERM' } slurp_lines($int_record) ), '... after stopping tcpdump' );
+        ok( !( $tcpdump_pid && kill( 0, $tcpdump_pid ) ), '... which is gone' );
+        @left = glob("$tmpdir/detect_dhcpd.*");
+        is( scalar(@left), 0, '... and the capture file is removed' );
+    }
 }
 
 done_testing();


### PR DESCRIPTION
Both copies of detect_dhcpd wrote the capture to /tmp/dhcpdumpfile.log, so a file left by another user or an earlier root run blocked the probe and two runs overwrote each other. tcpdump ran behind a shell, so the script killed it by searching the process table for any tcpdump on the interface, a tcpdump that failed to start left an empty file that read as zero DHCP servers, and an interrupt left the capture running.

The capture file is now a private temporary file removed on every exit. The child execs tcpdump itself, so the script stops and reaps exactly that pid, within a bounded grace period, with INT and TERM held off while it does so. A tcpdump that ended before the window, on another signal or with a non-zero status fails the run, and a failed send or an interrupt stops the capture and exits 1.
