### PR TITLE
fix(xcat-core): nodeset cannot boot an Ubuntu POWER install from live media

### DIFF
--- a/xCAT-server/lib/xcat/plugins/debian.pm
+++ b/xCAT-server/lib/xcat/plugins/debian.pm
@@ -191,6 +191,8 @@ my %INSTALL_BOOT_FILES = (
     'ppc64' => [
         [ 'install/netboot/ubuntu-installer/{darch}/vmlinux', 'install/netboot/ubuntu-installer/{darch}/initrd.gz' ],
         [ 'install/vmlinux',                                  'install/netboot/initrd.gz' ],
+        [ 'casper/hwe-vmlinux',                               'casper/hwe-initrd' ],
+        [ 'casper/vmlinux',                                   'casper/initrd' ],
     ],
     'riscv64' => [
         [ 'casper/vmlinux', 'casper/initrd' ],
@@ -377,6 +379,27 @@ sub _no_grub2_loader {
     $callback->({
         warning => [ "No grub2.$arch boot loader was installed because $reason. $consequence" ] });
     return;
+}
+
+#-------------------------------------------------------
+
+=head3  install_media_is_bootable
+
+    Descriptions: Report whether copied media carries an install kernel and initrd.
+    Arguments:
+        $arch   - the xCAT architecture of the node
+        $darch  - the dpkg architecture
+        $pkgdir - the directory copycds wrote the media to
+    Returns: 1 when the media can boot a network install, 0 when it cannot
+
+=cut
+
+#-------------------------------------------------------
+sub install_media_is_bootable
+{
+    my ($arch, $darch, $pkgdir) = @_;
+
+    return install_boot_files($arch, $darch, $pkgdir) ? 1 : 0;
 }
 
 sub is_ubuntu_live_media
@@ -1176,10 +1199,11 @@ sub mkinstall {
             next;
         }
 
-        if ($arch =~ /ppc64/i and !(-e "$pkgdir/install/netboot/initrd.gz") and
-            !(-e "$pkgdir/install/netboot/ubuntu-installer/$darch/initrd.gz")) {
-            xCAT::MsgUtils->report_node_error($callback, $node, 
-                "The network boot initrd.gz is not found in $pkgdir/install/netboot.  This is provided by Ubuntu, please download and retry."
+        # The POWER live-server ISO keeps its installer under casper and ships no netboot
+        # tree, so the media that can boot it is the media install_boot_files resolves.
+        unless (install_media_is_bootable($arch, $darch, $pkgdir)) {
+            xCAT::MsgUtils->report_node_error($callback, $node,
+                "No install kernel and initrd were found on the media in $pkgdir."
                 );
             next;
         }

--- a/xCAT-test/unit/debian_install_boot_files.t
+++ b/xCAT-test/unit/debian_install_boot_files.t
@@ -103,6 +103,58 @@ is(
     'riscv64 does not accept the kernel name the other live images use',
 );
 
+# The Ubuntu ppc64el live-server ISO carries no netboot tree at all. 22.04 and 24.04 ship
+# casper/hwe-vmlinux + casper/hwe-initrd beside casper/vmlinux + casper/initrd; 26.04 ships
+# the release pair only. Without these entries nodeset stops the diskful install with
+# "The network boot initrd.gz is not found in <pkgdir>/install/netboot".
+is(
+    resolved('ppc64le', 'ppc64el', media('casper/vmlinux', 'casper/initrd')),
+    'casper/vmlinux|casper/initrd',
+    'the POWER live image keeps its kernel under casper',
+);
+is(
+    resolved('ppc64le', 'ppc64el',
+        media('casper/hwe-vmlinux', 'casper/hwe-initrd', 'casper/vmlinux', 'casper/initrd')),
+    'casper/hwe-vmlinux|casper/hwe-initrd',
+    'the POWER hardware-enablement kernel wins over the release kernel',
+);
+is(
+    resolved('ppc64le', 'ppc64el',
+        media('install/netboot/ubuntu-installer/ppc64el/vmlinux',
+              'install/netboot/ubuntu-installer/ppc64el/initrd.gz',
+              'casper/vmlinux', 'casper/initrd')),
+    'install/netboot/ubuntu-installer/ppc64el/vmlinux|install/netboot/ubuntu-installer/ppc64el/initrd.gz',
+    'a POWER netboot tree still wins over a live image on the same media',
+);
+
+# mkinstall refused POWER media that carried no install/netboot/initrd.gz, whatever
+# install_boot_files could resolve. One routine answers the question now.
+can_ok('xCAT_plugin::debian', 'install_media_is_bootable');
+is(
+    xCAT_plugin::debian::install_media_is_bootable('ppc64le', 'ppc64el',
+        media('casper/vmlinux', 'casper/initrd')),
+    1,
+    'a POWER live image is bootable media',
+);
+is(
+    xCAT_plugin::debian::install_media_is_bootable('ppc64le', 'ppc64el',
+        media('install/netboot/ubuntu-installer/ppc64el/vmlinux',
+              'install/netboot/ubuntu-installer/ppc64el/initrd.gz')),
+    1,
+    'a POWER netboot tree is bootable media',
+);
+is(
+    xCAT_plugin::debian::install_media_is_bootable('ppc64le', 'ppc64el', media('README')),
+    0,
+    'media with no installer is not bootable media',
+);
+is(
+    xCAT_plugin::debian::install_media_is_bootable('x86_64', 'amd64',
+        media('casper/vmlinuz', 'casper/initrd')),
+    1,
+    'an x86 live image is bootable media',
+);
+
 # --- nothing to boot -------------------------------------------------------
 is(resolved('x86_64', 'amd64', media('casper/vmlinuz')), undef,
     'a kernel without its initrd is not a match');


### PR DESCRIPTION
`nodeset` stops the diskful install on every ppc64le cell of `xcat-core-devel-ubuntu-cd`, with
`The network boot initrd.gz is not found in /install/ubuntu24.04.4/ppc64el/install/netboot`. The
Ubuntu ppc64el live-server ISO carries no netboot tree, and the installer kernel and initrd sit
under `casper`. In `debian.pm`, `%INSTALL_BOOT_FILES` describes no casper layout for POWER, and
`mkinstall` applies a second POWER-only precondition before it calls the resolver. The POWER table
gains the casper entries, and `install_media_is_bootable` replaces the precondition.
`debian_install_boot_files.t` fails without the change.