### PR TITLE
fix(xcat-core): the Ubuntu ppc64le diskful install stops without grub-ieee1275

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -1850,6 +1850,19 @@ sub ubuntu_subiquity_apt_mirror
 # The key curtin names in the Deb822 source it writes for the primary apt mirror on 24.04 and later.
 my $UBUNTU_ARCHIVE_KEYRING = '/usr/share/keyrings/ubuntu-archive-keyring.gpg';
 
+# The apt lines that keep the recommended packages out of the install. ospkgs installs without
+# them and the installer matches it. ppc64el is the exception: curtin installs a bootloader
+# package of its own for UEFI and for s390x only, and on a PReP machine install_grub runs
+# "dpkg-reconfigure grub-ieee1275" on a package the Ubuntu kernel image merely recommends. With
+# the recommended packages off that package is absent and the install stops there.
+sub ubuntu_subiquity_no_recommends_lines
+{
+    my ($osarch) = @_;
+
+    return () if defined($osarch) && $osarch =~ /^ppc64/i;
+    return (q(    conf: 'APT::Install-Recommends "false";'));
+}
+
 sub ubuntu_subiquity_apt_config
 {
     my ($media_dir, $osarch, $pkgdirs) = @_;
@@ -1877,7 +1890,7 @@ sub ubuntu_subiquity_apt_config
             '  apt:',
             '    preserve_sources_list: false',
             '    geoip: false',
-            q(    conf: 'APT::Install-Recommends "false";'),
+            ubuntu_subiquity_no_recommends_lines($osarch),
             '    mirror-selection:',
             '      primary:',
             "      - uri: $online_mirror",
@@ -1916,7 +1929,7 @@ sub ubuntu_subiquity_apt_config
         '    preserve_sources_list: false',
         '    fallback: offline-install',
         '    geoip: false',
-        q(    conf: 'APT::Install-Recommends "false";'),
+        ubuntu_subiquity_no_recommends_lines($osarch),
         '    disable_suites:',
         '      - updates',
         '      - backports',

--- a/xCAT-server/share/xcat/install/ubuntu/compute.subiquity.tmpl
+++ b/xCAT-server/share/xcat/install/ubuntu/compute.subiquity.tmpl
@@ -127,4 +127,9 @@ autoinstall:
     # monitor that died and never came back is #7759.
     - ['bash', '-c', 'xm=#XCATVAR:XCATMASTER#; port="#TABLEBLANKOKAY:site:key=xcatiport:value#"; [ -n "$port" ] || port=3002; ok=0; for i in 1 2 3 4 5; do if exec 3<>/dev/tcp/$xm/$port; then if read -r -t 10 hello <&3 && [ "$hello" = "ready" ]; then printf "next\n" >&3; if read -r -t 10 ack <&3 && [ "$ack" = "done" ]; then ok=1; fi; fi; exec 3>&- 3<&-; [ "$ok" = 1 ] && break; fi; sleep 5; done; if [ "$ok" != 1 ]; then echo "xcat: FAILED to flip $(hostname) to local-disk boot via $xm:$port; the node will PXE back into the installer" >>/target/var/log/xcat/xcat.log; fi; exit 0']
   error-commands:
-    - tar -c --ignore-failed-read --transform='s/^/#HOSTNAME#-logs\//' /var/crash /var/log/installer /tmp/pre-install.log /autoinstall.yaml 2>/dev/null |nc -l 8080
+    # Subiquity waits for every error command to return. "nc -l 8080" waits for a collector, which
+    # an unattended install does not have, so the node held the failure until the provisioning
+    # timeout reset it and the reason never left the node. Keep the archive on the installer, and
+    # print the end of the curtin log to the console, which the management node records.
+    - ['sh', '-c', 'tar -c --ignore-failed-read --transform="s/^/#HOSTNAME#-logs\//" /var/crash /var/log/installer /tmp/pre-install.log /autoinstall.yaml >/run/#HOSTNAME#-logs.tar 2>/dev/null; exit 0']
+    - ['sh', '-c', 'tail -n 80 /var/log/installer/curtin-install.log >"${XCAT_ERROR_CONSOLE:-/dev/console}" 2>/dev/null; exit 0']

--- a/xCAT-test/unit/ubuntu_subiquity_error_commands.t
+++ b/xCAT-test/unit/ubuntu_subiquity_error_commands.t
@@ -1,0 +1,68 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use File::Temp qw(tempdir);
+use Test::More;
+
+# Subiquity waits for every error command to return before it reports the failure. The template
+# used to offer the installer logs with "nc -l 8080", which waits for a collector that an
+# unattended install never has, so a failed install stopped there: the node answered ping with no
+# disk or network activity for as long as the provisioning timeout allowed, and the reason for the
+# failure stayed on the node. That is how a missing grub-ieee1275 on ppc64el read as a wedged
+# curtin extract.
+#
+# Run the error commands, with the programs that would reach the host or the network replaced, and
+# check that they return and that they write the end of the curtin log where the caller points.
+
+my $tmpl = "$FindBin::Bin/../../xCAT-server/share/xcat/install/ubuntu/compute.subiquity.tmpl";
+plan skip_all => 'compute.subiquity.tmpl not found' unless -r $tmpl;
+
+open(my $fh, '<', $tmpl) or die "open $tmpl: $!";
+my $source = do { local $/; <$fh> };
+close $fh;
+
+my ($block) = $source =~ m{^  error-commands:\n((?:    [-#].*\n)+)}m;
+BAIL_OUT('the template declares no error-commands') unless $block;
+
+# One command per list item. The list form ['sh', '-c', '...'] carries the command in its last
+# element; a plain item is the command itself.
+my @commands;
+foreach my $line (split /\n/, $block) {
+    next unless $line =~ m{^    - (.*)$};
+    my $item = $1;
+    if ($item =~ m{^\['[^']+', '-c', '(.*)'\]$}) { push @commands, $1; }
+    else                                         { push @commands, $item; }
+}
+BAIL_OUT('no error command found in the block') unless @commands;
+
+my $root = tempdir(CLEANUP => 1);
+my $console = "$root/console";
+my $script  = "$root/error-commands.sh";
+
+# nc, tar and tail are shadowed: bash resolves a function ahead of PATH, so the commands run as
+# written while nothing reaches the host or the network. nc waits the way a listener with no
+# collector waits.
+open(my $out, '>', $script) or die "open $script: $!";
+print {$out} "export XCAT_ERROR_CONSOLE='$console'\n";
+print {$out} "nc() { sleep 300; }\n";
+print {$out} "tar() { :; }\n";
+print {$out} "tail() { echo XCAT_CURTIN_LOG_TAIL; }\n";
+foreach my $command (@commands) {
+    ( my $rendered = $command ) =~ s/#HOSTNAME#/testnode/g;
+    # Subiquity runs each error command on its own, so a command that ends in "exit 0" must not
+    # end the others.
+    print {$out} "( $rendered )\n";
+}
+close $out;
+
+my $rc = system('timeout', '10', 'bash', $script);
+my $status = $rc == -1 ? -1 : $rc >> 8;
+isnt( $status, 124, 'the error commands return instead of waiting for someone to collect the logs' );
+
+my $written = '';
+if (open(my $log, '<', $console)) { local $/; $written = <$log>; close $log; }
+like( $written, qr/XCAT_CURTIN_LOG_TAIL/, 'and write the end of the curtin log to the console the installer names' );
+
+done_testing();

--- a/xCAT-test/unit/ubuntu_subiquity_pkglist.t
+++ b/xCAT-test/unit/ubuntu_subiquity_pkglist.t
@@ -193,8 +193,21 @@ is( $render->( $pkglist, environvar => 'ACCEPT_EULA=Y' ), $without,
     };
     like( $apt_render->(), qr{URIs: http://mirror\.example/ubuntu}, 'the pkgdir mirror joins the installer sources' );
     like( $apt_render->(), qr{^    conf: 'APT::Install-Recommends "false";'$}m, 'the installer installs without recommended packages, as ospkgs does' );
+    # On a PReP machine curtin installs no bootloader package of its own: install_missing_packages
+    # covers UEFI and s390x only, and install_grub then runs "dpkg-reconfigure grub-ieee1275".
+    # The Ubuntu kernel image recommends grub-ieee1275, so the package reaches the target only
+    # when the installer keeps recommended packages.
+    unlike( $apt_render->( osarch => 'ppc64el' ), qr{APT::Install-Recommends},
+        'except on ppc64el, where the bootloader the installer configures is a recommended package' );
     unlike( $apt_render->( environvar => 'http_proxy=http://proxy.example:3128' ), qr{mirror\.example|xcat-pkgdir},
         'but not for an osimage with environvar, whose mirrors may need those variables' );
+
+    # The offline configuration installs from the media alone and carries the same setting.
+    local *xCAT::Template::ubuntu_subiquity_apt_mirror = sub { '' };
+    like( $apt_render->(), qr{^    conf: 'APT::Install-Recommends "false";'$}m,
+        'an offline install drops the recommended packages as well' );
+    unlike( $apt_render->( osarch => 'ppc64el' ), qr{APT::Install-Recommends},
+        'and keeps them on ppc64el for the same reason' );
 }
 
 done_testing();


### PR DESCRIPTION
A diskful install of Ubuntu on a ppc64el node runs to the bootloader step and stops. curtin reports
`dpkg-query: package 'grub-ieee1275' is not installed`, and the node never reaches the disk it
installed. `ubuntu_subiquity_apt_config` in `Template.pm` writes `APT::Install-Recommends "false"`
for every architecture, and on a PReP machine `grub-ieee1275` reaches the target only as a
recommended package of the kernel image. The apt block now keeps the recommended packages on
ppc64el. `ubuntu_subiquity_pkglist.t` fails both of its assertions without the change.