### PR TITLE
fix(xcat-core): the Genesis deb version never advances past snap000000000000

### DIFF
--- a/builddebs.pl
+++ b/builddebs.pl
@@ -93,9 +93,12 @@ my $VERSION = read_line("$ROOT/Version") // die "Cannot read $ROOT/Version\n";
 my $EPOCH   = source_date_epoch();
 # A Release file, when present, is authoritative: buildrpms.pl writes one, and a
 # pipeline that builds both must stamp the rpms and the debs with the same release.
+# The tracked file holds snap000000000000, which no build writes -- snap_release()
+# renders a real time. A tree where buildrpms.pl has not run still carries it, so
+# treat the placeholder as an unstamped tree and derive the release from the commit.
 my $FILE_RELEASE = do {
     my $r = read_line("$ROOT/Release");
-    ($r && $r =~ /\S/) ? $r : undef;
+    ($r && $r =~ /\S/ && $r !~ /\Asnap0+\z/) ? $r : undef;
 };
 my $RELEASE = $opts{release} || $FILE_RELEASE || snap_release($EPOCH);
 my $PKGVER  = deb_version($VERSION, $RELEASE);

--- a/xCAT-test/unit/builddebs_release_placeholder.t
+++ b/xCAT-test/unit/builddebs_release_placeholder.t
@@ -1,0 +1,69 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use File::Spec;
+use File::Temp qw(tempdir);
+use FindBin;
+use lib "$FindBin::Bin/../../build-utils/lib";
+use Test::More;
+use XCAT::BuildUtils qw(read_line snap_release);
+
+# builddebs.pl takes the Release file as authoritative. The tracked file holds the
+# placeholder snap000000000000, and buildrpms.pl overwrites it with the commit time.
+# A pipeline that builds only the Genesis debs never runs buildrpms.pl, so the
+# placeholder stays and every deb carries the same version forever.
+#
+# The release decision is extracted from builddebs.pl and run here, so the assertions
+# measure the shipped code rather than a copy of it.
+
+my $repo_root = File::Spec->rel2abs( File::Spec->catdir( $FindBin::Bin, '..', '..' ) );
+my $builder = File::Spec->catfile( $repo_root, 'builddebs.pl' );
+plan skip_all => "builddebs.pl not found" unless -f $builder;
+
+my $src = do { local $/; open my $fh, '<', $builder or die $!; <$fh> };
+
+# BAIL_OUT rather than skip: a rewrite that stops this matching must fail loudly
+# instead of silently covering nothing.
+my ($block) = $src =~ /^(my \$FILE_RELEASE\b.*?^my \$RELEASE\s*=.*?;\n)/ms;
+BAIL_OUT('could not extract the release decision from builddebs.pl')
+    unless defined $block;
+
+my $dir = tempdir( CLEANUP => 1 );
+my $run = 0;
+
+# Resolve the release the way builddebs.pl does, for one Release file content and one
+# --release option. Returns the release string.
+sub release_for {
+    my ( $file_content, $opt_release ) = @_;
+    $run++;
+    my $ROOT = File::Spec->catdir( $dir, "run$run" );
+    mkdir $ROOT or die $!;
+    if ( defined $file_content ) {
+        open( my $fh, '>', File::Spec->catfile( $ROOT, 'Release' ) ) or die $!;
+        print {$fh} $file_content;
+        close($fh);
+    }
+    my $EPOCH = 1756000000;
+    my %opts;
+    $opts{release} = $opt_release if defined $opt_release;
+    my $got = eval "$block\n\$RELEASE";
+    die $@ if $@;
+    return $got;
+}
+
+my $from_epoch = snap_release(1756000000);
+
+is( release_for("snap000000000000\n"), $from_epoch,
+    'the tracked placeholder is not a release, so the commit time is used' );
+
+is( release_for("snap202608240826\n"), 'snap202608240826',
+    'a release buildrpms.pl wrote is still authoritative' );
+
+is( release_for(undef), $from_epoch,
+    'no Release file gives the commit time' );
+
+is( release_for( "snap000000000000\n", 'snap209901010000' ), 'snap209901010000',
+    '--release still wins over the placeholder' );
+
+done_testing();


### PR DESCRIPTION
Every Genesis deb the Ubuntu dependency pipeline publishes is versioned `2.19.0-snap000000000000`,
so apt never upgrades an installed `xcat-genesis-base` and the channel cannot ship a Genesis fix.
`Release` is a tracked placeholder that `buildrpms.pl` overwrites with the commit time, and the
dependency job clones xcat-core only to build the Genesis debs, so `buildrpms.pl` never runs there
and `builddebs.pl` reads the placeholder as authoritative. `builddebs.pl` now treats an all-zero
`Release` as unstamped and falls back to the commit time. `builddebs_release_placeholder.t` fails
on the unfixed tree.